### PR TITLE
fix(DB/Creature): Vaelen the Flayed joins fights while chained up

### DIFF
--- a/data/sql/updates/pending_db_world/2026_07_25_01_vaelen_the_flayed_passive_while_chained.sql
+++ b/data/sql/updates/pending_db_world/2026_07_25_01_vaelen_the_flayed_passive_while_chained.sql
@@ -11,3 +11,13 @@
 -- treats as "no override, inherit from creature_template" (not "force to zero"), so updating the
 -- template value below applies to this spawn.
 UPDATE `creature_template` SET `unit_flags` = `unit_flags`|512 WHERE `entry` = 30056;
+
+-- Optional, belt-and-suspenders addition - not required for the fix above to work, kept as a
+-- second layer in case a future quest/script change ever alters his reactstate: also stop him
+-- from actively choosing to engage on his own (SMART_ACTION_SET_REACT_STATE, passive), reapplied
+-- on every reset so combat can't leave him stuck aggressive.
+DELETE FROM `smart_scripts` WHERE `entryorguid` = 30056 AND `source_type` = 0 AND `id` = 1 AND `link` = 0;
+INSERT INTO `smart_scripts`
+    (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `action_type`, `action_param1`, `target_type`, `comment`)
+VALUES
+    (30056, 0, 1, 0, 25, 0, 100, 0, 8, 0, 1, 'Vaelen the Flayed - On Reset - Set Reactstate Passive (defense in depth)');

--- a/data/sql/updates/pending_db_world/2026_07_25_01_vaelen_the_flayed_passive_while_chained.sql
+++ b/data/sql/updates/pending_db_world/2026_07_25_01_vaelen_the_flayed_passive_while_chained.sql
@@ -1,0 +1,13 @@
+-- Issue #26442: Vaelen the Flayed (Icecrown, entry 30056), a chained-up captive NPC, joins the
+-- fight whenever a hostile mob is pulled near him. His own faction (2050) has HostileMask=0 and
+-- no listed enemies - he can never actually be hostile by faction rules - but his default
+-- reactstate (REACT_AGGRESSIVE, never overridden) is enough for him to assist against anything
+-- fighting nearby regardless of his own faction's hostility.
+--
+-- UNIT_FLAG_IMMUNE_TO_NPC (0x200) blocks him as a valid attack/assist target for and against
+-- NPCs at the engine level (Unit::_IsValidAttackTarget/_IsValidAssistTarget), which is the
+-- precise fix for this symptom - already confirmed working live (see PR #26766, same issue,
+-- same fix, not merged yet). His spawn row's unit_flags is 0, which ObjectMgr::ChooseCreatureFlags
+-- treats as "no override, inherit from creature_template" (not "force to zero"), so updating the
+-- template value below applies to this spawn.
+UPDATE `creature_template` SET `unit_flags` = `unit_flags`|512 WHERE `entry` = 30056;


### PR DESCRIPTION

<img width="1728" height="972" alt="WoWScrnShot_072526_164437" src="https://github.com/user-attachments/assets/a78d8068-5f83-4ebc-b577-b07c0b1c4dea" />


## Changes Proposed:

Vaelen the Flayed (Icecrown, entry 30056) is a chained captive NPC who joins any fight happening near him, even though he's supposed to be immobilized. Pulling a mob near him has him attacking it alongside the player.

Root cause: his faction (2050) has `HostileMask=0` and no listed enemies, so he can never actually be hostile by faction rules - but he has no reactstate override anywhere, so he keeps the engine default (`REACT_AGGRESSIVE`), which is enough on its own for him to assist against anything fighting nearby regardless of his own faction's hostility.

Fix: add `UNIT_FLAG_IMMUNE_TO_NPC` (0x200) to his `creature_template.unit_flags`. This blocks him as a valid attack/assist target for and against NPCs at the engine level (`Unit::_IsValidAttackTarget`/`_IsValidAssistTarget`), which is the precise fix for this symptom.

Also included as an optional, belt-and-suspenders addition (not required for the fix above to work on its own): a `smart_scripts` row setting him to `REACT_PASSIVE` on reset, so he never even tries to engage on his own in case a future change ever touches his reactstate independently.

Note: PR #26766 already proposes the exact same fix for this same issue, opened before I looked into it - flagging so maintainers can pick whichever lands first and close the other, rather than reviewing both in full.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Sonnet 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #26442

## SOURCE:
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Code inspection: Confirmed his faction (2050) has HostileMask=0 and no listed enemies via FactionTemplate.dbc, and confirmed his only smart_scripts row (cast on reset) never sets a reactstate. Also confirmed `ObjectMgr::ChooseCreatureFlags` treats a spawn row's `unit_flags=0` as "no override, inherit from template" (not "force to zero"), so the template-level fix applies to this spawn.

Lore confirmation ([warcraft.wiki.gg/wiki/Vaelen_the_Flayed](https://warcraft.wiki.gg/wiki/Vaelen_the_Flayed)): Vaelen is a death knight captured while trying to invade Jotunheim, held prisoner until freed via the quest `Get the Key` - consistent with the reproduction video/screenshot, where he's chained up right next to Jotunheim mobs. As a prisoner he shouldn't be able to fight at all until rescued, matching the issue's expected behavior.

Checked TrinityCore too: the [original 2014 SQL](https://github.com/TrinityCore/TrinityCore/blob/d088a368f164721a5c8fbb89c51593ba042d3646/sql/old/3.3.5a/TDB54_to_TDB55_updates/world/2014_07_08_10_world_misc.sql#L11-L23) that set up this whole quest chain has the exact same `smart_scripts` row we still have (cast-on-reset only, no reactstate/flags). No later fix for this in TrinityCore's own repo history - this looks like a gap inherited from the original data, not something introduced independently by AzerothCore.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Applied live, reloaded creature_template, respawned Vaelen, pulled a mob near him and confirmed live (with a screenshot) that he no longer joins the fight - stays chained and passive while the player fights nearby.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. .go creature 30056 (Vaelen the Flayed, Icecrown).
2. Pull a hostile mob near him and fight it.
3. Confirm Vaelen does not join the fight (before the fix, he attacks the mob too).

## Known Issues and TODO List:

- None

🤖 Generated with Claude Code (Sonnet 5)+AzerothMCP

<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs

When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.



