### PR TITLE
fix(Core/Spells): Sanctified/Swift Retribution require an active paladin aura

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1784986738601277200.sql
+++ b/data/sql/updates/pending_db_world/rev_1784986738601277200.sql
@@ -1,0 +1,6 @@
+--
+DELETE FROM `spell_script_names` WHERE `spell_id` IN (63510, 63514, 63531);
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(63510, 'spell_pal_improved_concentraction_aura_effect'),
+(63514, 'spell_pal_improved_devotion_aura_effect'),
+(63531, 'spell_pal_sanctified_retribution_effect');

--- a/src/server/scripts/Spells/spell_paladin.cpp
+++ b/src/server/scripts/Spells/spell_paladin.cpp
@@ -71,7 +71,13 @@ enum PaladinSpells
 
     SPELL_PALADIN_SEAL_OF_RIGHTEOUSNESS          = 25742,
 
+    SPELL_PALADIN_DEVOTION_AURA_R1               = 465,
+    SPELL_PALADIN_RETRIBUTION_AURA_R1            = 7294,
     SPELL_PALADIN_CONCENTRACTION_AURA            = 19746,
+    SPELL_PALADIN_SHADOW_RESISTANCE_AURA_R1      = 19876,
+    SPELL_PALADIN_FROST_RESISTANCE_AURA_R1       = 19888,
+    SPELL_PALADIN_FIRE_RESISTANCE_AURA_R1        = 19891,
+    SPELL_PALADIN_CRUSADER_AURA                  = 32223,
     SPELL_PALADIN_SANCTIFIED_RETRIBUTION_R1      = 31869,
     SPELL_PALADIN_SWIFT_RETRIBUTION_R1           = 53379,
 
@@ -2133,6 +2139,70 @@ private:
     uint32 _spellId;
 };
 
+// 63510 - Improved Concentration Aura (requires Concentration Aura on the target)
+// 63514 - Improved Devotion Aura (requires Devotion Aura on the target)
+class spell_pal_improved_aura_effect : public AuraScript
+{
+    PrepareAuraScript(spell_pal_improved_aura_effect);
+
+public:
+    spell_pal_improved_aura_effect(uint32 auraSpellId) : AuraScript(), _auraSpellId(auraSpellId) { }
+
+    bool Validate(SpellInfo const* /*spellInfo*/) override
+    {
+        return ValidateSpellInfo({ _auraSpellId });
+    }
+
+    bool CheckAreaTarget(Unit* target)
+    {
+        return target->GetAuraOfRankedSpell(_auraSpellId, GetCasterGUID());
+    }
+
+    void Register() override
+    {
+        DoCheckAreaTarget += AuraCheckAreaTargetFn(spell_pal_improved_aura_effect::CheckAreaTarget);
+    }
+
+private:
+    uint32 _auraSpellId;
+};
+
+// 63531 - Sanctified Retribution
+// "Targets affected by any of your auras" - shared effect of Sanctified Retribution and Swift Retribution
+class spell_pal_sanctified_retribution_effect : public AuraScript
+{
+    PrepareAuraScript(spell_pal_sanctified_retribution_effect);
+
+    bool Validate(SpellInfo const* /*spellInfo*/) override
+    {
+        return ValidateSpellInfo(
+        {
+            SPELL_PALADIN_DEVOTION_AURA_R1,
+            SPELL_PALADIN_RETRIBUTION_AURA_R1,
+            SPELL_PALADIN_CONCENTRACTION_AURA,
+            SPELL_PALADIN_SHADOW_RESISTANCE_AURA_R1,
+            SPELL_PALADIN_FROST_RESISTANCE_AURA_R1,
+            SPELL_PALADIN_FIRE_RESISTANCE_AURA_R1,
+            SPELL_PALADIN_CRUSADER_AURA
+        });
+    }
+
+    bool CheckAreaTarget(Unit* target)
+    {
+        for (uint32 auraSpellId : { SPELL_PALADIN_DEVOTION_AURA_R1, SPELL_PALADIN_RETRIBUTION_AURA_R1, SPELL_PALADIN_CONCENTRACTION_AURA,
+            SPELL_PALADIN_SHADOW_RESISTANCE_AURA_R1, SPELL_PALADIN_FROST_RESISTANCE_AURA_R1, SPELL_PALADIN_FIRE_RESISTANCE_AURA_R1, SPELL_PALADIN_CRUSADER_AURA })
+            if (target->GetAuraOfRankedSpell(auraSpellId, GetCasterGUID()))
+                return true;
+
+        return false;
+    }
+
+    void Register() override
+    {
+        DoCheckAreaTarget += AuraCheckAreaTargetFn(spell_pal_sanctified_retribution_effect::CheckAreaTarget);
+    }
+};
+
 // 53651 - Light's Beacon - Beacon of Light
 // Each source heal has a dedicated beacon copy spell:
 //   53652 - Holy Light, 53653 - Flash of Light, 53654 - Holy Shock
