### PR TITLE
fix(Scripts/TempleOfAhnQiraj): pass aggro target to Skeram's aggro yell

### DIFF
--- a/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_skeram.cpp
+++ b/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_skeram.cpp
@@ -142,7 +142,7 @@ struct boss_skeram : public BossAI
             me->RemoveCorpse();
     }
 
-    void JustEngagedWith(Unit* /*who*/) override
+    void JustEngagedWith(Unit* who) override
     {
         _JustEngagedWith();
         events.Reset();
@@ -154,7 +154,7 @@ struct boss_skeram : public BossAI
 
         if (!me->IsSummon())
         {
-            Talk(SAY_AGGRO);
+            Talk(SAY_AGGRO, who);
         }
     }
 

--- a/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_skeram.cpp
+++ b/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_skeram.cpp
@@ -154,7 +154,9 @@ struct boss_skeram : public BossAI
 
         if (!me->IsSummon())
         {
-            Talk(SAY_AGGRO, who);
+            // Resolve pets/guardians to their owner so gendered locales resolve $g against the puller
+            Player* puller = who->GetCharmerOrOwnerPlayerOrPlayerItself();
+            Talk(SAY_AGGRO, puller ? puller : who);
         }
     }
 


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

The Prophet Skeram's aggro yell is sent without a chat target, so clients of gendered languages cannot resolve the `$g` token in the localized broadcast text (frFR 11445: `Êtes-vous $gpressé:pressée; de mourir ?`) and display both gender forms at once.

`JustEngagedWith` now passes `who` to `Talk(SAY_AGGRO)`, so the puller's GUID is written as the receiver of the `SMSG_MESSAGECHAT` packet and the client resolves the token against that player's gender, as on retail where the line addresses whoever pulled.

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Fable 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #2864

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Retail behavior described by French players in #2864: the line is spoken in singular form addressing the player who pulled, with the adjective agreeing with that player's gender.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. Use a client with a gendered locale (frFR or esES).
2. Pull The Prophet Skeram (entry 15263) in AQ40 with a female character, check the aggro yell shows `pressée` only.
3. Repeat with a male character, check it shows `pressé` only.
4. On enUS nothing changes, since the English text has no `$g` token.

## Known Issues and TODO List:

- [ ] Other creature texts whose scripts do not pass a talk target still show both gender forms on gendered-locale clients; ~15k `broadcast_text_locale` rows contain `$g` tokens.

<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
