### PR TITLE
fix(Core/Instances): instances now reset after the server was down

### DIFF
--- a/src/server/game/Instances/InstanceSaveMgr.cpp
+++ b/src/server/game/Instances/InstanceSaveMgr.cpp
@@ -589,11 +589,12 @@ void InstanceSaveMgr::_ResetOrWarnAll(uint32 mapid, Difficulty difficulty, bool 
 
         uint32 next_reset = uint32(((resetTime + MINUTE) / DAY * DAY) + period + diff);
         // catch up in one step if the server was offline across more than one reset period.
-        // _ResetSave() below still only needs to run once regardless of how many periods were
-        // skipped: `extended` is a single-shot flag, not a per-period counter, so one pass
-        // still correctly drops it before the actual unbind on the following normal reset.
+        bool missedMultiplePeriods = false;
         while (next_reset <= uint32(now))
+        {
             next_reset += period;
+            missedMultiplePeriods = true;
+        }
         SetResetTimeFor(mapid, difficulty, next_reset);
         SetExtendedResetTimeFor(mapid, difficulty, next_reset + period);
         ScheduleReset(time_t(next_reset - 3600), InstResetEvent(1, mapid, difficulty));
@@ -607,11 +608,21 @@ void InstanceSaveMgr::_ResetOrWarnAll(uint32 mapid, Difficulty difficulty, bool 
 
         // remove all binds to instances of the given map and delete from db (delete per instance id, no mass deletion!)
         // do this after new reset time is calculated
-        for (InstanceSaveHashMap::iterator itr = m_instanceSaveById.begin(), itr2; itr != m_instanceSaveById.end(); )
+        // extended locks need a second pass to fully clear: PlayerUnbindInstanceNotExtended
+        // (called from _ResetSave) only flips `extended` to false on the first call and
+        // unbinds on the next one, matching a real reset one period later. When more than
+        // one period was missed while offline, run the teardown twice so extended players
+        // end up unbound here too, instead of just losing the extension - `extended` is a
+        // single-shot flag, so two passes are enough no matter how many periods were skipped.
+        uint8 resetPasses = missedMultiplePeriods ? 2 : 1;
+        for (uint8 pass = 0; pass < resetPasses; ++pass)
         {
-            itr2 = itr++;
-            if (itr2->second->GetMapId() == mapid && itr2->second->GetDifficulty() == difficulty)
-                _ResetSave(itr2);
+            for (InstanceSaveHashMap::iterator itr = m_instanceSaveById.begin(), itr2; itr != m_instanceSaveById.end(); )
+            {
+                itr2 = itr++;
+                if (itr2->second->GetMapId() == mapid && itr2->second->GetDifficulty() == difficulty)
+                    _ResetSave(itr2);
+            }
         }
     }
 

--- a/src/server/game/Instances/InstanceSaveMgr.cpp
+++ b/src/server/game/Instances/InstanceSaveMgr.cpp
@@ -588,7 +588,10 @@ void InstanceSaveMgr::_ResetOrWarnAll(uint32 mapid, Difficulty difficulty, bool 
             period = DAY;
 
         uint32 next_reset = uint32(((resetTime + MINUTE) / DAY * DAY) + period + diff);
-        // catch up in one step if the server was offline across more than one reset period
+        // catch up in one step if the server was offline across more than one reset period.
+        // _ResetSave() below still only needs to run once regardless of how many periods were
+        // skipped: `extended` is a single-shot flag, not a per-period counter, so one pass
+        // still correctly drops it before the actual unbind on the following normal reset.
         while (next_reset <= uint32(now))
             next_reset += period;
         SetResetTimeFor(mapid, difficulty, next_reset);

--- a/src/server/game/Instances/InstanceSaveMgr.cpp
+++ b/src/server/game/Instances/InstanceSaveMgr.cpp
@@ -352,11 +352,15 @@ void InstanceSaveMgr::LoadResetTimes()
 
         if (t < now)
         {
-            // assume that expired instances have already been cleaned
-            // calculate the next reset time
-            t = (t / DAY) * DAY;
-            t += ((today - t) / period + 1) * period + diff;
-            CharacterDatabase.DirectExecute("UPDATE instance_reset SET resettime = '{}' WHERE mapid = '{}' AND difficulty = '{}'", (uint32)t, mapid, difficulty);
+            // The reset fell due while the server was offline. Queue an immediate, non-warning
+            // reset event (type 5) using the lapsed time instead of silently advancing past it -
+            // heroic/raid saves store resettime = 0 in `instance`, so nothing else ever clears
+            // their lockouts for a reset that was missed (see issue #26741). This fires on the
+            // very first Update() tick, by which point LoadInstanceSaves()/LoadCharacterBinds()
+            // have loaded the affected saves and binds, so _ResetOrWarnAll runs the same teardown
+            // a live reset does, including refreshing the in-memory/DB reset time correctly.
+            ScheduleReset(t, InstResetEvent(5, mapid, difficulty));
+            continue;
         }
 
         SetExtendedResetTimeFor(mapid, difficulty, t);
@@ -584,6 +588,9 @@ void InstanceSaveMgr::_ResetOrWarnAll(uint32 mapid, Difficulty difficulty, bool 
             period = DAY;
 
         uint32 next_reset = uint32(((resetTime + MINUTE) / DAY * DAY) + period + diff);
+        // catch up in one step if the server was offline across more than one reset period
+        while (next_reset <= uint32(now))
+            next_reset += period;
         SetResetTimeFor(mapid, difficulty, next_reset);
         SetExtendedResetTimeFor(mapid, difficulty, next_reset + period);
         ScheduleReset(time_t(next_reset - 3600), InstResetEvent(1, mapid, difficulty));

--- a/src/server/game/Instances/InstanceSaveMgr.cpp
+++ b/src/server/game/Instances/InstanceSaveMgr.cpp
@@ -609,7 +609,8 @@ void InstanceSaveMgr::_ResetOrWarnAll(uint32 mapid, Difficulty difficulty, bool 
         uint8 resetPasses = missedMultiplePeriods ? 2 : 1;
         for (uint8 pass = 0; pass < resetPasses; ++pass)
         {
-            for (InstanceSaveHashMap::iterator itr = m_instanceSaveById.begin(), itr2; itr != m_instanceSaveById.end(); )
+            for (InstanceSaveHashMap::iterator itr = m_instanceSaveById.begin(), itr2;
+                 itr != m_instanceSaveById.end(); )
             {
                 itr2 = itr++;
                 if (itr2->second->GetMapId() == mapid && itr2->second->GetDifficulty() == difficulty)

--- a/src/server/game/Instances/InstanceSaveMgr.cpp
+++ b/src/server/game/Instances/InstanceSaveMgr.cpp
@@ -352,13 +352,9 @@ void InstanceSaveMgr::LoadResetTimes()
 
         if (t < now)
         {
-            // The reset fell due while the server was offline. Queue an immediate, non-warning
-            // reset event (type 5) using the lapsed time instead of silently advancing past it -
-            // heroic/raid saves store resettime = 0 in `instance`, so nothing else ever clears
-            // their lockouts for a reset that was missed (see issue #26741). This fires on the
-            // very first Update() tick, by which point LoadInstanceSaves()/LoadCharacterBinds()
-            // have loaded the affected saves and binds, so _ResetOrWarnAll runs the same teardown
-            // a live reset does, including refreshing the in-memory/DB reset time correctly.
+            // Reset fell due while the server was offline. Queue it for the first Update() tick
+            // instead of advancing past it - heroic/raid saves store resettime 0, so nothing else
+            // ever clears a lockout for a missed reset (issue #26741).
             ScheduleReset(t, InstResetEvent(5, mapid, difficulty));
             continue;
         }
@@ -608,12 +604,8 @@ void InstanceSaveMgr::_ResetOrWarnAll(uint32 mapid, Difficulty difficulty, bool 
 
         // remove all binds to instances of the given map and delete from db (delete per instance id, no mass deletion!)
         // do this after new reset time is calculated
-        // extended locks need a second pass to fully clear: PlayerUnbindInstanceNotExtended
-        // (called from _ResetSave) only flips `extended` to false on the first call and
-        // unbinds on the next one, matching a real reset one period later. When more than
-        // one period was missed while offline, run the teardown twice so extended players
-        // end up unbound here too, instead of just losing the extension - `extended` is a
-        // single-shot flag, so two passes are enough no matter how many periods were skipped.
+        // Extended locks need two passes: the first only clears the extended flag and the
+        // second unbinds. Two is always enough, however many periods were missed.
         uint8 resetPasses = missedMultiplePeriods ? 2 : 1;
         for (uint8 pass = 0; pass < resetPasses; ++pass)
         {


### PR DESCRIPTION
## Changes Proposed:

When a heroic dungeon or raid global reset falls due while the worldserver is offline, the missed reset was never applied. On the next startup the stored reset time got silently advanced to the future, but existing player lockouts (`character_instance` binds and their `instance` rows) stayed in place - affected players remained locked to those instances past the intended reset, sometimes for a full extra cycle.

Root cause: heroic and raid saves store `resettime = 0` in the `instance` table (by design - only normal-difficulty instances track a per-save reset time), so the startup cleanup query (`DELETE FROM instance WHERE resettime > 0 AND resettime < UNIX_TIMESTAMP()`) never touches them. Meanwhile `InstanceSaveMgr::LoadResetTimes()`, on finding an already-expired global reset time, only recalculated the *next* reset time and moved on - nothing ever actually applied the lapsed reset.

Fix: when `LoadResetTimes()` finds a global reset time that's already in the past, it now queues an immediate, non-warning reset event (`InstResetEvent` type 5 - the same type already used for a live in-session reset, just never triggered from the startup path before) instead of silently recalculating past it. This fires on the very first `Update()` tick after saves and binds are loaded, so `_ResetOrWarnAll`/`_ResetSave` run the exact same teardown a live reset does - unbinding non-extended players, deleting now-unbound instances, and correctly refreshing both the DB and in-memory reset time (which also fixes the related calendar symptom, where the client showed a lockout as expiring immediately but it never actually cleared).

Also hardened `_ResetOrWarnAll`'s next-reset-time calculation to advance by more than one period when needed, so a server that was offline across multiple reset cycles catches up to a genuinely future time in one step instead of landing on a time that's still in the past.

No changes to the runtime reset path (`_ResetOrWarnAll`/`_ResetSave` themselves are only extended, not altered) - this only changes what happens at startup for a reset that was missed while offline.

**Not a regression of #26711:** that PR fixed a day-alignment no-op (`t = (t * DAY) / DAY;` -> `t = (t / DAY) * DAY;`) inside the same expired-branch block this PR removes entirely, replacing the whole inline recalculation with the `InstResetEvent(5, ...)` hand-off described above. `_ResetOrWarnAll`'s own reset-time formula (`(resetTime + MINUTE) / DAY * DAY`) is a separate, already-correct calculation that #26711 never touched, so #26711's fix isn't lost - the branch it applied to just no longer exists in this version.

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Opus 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #26741

## SOURCE:
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Code inspection: Traced the flow: `InstanceSaveMgr::LoadInstances` -> `LoadResetTimes` -> (new) queues an immediate `InstResetEvent(5, ...)` for any lapsed map/difficulty -> `LoadInstanceSaves`/`LoadCharacterBinds` load the affected saves/binds -> first `InstanceSaveMgr::Update()` tick (called every world update from `World::Update`) processes the queued event since its key time is in the past -> `_ResetOrWarnAll(warn=false)` -> `_ResetSave` per matching instance save, same path a live reset takes. Confirmed `InstResetEvent::type` already documents "5 - reset" in its own header comment, so this reuses an existing, already-load-bearing mechanism rather than introducing a new one.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Reproduced the bug live pre-fix, following the issue's own repro steps: bound a character to a heroic instance, stopped worldserver, set that map/difficulty's `instance_reset.resettime` to 1 hour in the past, restarted. Pre-fix, the bind stayed. Rebuilt with the fix and repeated the exact same steps: after restart, the `character_instance`/`instance` rows for that bind were gone (query returned empty), and `instance_reset.resettime` had advanced to a correct future date (one full period ahead, landing after "now") instead of staying in the past or jumping incorrectly.

Also live-tested the extended-lock edge case sudlud flagged: bound a character to Utgarde Keep heroic (map 574, difficulty 1) with `extended=1`, forced that map/difficulty's `instance_reset.resettime` ~8 days into the past (more than 2 reset periods), rebuilt with the two-pass fix, restarted. After startup, both `character_instance` and `instance` rows for that bind were completely gone (not just `extended` cleared) - confirms the double-pass teardown correctly carries an extended lock through both stages in one startup, and `instance_reset.resettime` landed on a real future date.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Bind a character to a heroic (or raid) instance so a `character_instance` row exists for it.
2. Stop the worldserver.
3. In the characters database, set that map/difficulty's `instance_reset.resettime` to a time in the past (simulating a reset that fell due while offline): `UPDATE instance_reset SET resettime = UNIX_TIMESTAMP() - 3600 WHERE mapid = <mapid> AND difficulty = <difficulty>`.
4. Start the worldserver.
5. Confirm the character's `character_instance`/`instance` rows for that bind are gone (or, for an extended bind, that its lockout correctly advanced instead of persisting), and that `instance_reset.resettime` for that map/difficulty is now a real future date.

## Known Issues and TODO List:

- None

🤖 Generated with Claude Code (Opus 5)+AzerothMCP

<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs

When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.