@@ -2256,5 +2326,8 @@ void AddSC_paladin_spell_scripts()
     RegisterSpellScriptWithArgs(spell_pal_improved_aura, "spell_pal_improved_devotion_aura", SPELL_PALADIN_IMPROVED_DEVOTION_AURA);
     RegisterSpellScriptWithArgs(spell_pal_improved_aura, "spell_pal_sanctified_retribution", SPELL_PALADIN_SANCTIFIED_RETRIBUTION_AURA);
     RegisterSpellScriptWithArgs(spell_pal_improved_aura, "spell_pal_swift_retribution", SPELL_PALADIN_SANCTIFIED_RETRIBUTION_AURA);
+    RegisterSpellScriptWithArgs(spell_pal_improved_aura_effect, "spell_pal_improved_concentraction_aura_effect", SPELL_PALADIN_CONCENTRACTION_AURA);
+    RegisterSpellScriptWithArgs(spell_pal_improved_aura_effect, "spell_pal_improved_devotion_aura_effect", SPELL_PALADIN_DEVOTION_AURA_R1);
+    RegisterSpellScript(spell_pal_sanctified_retribution_effect);
     RegisterSpellScript(spell_pal_light_s_beacon);
 }


### PR DESCRIPTION
## Changes Proposed:

Sanctified Retribution and Swift Retribution carry no bonus themselves: their effects are spellmods feeding the serverside raid area aura 63531, which `spell_pal_improved_aura` casts on the paladin when the talent is applied and only removes when the talent is unlearned. Nothing gates it on actually having an aura active, so the 3% damage / 1-3% haste is up permanently. The same script also applies 63514 (Improved Devotion Aura, +3% healing received) and 63510 (Improved Concentration Aura, silence/interrupt duration reduction) unconditionally, so those raid buffs are permanently active without their auras too.

This PR gates all three helpers per target with `DoCheckAreaTarget`, following the existing `spell_pal_aura_mastery_immune` pattern (64364 gated on the target having the caster's Concentration Aura):

- 63531 requires the target to be affected by any of the caster's auras (Devotion, Retribution, Concentration, Shadow/Frost/Fire Resistance, Crusader), matching the tooltip "targets affected by any of your auras". Since patch 3.1.0 both talents work with any aura, not just Retribution Aura.
- 63514 requires the caster's Devotion Aura on the target.
- 63510 requires the caster's Concentration Aura on the target.

Rank chains are handled via `GetAuraOfRankedSpell` with the caster GUID, so another paladin's aura does not enable the buff. The talent-side script is untouched (it carries the spellmodded amounts); the area aura target map update applies and strips the buff within ~500 ms of toggling an aura.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Fable 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/26050

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Talent tooltips: [Sanctified Retribution](https://wowpedia.fandom.com/wiki/Sanctified_Retribution) "Increases damage caused by targets affected by any of your auras by 3%", [Swift Retribution](https://wowpedia.fandom.com/wiki/Swift_Retribution) "Your auras also increase casting, ranged and melee attack speeds". Patch 3.1.0 notes on both pages: now affects all auras instead of only Retribution Aura.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Paladin with Sanctified Retribution and/or Swift Retribution talented, no aura active: no damage/haste bonus on the paladin or party members.
2. Activate any paladin aura (including resistance auras and Crusader Aura): the bonus applies within ~500 ms; deactivate it and the bonus is removed.
3. With Improved Devotion Aura talented, the +3% healing received raid buff (63514) should only be present while Devotion Aura is active; same for Improved Concentration Aura (63510) with Concentration Aura.
4. Regression check: Aura Mastery with Concentration Aura still works as before.

## Known Issues and TODO List:

- Restoring the talent-applied helper auras after a `.pdump load` import still fails (caster GUID mismatch, see https://github.com/azerothcore/azerothcore-wotlk/issues/26349). Separate persistence issue, not addressed here.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
