### PR TITLE
fix(Core/Collision): make spawned WMO gameobjects provide indoor/area info

### DIFF
--- a/src/common/Collision/Models/GameObjectModel.cpp
+++ b/src/common/Collision/Models/GameObjectModel.cpp
@@ -198,7 +198,8 @@ bool GameObjectModel::intersectRay(G3D::Ray const& ray, float& MaxDist, bool Sto
 
 bool GameObjectModel::GetLocationInfo(G3D::Vector3 const& point, VMAP::LocationInfo& info, uint32 ph_mask) const
 {
-    if (!(phasemask & ph_mask) || !owner->IsSpawned() || !IsMapObject())
+    // transports provide inaccurate area info while moving (e.g. Booty Bay - Ratchet boat, see #7335)
+    if (!(phasemask & ph_mask) || !owner->IsSpawned() || !IsMapObject() || owner->IsTransport())
         return false;
 
     if (!iBound.contains(point))
@@ -216,6 +217,8 @@ bool GameObjectModel::GetLocationInfo(G3D::Vector3 const& point, VMAP::LocationI
         float world_Z = ((modelGround * iInvRot) * iScale + iPos).z;
         if (info.ground_Z < world_Z)
         {
+            info.rootId = groupInfo.rootId;
+            info.hitModel = groupInfo.hitModel;
             info.ground_Z = world_Z;
             return true;
         }

--- a/src/common/Collision/Models/GameObjectModel.h
+++ b/src/common/Collision/Models/GameObjectModel.h
@@ -42,6 +42,7 @@ public:
     virtual ~GameObjectModelOwnerBase() = default;
 
     [[nodiscard]] virtual bool IsSpawned() const = 0;
+    [[nodiscard]] virtual bool IsTransport() const = 0;
     [[nodiscard]] virtual uint32 GetDisplayId() const = 0;
     [[nodiscard]] virtual uint32 GetPhaseMask() const = 0;
     [[nodiscard]] virtual G3D::Vector3 GetPosition() const = 0;

--- a/src/common/Collision/Models/GameObjectModel.h
+++ b/src/common/Collision/Models/GameObjectModel.h
@@ -42,7 +42,7 @@ public:
     virtual ~GameObjectModelOwnerBase() = default;
 
     [[nodiscard]] virtual bool IsSpawned() const = 0;
-    [[nodiscard]] virtual bool IsTransport() const = 0;
+    [[nodiscard]] virtual bool IsTransport() const { return false; }
     [[nodiscard]] virtual uint32 GetDisplayId() const = 0;
     [[nodiscard]] virtual uint32 GetPhaseMask() const = 0;
     [[nodiscard]] virtual G3D::Vector3 GetPosition() const = 0;

--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -2968,6 +2968,7 @@ public:
     explicit GameObjectModelOwnerImpl(GameObject* owner) : _owner(owner) { }
 
     bool IsSpawned() const override { return _owner->isSpawned(); }
+    bool IsTransport() const override { return _owner->IsTransport(); }
     uint32 GetDisplayId() const override { return _owner->GetDisplayId(); }
     uint32 GetPhaseMask() const override { return (_owner->GetGoState() == GO_STATE_READY || _owner->IsTransport()) ? _owner->GetPhaseMask() : 0; }
     G3D::Vector3 GetPosition() const override { return G3D::Vector3(_owner->GetPositionX(), _owner->GetPositionY(), _owner->GetPositionZ()); }

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -1389,15 +1389,15 @@ LiquidData const Map::GetLiquidData(uint32 phaseMask, float x, float y, float z,
    return liquidData;
 }
 
-void Map::GetFullTerrainStatusForPosition(uint32 /*phaseMask*/, float x, float y, float z, float collisionHeight, PositionFullTerrainStatus& data, Optional<uint8> reqLiquidType)
+void Map::GetFullTerrainStatusForPosition(uint32 phaseMask, float x, float y, float z, float collisionHeight, PositionFullTerrainStatus& data, Optional<uint8> reqLiquidType)
 {
     GridTerrainData* gmap = GetGridTerrainData(x, y);
 
     VMAP::AreaAndLiquidData vmapData;
-    // VMAP::AreaAndLiquidData dynData;
+    VMAP::AreaAndLiquidData dynData;
     VMAP::AreaAndLiquidData* wmoData = nullptr;
     _mapCollisionData.GetStaticTree().GetAreaAndLiquidData(x, y, z, reqLiquidType, vmapData);
-    // _dynamicTree.GetAreaAndLiquidData(x, y, z, phaseMask, reqLiquidType, dynData);
+    _mapCollisionData.GetDynamicTree().GetAreaAndLiquidData(x, y, z, phaseMask, reqLiquidType, dynData);
 
     uint32 gridAreaId = 0;
     float gridMapHeight = INVALID_HEIGHT;
@@ -1424,7 +1424,6 @@ void Map::GetFullTerrainStatusForPosition(uint32 /*phaseMask*/, float x, float y
     // NOTE: Objects will not detect a case when a wmo providing area/liquid despawns from under them
     // but this is fine as these kind of objects are not meant to be spawned and despawned a lot
     // example: Lich King platform
-    /*
     if (dynData.floorZ > VMAP_INVALID_HEIGHT && G3D::fuzzyGe(z, dynData.floorZ - GROUND_HEIGHT_TOLERANCE) &&
         (G3D::fuzzyLt(z, gridMapHeight - GROUND_HEIGHT_TOLERANCE) || dynData.floorZ > gridMapHeight) &&
         (G3D::fuzzyLt(z, vmapData.floorZ - GROUND_HEIGHT_TOLERANCE) || dynData.floorZ > vmapData.floorZ))
@@ -1432,7 +1431,6 @@ void Map::GetFullTerrainStatusForPosition(uint32 /*phaseMask*/, float x, float y
         data.floorZ = dynData.floorZ;
         wmoData = &dynData;
     }
-    */
 
     if (wmoData)
     {


### PR DESCRIPTION
## Changes Proposed:

Players are never dismounted inside spawned WMO gameobjects such as the Wintergrasp towers, because the server only ever computed the indoor/outdoor state from static vmaps and terrain.

Two separate problems:

1. `GameObjectModel::GetLocationInfo` never populated `hitModel` and `rootId` in the result, so `DynamicMapTree::GetAreaAndLiquidData` always returned no area info. Before #23233 the dynamic query in `Map::GetAreaInfo` went through the old `IntersectPoint` path and worked; #23233 unified everything on the `LocationInfo` path and gameobject-based area ids silently regressed, since the copy-back of `GroupLocationInfo` was only added to `ModelInstance::GetLocationInfo` (the static path) and not to the gameobject path. So this part is a regression fix. Note that the gap comes from upstream: TrinityCore's `GameObjectModel::GetLocationInfo` is missing the same assignments on both master and 3.3.5, so this PR deliberately diverges from TC here.
2. The dynamic tree query in `Map::GetFullTerrainStatusForPosition` (the function that feeds `WorldObject::IsOutdoors()` and therefore the indoor dismount in `Player::CheckAreaExploreAndOutdoor`) was commented out by #7898 because it caused wrong area data on moving transports (#7335).

This PR restores the missing assignments, re-enables the dynamic tree query, and excludes transports (type 11 and 15) from serving area info via a new `IsTransport()` on `GameObjectModelOwnerBase`. The exclusion is a deliberate trade-off, not a fix of #7335 at the source: transport WMO data is unreliable while they move, so they are kept out of area/indoor detection entirely. Boat and zeppelin cabins therefore still do not count as indoors. That matches the behavior without this PR (verified in-game: no cabin dismount on master either), so nothing changes for transports. A real cabin fix would need transport-local position handling and is out of scope.

With this, riding into a WG tower flips `IsOutdoors()` to false and the existing dismount logic fires, with no Wintergrasp-specific code. Requires `vmap.enableIndoorCheck = 1`.

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Claude Fable 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #5545

## SOURCE:
The changes have been validated through:
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)

On retail 3.3.5 players are dismounted inside the Wintergrasp tower and keep interiors (see the linked issue).

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Builds without errors (MSVC 2022, Release). Tested in-game: dismount when riding into WG towers, mounting blocked inside, mounting works again outside. Boat cabins behave the same as master (no dismount).

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Make sure `vmap.enableIndoorCheck = 1` in worldserver.conf.
2. Go to Wintergrasp, mount up and ride into one of the towers or the keep buildings: you should be dismounted inside.
3. Try to mount while inside: it should fail with the "can't use that here" error.
4. Step outside and mount again: it should work immediately.

A full regression checklist is posted in the comments below. Since this touches a generic code path (area/indoor detection near all spawned WMO gameobjects), testing beyond Wintergrasp is very welcome.

## Known Issues and TODO List:

- [ ] A WMO gameobject despawning from under a player does not retrigger position data until the player moves (pre-existing note in the code). In practice: after a tower is destroyed, players inside flip back to outdoors on their next movement.
- [ ] The dynamic path does not honour `VMAP_DISABLE_AREAFLAG` / `VMAP_DISABLE_LIQUIDSTATUS` while the static path does (pre-existing gap, only consequential now that the dynamic path returns data). Follow-up candidate.
- [ ] Boat/zeppelin cabins still do not count as indoors (unchanged from master, see trade-off above).
