### PR TITLE
fix(Scripts/BlackTemple): restore Supremus Molten Flame chase

### DIFF
--- a/src/server/scripts/Outland/BlackTemple/boss_supremus.cpp
+++ b/src/server/scripts/Outland/BlackTemple/boss_supremus.cpp
@@ -186,27 +186,24 @@ struct npc_supremus_punch_invisible_stalker : public ScriptedAI
 {
     npc_supremus_punch_invisible_stalker(Creature* creature) : ScriptedAI(creature) { }
 
-    void IsSummonedBy(WorldObject* /*summoner*/) override
+    void IsSummonedBy(WorldObject* summoner) override
     {
-        me->SetInCombatWithZone();
-        if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, 100.0f, true))
-            me->AddThreat(target, 10000.f);
-
         DoCastSelf(SPELL_MOLTEN_FLAME, true);
+
+        // Trigger creatures cannot have their own threat list, pick the chase target from the summoner's
+        if (Creature* supremus = summoner->ToCreature())
+            if (Unit* target = supremus->AI()->SelectTarget(SelectTargetMethod::Random, 0, 100.0f, true))
+                me->GetMotionMaster()->MoveFollow(target, 0.0f, 0.0f);
 
         scheduler.Schedule(6s, 10s, [this](TaskContext /*context*/)
         {
-            me->CombatStop();
-            me->SetReactState(REACT_PASSIVE);
+            me->GetMotionMaster()->MoveIdle();
         });
     }
 
     void UpdateAI(uint32 diff) override
     {
         scheduler.Update(diff);
-
-        if (!UpdateVictim())
-            return;
     }
 };
 


### PR DESCRIPTION
## Changes Proposed:

Supremus stopped spawning Molten Flames because the punch stalker (NPC 23095) relies on its own threat list to chase a random player, and since the TrinityCore threat system port (https://github.com/azerothcore/azerothcore-wotlk/commit/984baa92ddaf852a737cbe8f06528d6dd4c5a7a7) trigger creatures cannot have a threat list (https://github.com/azerothcore/azerothcore-wotlk/blob/master/src/server/game/Combat/ThreatManager.cpp#L199-L201). `SelectTarget` on the stalker's own list always returns nullptr and `UpdateVictim()` is always false, so the stalker never moves and the flame stays hidden at the summon point under the boss.

The summon chain itself (Molten Punch 40126 -> stalker -> Molten Flame 40980 -> flame patches 40253) is intact, so the fix only rewires the movement: the stalker now picks its chase target from Supremus' threat list and follows it with `MoveFollow`, then stops moving after the existing 6-10s window. The dead `SetInCombatWithZone`/`AddThreat`/`UpdateVictim` usage is removed.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Fable 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/26228

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

The chase behavior preserves what this script did before the threat rework. TrinityCore's `npc_molten_flame` avoids threat entirely for the same reason (their system has the same trigger-creature restriction) and moves in a random direction instead.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Builds without errors on Windows (MSVC, RelWithDebInfo).

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. `.go creature name Supremus` in Black Temple and engage him.
2. After ~20 seconds (and every 15-20s after), Supremus casts Molten Punch.
3. A Molten Flame trail should spawn and chase a random player for a few seconds, damaging players it touches.

## Known Issues and TODO List:

Other scripts that drive `CREATURE_FLAG_EXTRA_TRIGGER` creatures through their own threat list are broken the same way since the threat rework and need a separate audit.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
