### PR TITLE
feat(Core/Scripting): add OnPlayerUnlinkFromDB player hook

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -4387,6 +4387,8 @@ void Player::DeleteFromDB(ObjectGuid::LowType lowGuid, uint32 accountId, bool up
         // The character gets unlinked from the account, the name gets freed up and appears as deleted ingame
         case CHAR_DELETE_UNLINK:
             {
+                sScriptMgr->OnPlayerUnlinkFromDB(lowGuid);
+
                 stmt = CharacterDatabase.GetPreparedStatement(CHAR_UPD_DELETE_INFO);
 
                 stmt->SetData(0, lowGuid);

--- a/src/server/game/Scripting/ScriptDefines/PlayerScript.cpp
+++ b/src/server/game/Scripting/ScriptDefines/PlayerScript.cpp
@@ -562,6 +562,11 @@ void ScriptMgr::OnPlayerDeleteFromDB(CharacterDatabaseTransaction trans, uint32 
     CALL_ENABLED_HOOKS(PlayerScript, PLAYERHOOK_ON_DELETE_FROM_DB, script->OnPlayerDeleteFromDB(trans, guid));
 }
 
+void ScriptMgr::OnPlayerUnlinkFromDB(uint32 lowGuid)
+{
+    CALL_ENABLED_HOOKS(PlayerScript, PLAYERHOOK_ON_UNLINK_FROM_DB, script->OnPlayerUnlinkFromDB(lowGuid));
+}
+
 bool ScriptMgr::OnPlayerCanRepopAtGraveyard(Player* player)
 {
     CALL_ENABLED_BOOLEAN_HOOKS(PlayerScript, PLAYERHOOK_CAN_REPOP_AT_GRAVEYARD, !script->OnPlayerCanRepopAtGraveyard(player));

--- a/src/server/game/Scripting/ScriptDefines/PlayerScript.h
+++ b/src/server/game/Scripting/ScriptDefines/PlayerScript.h
@@ -215,6 +215,7 @@ enum PlayerHook
     PLAYERHOOK_ON_GET_REPUTATION_PRICE_DISCOUNT,
     PLAYERHOOK_ON_LEARN_TAXI_NODE,
     PLAYERHOOK_ON_BEFORE_GET_LEVEL_FOR_XP_GAIN,
+    PLAYERHOOK_ON_UNLINK_FROM_DB,
     PLAYERHOOK_END
 };
 
@@ -513,6 +514,12 @@ public:
     [[nodiscard]] virtual bool OnPlayerCanGiveMailRewardAtGiveLevel(Player* /*player*/, uint8 /*level*/) { return true; }
 
     virtual void OnPlayerDeleteFromDB(CharacterDatabaseTransaction /*trans*/, uint32 /*guid*/) { }
+
+    /**
+     * @brief Called when a character is soft-deleted (unlinked from its account, CharDelete.Method = 1),
+     * before the unlink is executed, while all character data still exists in the database.
+     */
+    virtual void OnPlayerUnlinkFromDB(uint32 /*lowGuid*/) { }
 
     [[nodiscard]] virtual bool OnPlayerCanRepopAtGraveyard(Player* /*player*/) { return true; }
 

--- a/src/server/game/Scripting/ScriptMgr.h
+++ b/src/server/game/Scripting/ScriptMgr.h
@@ -398,6 +398,7 @@ public: /* PlayerScript */
     void OnPlayerRewardKillRewarder(Player* player, KillRewarder* rewarder, bool isDungeon, float& rate);
     bool OnPlayerCanGiveMailRewardAtGiveLevel(Player* player, uint8 level);
     void OnPlayerDeleteFromDB(CharacterDatabaseTransaction trans, uint32 guid);
+    void OnPlayerUnlinkFromDB(uint32 lowGuid);
     bool OnPlayerCanRepopAtGraveyard(Player* player);
     std::optional<bool> OnPlayerIsClass(Player const* player, Classes playerClass, ClassContext context);
     void OnPlayerGetMaxSkillValue(Player* player, uint32 skill, int32& result, bool IsPure);


### PR DESCRIPTION
## Changes Proposed:

Adds a `OnPlayerUnlinkFromDB(uint32 lowGuid)` PlayerScript hook, fired in the `CHAR_DELETE_UNLINK` branch of `Player::DeleteFromDB`.

`OnPlayerDeleteFromDB` only fires in the permanent deletion branch. When `CharDelete.Method` is set to unlink, no hook fires at all, so modules cannot react to soft deletions. The new hook fires before the `CHAR_UPD_DELETE_INFO` statement executes, while the account link and all character rows are still intact, so scripts can read (or adjust) the character data that a later restore would bring back.

Use case: a module granting account-level compensation when a character is deleted (e.g. hardcore/challenge modes) needs to act on soft deletes too, and to do so before the character becomes restorable.

## Issues Addressed:

None (module enablement).

## SOURCE:

Core code analysis of `Player::DeleteFromDB`.

## Tests Performed:

Not built locally; the change mirrors the existing `OnPlayerDeleteFromDB` boilerplate (enum entry, virtual, dispatch, call site).

## How to Test the Changes:

1. Set `CharDelete.Method = 1` and `CharDelete.MinLevel = 0`.
2. Register a PlayerScript overriding `OnPlayerUnlinkFromDB` with a log line.
3. Delete a character from the character selection screen: the hook fires with its low GUID.
4. Set `CharDelete.Method = 0` and delete another character: the hook does not fire, `OnPlayerDeleteFromDB` fires instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)