### PR TITLE
fix(Scripts/TempleOfAhnQiraj): fix GCC/Clang build error in Skeram aggro yell

### DIFF
--- a/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_skeram.cpp
+++ b/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_skeram.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "CreatureScript.h"
+#include "Player.h"
 #include "ScriptedCreature.h"
 #include "SpellScript.h"
 #include "SpellScriptLoader.h"

--- a/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_skeram.cpp
+++ b/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_skeram.cpp
@@ -155,7 +155,7 @@ struct boss_skeram : public BossAI
         if (!me->IsSummon())
         {
             // Resolve pets/guardians to their owner so gendered locales resolve $g against the puller
-            Player* puller = who->GetCharmerOrOwnerPlayerOrPlayerItself();
+            Unit* puller = who->GetCharmerOrOwnerPlayerOrPlayerItself();
             Talk(SAY_AGGRO, puller ? puller : who);
         }
     }


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Follow-up to #26789, which broke the GCC/Clang build after the squash merge: in `Talk(SAY_AGGRO, puller ? puller : who)` the ternary mixes `Player*` (from `GetCharmerOrOwnerPlayerOrPlayerItself()`) with `Unit*`, which GCC and Clang reject (`error: conditional expression between distinct pointer types 'Player*' and 'Unit*' lacks a cast`). MSVC accepts the implicit conversion, which is how it slipped through local testing.

Declares the variable as `Unit*` so both ternary operands have the same type.

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Fable 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Fixes the master build failure introduced by #26789

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Compiler error, see the failing CI runs on #26789 (e.g. https://github.com/azerothcore/azerothcore-wotlk/actions/runs/30166314344/job/89699841940).

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Compiles clean on MSVC (Release). One-line type change, no behavior difference.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue

1. Build with GCC or Clang, the build succeeds again.
2. Pull The Prophet Skeram with a pet, the aggro yell targets the pet's owner.

## Known Issues and TODO List:

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
