### PR TITLE
fix(Core/Pools): respawn nested pools when the same child pool is re-selected

### DIFF
--- a/src/server/game/Pools/PoolMgr.cpp
+++ b/src/server/game/Pools/PoolMgr.cpp
@@ -526,26 +526,12 @@ void PoolGroup<Quest>::SpawnObject(ActivePoolData& spawns, uint32 limit, uint32 
         sPoolMgr->SaveQuestsToDB(false, false, true);
 }
 
-// Method that does the respawn job on the specified creature
-template <>
-void PoolGroup<Creature>::ReSpawn1Object(PoolObject* obj)
+// Method that does the respawn job on the specified object
+template <typename T>
+void PoolGroup<T>::ReSpawn1Object(PoolObject* obj)
 {
     Despawn1Object(obj->guid);
     Spawn1Object(obj);
-}
-
-// Method that does the respawn job on the specified gameobject
-template <>
-void PoolGroup<GameObject>::ReSpawn1Object(PoolObject* obj)
-{
-    Despawn1Object(obj->guid);
-    Spawn1Object(obj);
-}
-
-// Nothing to do for a child Pool
-template <>
-void PoolGroup<Pool>::ReSpawn1Object(PoolObject* /*obj*/)
-{
 }
 
 // Nothing to do for a quest


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

When a creature or gameobject that belongs to a pool-of-pools structure (`pool_template` + `pool_pool`) dies and the mother pool's re-roll selects the same child pool again, `PoolGroup<Pool>::ReSpawn1Object` was an empty no-op. The child pool stayed flagged as spawned, the respawn time had already been removed from the DB by `Map::ProcessCreatureRespawn`, and nothing ever respawned again until server restart.

With the stock Time-Lost Proto-Drake pool (4 equal-chanced location sub-pools) this permanently kills the spawn in roughly 1 out of 4 death cycles. 658 mother pools in the world DB use this structure.

The fix replaces the per-type `ReSpawn1Object` specializations with a single generic implementation that despawns and respawns the triggering object. For a re-selected child pool this despawns its members and re-rolls the child, producing a live spawn again. The Quest specialization stays a no-op since quest pools handle rotation in their own `SpawnObject` specialization and never reach this path.

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Fable 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #26788

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Port of TrinityCore https://github.com/TrinityCore/TrinityCore/commit/48fd0413046ebc11d59883eaabbfdb99981647d8 (3.3.5 branch: https://github.com/TrinityCore/TrinityCore/commit/f50770ae88c9269a08bbb99d15f0dd5b445d3d64), which fixed the same inherited bug there (https://github.com/TrinityCore/TrinityCore/issues/28524). Committed with `--author` crediting the original author.

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. Follow the reproduction steps in #26788 (force one TLPD sub-pool to always win the re-roll, lower `spawntimesecs`, kill the spawn near Frozen Lake).
2. Before this PR: after the respawn timer expires nothing respawns anywhere and only a restart recovers the pool.
3. With this PR: a new creature (TLPD or Vyragosa) spawns at the location after every respawn cycle.
4. Regression check: verify normal pool behaviour is unaffected, both for pools of creatures without a mother pool (e.g. kill a pooled mob and watch it or a sibling respawn) and for the "different sub-pool selected" path (restore the original chances and verify the spawn moves between locations).

## Known Issues and TODO List:

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
