### PR TITLE
fix(Scripts/TempleOfAhnQiraj): fix Skeram build failure on clang/gcc

### DIFF
--- a/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_skeram.cpp
+++ b/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_skeram.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "CreatureScript.h"
+#include "Player.h"
 #include "ScriptedCreature.h"
 #include "SpellScript.h"
 #include "SpellScriptLoader.h"

--- a/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_skeram.cpp
+++ b/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_skeram.cpp
@@ -156,7 +156,7 @@ struct boss_skeram : public BossAI
         {
             // Resolve pets/guardians to their owner so gendered locales resolve $g against the puller
             Player* puller = who->GetCharmerOrOwnerPlayerOrPlayerItself();
-            Talk(SAY_AGGRO, puller ? puller : who);
+            Talk(SAY_AGGRO, puller ? static_cast<Unit*>(puller) : who);
         }
     }
 


### PR DESCRIPTION
## Changes Proposed:

#26789 (merged) introduced a build-breaking regression on Linux: `boss_skeram.cpp`'s `JustEngagedWith` uses a ternary mixing `Player*` and `Unit*` operands (`puller ? puller : who`). MSVC accepts this, but clang and gcc reject it as "incompatible operand types," which was failing every Linux CI job off master (ubuntu-24.04/26.04 clang-18/clang-20/gcc-14, pch and nopch) - not specific to any one PR, any PR built off current master hits it.

Fix: cast `puller` to `Unit*` before the ternary, so both operands match. No behavior change - `Talk()` takes a `WorldObject const*`, and both `Player*` and `Unit*` already convert to that fine; this only fixes the ternary's own type resolution.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Sonnet 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- None

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Code inspection: Confirmed via the actual CI failure logs on two unrelated PRs (#26799, #26801) that both hit the identical Linux build failure at the identical location (`boss_skeram.cpp:159`), despite touching completely different files - ruling out either PR as the cause. `CreatureAI::Talk`'s signature (`CreatureAI.h`) takes `WorldObject const* whisperTarget`, confirming the cast target is compatible with the call site.

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Not in-game tested (pure compile-error fix, no runtime behavior change) - relying on this PR's own Linux CI to confirm the build passes, since that's the exact failure this fixes.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

Check this PR's own CI - the ubuntu-24.04/26.04 clang/gcc build jobs should now pass instead of failing at boss_skeram.cpp with "incompatible operand types".

## Known Issues and TODO List:

- None

🤖 Generated with Claude Code (Sonnet 5)+AzerothMCP

<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs

When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
