### PR TITLE
fix(Spells): generic ghost-charge window for charge-based procs

### DIFF
--- a/data/sql/updates/pending_db_world/2026_07_25_02_fingers_of_frost_charge_drop_delay.sql
+++ b/data/sql/updates/pending_db_world/2026_07_25_02_fingers_of_frost_charge_drop_delay.sql
@@ -1,6 +1,7 @@
--- Adds a generic "ghost charge" window for charge-based proc auras: keeps the aura
--- alive for ChargeDropDelay ms after its last charge is consumed instead of removing
--- it immediately, so an instant cast already queued in the same batch can still use it.
+-- Adds a generic "ghost charge" grace window for charge-based proc auras: keeps the
+-- aura alive for ChargeDropDelay ms after its last charge is consumed instead of
+-- removing it immediately, so an instant cast issued right as the last charge lands
+-- can still benefit from it.
 ALTER TABLE `spell_proc` ADD COLUMN `ChargeDropDelay` INT UNSIGNED NOT NULL DEFAULT 0 AFTER `Charges`;
 
 -- 74396 - Fingers of Frost (Mage): already has a row, just add the delay.

--- a/data/sql/updates/pending_db_world/2026_07_25_02_fingers_of_frost_charge_drop_delay.sql
+++ b/data/sql/updates/pending_db_world/2026_07_25_02_fingers_of_frost_charge_drop_delay.sql
@@ -1,0 +1,16 @@
+-- Adds a generic "ghost charge" window for charge-based proc auras: keeps the aura
+-- alive for ChargeDropDelay ms after its last charge is consumed instead of removing
+-- it immediately, so an instant cast already queued in the same batch can still use it.
+ALTER TABLE `spell_proc` ADD COLUMN `ChargeDropDelay` INT UNSIGNED NOT NULL DEFAULT 0 AFTER `Charges`;
+
+-- 74396 - Fingers of Frost (Mage): already has a row, just add the delay.
+UPDATE `spell_proc` SET `ChargeDropDelay` = 400 WHERE `SpellId` = 74396;
+
+-- 20216 - Divine Favor (Paladin): had no row (ran purely on the DBC-derived auto-generated
+-- proc entry). Values below mirror exactly what SpellMgr::LoadSpellProcs() auto-generates
+-- for it today, so this only adds ChargeDropDelay without changing existing proc behavior.
+DELETE FROM `spell_proc` WHERE `SpellId` = 20216;
+INSERT INTO `spell_proc`
+    (`SpellId`, `SchoolMask`, `SpellFamilyName`, `SpellFamilyMask0`, `SpellFamilyMask1`, `SpellFamilyMask2`, `ProcFlags`, `SpellTypeMask`, `SpellPhaseMask`, `HitMask`, `AttributesMask`, `DisableEffectsMask`, `ProcsPerMinute`, `Chance`, `Cooldown`, `Charges`, `ChargeDropDelay`)
+VALUES
+    (20216, 0, 10, 3223322624, 0, 0, 81920, 7, 2, 0, 8, 0, 0, 100, 0, 1, 400);

--- a/src/server/game/Spells/Auras/SpellAuras.cpp
+++ b/src/server/game/Spells/Auras/SpellAuras.cpp
@@ -2337,7 +2337,14 @@ void Aura::ConsumeProcCharges(SpellProcEntry const* procEntry)
     else if (IsUsingCharges())
     {
         if (!GetCharges())
-            Remove();
+        {
+            // out of charges already blocks further procs (see CalcProcChance), so holding the
+            // aura here just keeps it visible/consumable for an instant cast queued in the same batch
+            if (procEntry->ChargeDropDelay.count())
+                SetDuration(procEntry->ChargeDropDelay.count());
+            else
+                Remove();
+        }
     }
 }
 

--- a/src/server/game/Spells/Auras/SpellAuras.cpp
+++ b/src/server/game/Spells/Auras/SpellAuras.cpp
@@ -2339,7 +2339,7 @@ void Aura::ConsumeProcCharges(SpellProcEntry const* procEntry)
         if (!GetCharges())
         {
             // out of charges already blocks further procs (see CalcProcChance), so holding the
-            // aura here just keeps it visible/consumable for an instant cast queued in the same batch
+            // aura here just gives a short grace window for an instant cast issued right as the last charge lands
             if (procEntry->ChargeDropDelay.count())
                 SetDuration(procEntry->ChargeDropDelay.count());
             else

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -2009,8 +2009,8 @@ void SpellMgr::LoadSpellProcs()
 
     mSpellProcMap.clear();                             // need for reload case
 
-    //                                                 0        1           2                3                 4                 5                 6          7              8              9         10              11                  12             13      14        15
-    QueryResult result = WorldDatabase.Query("SELECT SpellId, SchoolMask, SpellFamilyName, SpellFamilyMask0, SpellFamilyMask1, SpellFamilyMask2, ProcFlags, SpellTypeMask, SpellPhaseMask, HitMask, AttributesMask, DisableEffectsMask, ProcsPerMinute, Chance, Cooldown, Charges FROM spell_proc");
+    //                                                 0        1           2                3                 4                 5                 6          7              8              9         10              11                  12             13      14        15       16
+    QueryResult result = WorldDatabase.Query("SELECT SpellId, SchoolMask, SpellFamilyName, SpellFamilyMask0, SpellFamilyMask1, SpellFamilyMask2, ProcFlags, SpellTypeMask, SpellPhaseMask, HitMask, AttributesMask, DisableEffectsMask, ProcsPerMinute, Chance, Cooldown, Charges, ChargeDropDelay FROM spell_proc");
     if (!result)
     {
         LOG_WARN("server.loading", ">> Loaded 0 Spell Proc Conditions And Data. DB table `spell_proc` Is Empty.");
@@ -2065,6 +2065,7 @@ void SpellMgr::LoadSpellProcs()
         baseProcEntry.Chance             = fields[13].Get<float>();
         baseProcEntry.Cooldown           = Milliseconds(fields[14].Get<uint32>());
         baseProcEntry.Charges            = fields[15].Get<uint32>();
+        baseProcEntry.ChargeDropDelay    = Milliseconds(fields[16].Get<uint32>());
 
         while (spellInfo)
         {
@@ -2103,6 +2104,8 @@ void SpellMgr::LoadSpellProcs()
                 LOG_ERROR("sql.sql", "`spell_proc` table entry for SpellId {} has too big value in `Charges` field", spellId);
                 procEntry.Charges = 99;
             }
+            if (procEntry.ChargeDropDelay.count() && !procEntry.Charges)
+                LOG_ERROR("sql.sql", "`spell_proc` table entry for SpellId {} has `ChargeDropDelay` value defined, but `Charges` is 0 (infinite charges), the aura is never removed for the delay to apply", spellId);
             if (!procEntry.ProcFlags)
                 LOG_ERROR("sql.sql", "`spell_proc` table entry for SpellId {} doesn't have `ProcFlags` value defined, proc will not be triggered", spellId);
             if (procEntry.SpellTypeMask & ~PROC_SPELL_TYPE_MASK_ALL)

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -2105,7 +2105,9 @@ void SpellMgr::LoadSpellProcs()
                 procEntry.Charges = 99;
             }
             if (procEntry.ChargeDropDelay.count() && !procEntry.Charges)
-                LOG_ERROR("sql.sql", "`spell_proc` table entry for SpellId {} has `ChargeDropDelay` value defined, but `Charges` is 0 (infinite charges), the aura is never removed for the delay to apply", spellId);
+                LOG_ERROR("sql.sql",
+                    "`spell_proc` entry for SpellId {} has `ChargeDropDelay` but `Charges` is 0, never applies",
+                    spellId);
             if (!procEntry.ProcFlags)
                 LOG_ERROR("sql.sql", "`spell_proc` table entry for SpellId {} doesn't have `ProcFlags` value defined, proc will not be triggered", spellId);
             if (procEntry.SpellTypeMask & ~PROC_SPELL_TYPE_MASK_ALL)
@@ -2286,6 +2288,7 @@ void SpellMgr::LoadSpellProcs()
         procEntry.Chance          = static_cast<float>(spellInfo->ProcChance);
         procEntry.Cooldown        = Milliseconds::zero();
         procEntry.Charges         = spellInfo->ProcCharges;
+        procEntry.ChargeDropDelay = Milliseconds::zero();
 
         mSpellProcMap[spellInfo->Id] = procEntry;
         ++count;

--- a/src/server/game/Spells/SpellMgr.h
+++ b/src/server/game/Spells/SpellMgr.h
@@ -297,7 +297,7 @@ struct SpellProcEntry
     float        Chance;                                     // if nonzero - owerwrite procChance field for given Spell.dbc entry, defines chance of proc to occur, not used if ProcsPerMinute set
     Milliseconds Cooldown;                                   // if nonzero - cooldown in secs for aura proc, applied to aura
     uint32       Charges;                                    // if nonzero - owerwrite procCharges field for given Spell.dbc entry, defines how many times proc can occur before aura remove, 0 - infinite
-    Milliseconds ChargeDropDelay;                            // if nonzero - keeps the aura alive (out of charges, can no longer proc) for this long after its last charge is consumed instead of removing it immediately - emulates 3.3.5's spell-batching window for an instant cast already queued at that moment
+    Milliseconds ChargeDropDelay;                            // if nonzero - keeps the aura alive (out of charges, can no longer proc) for this long after its last charge is consumed instead of removing it immediately, giving a brief grace window for an instant cast issued right as the last charge lands to still benefit from it
 };
 
 typedef std::unordered_map<uint32, SpellProcEntry> SpellProcMap;

--- a/src/server/game/Spells/SpellMgr.h
+++ b/src/server/game/Spells/SpellMgr.h
@@ -297,7 +297,7 @@ struct SpellProcEntry
     float        Chance;                                     // if nonzero - owerwrite procChance field for given Spell.dbc entry, defines chance of proc to occur, not used if ProcsPerMinute set
     Milliseconds Cooldown;                                   // if nonzero - cooldown in secs for aura proc, applied to aura
     uint32       Charges;                                    // if nonzero - owerwrite procCharges field for given Spell.dbc entry, defines how many times proc can occur before aura remove, 0 - infinite
-    Milliseconds ChargeDropDelay;                            // if nonzero - keeps the aura alive (out of charges, can no longer proc) for this long after its last charge is consumed instead of removing it immediately, giving a brief grace window for an instant cast issued right as the last charge lands to still benefit from it
+    Milliseconds ChargeDropDelay;                            // ms grace window before removing an out-of-charges aura
 };
 
 typedef std::unordered_map<uint32, SpellProcEntry> SpellProcMap;

--- a/src/server/game/Spells/SpellMgr.h
+++ b/src/server/game/Spells/SpellMgr.h
@@ -297,6 +297,7 @@ struct SpellProcEntry
     float        Chance;                                     // if nonzero - owerwrite procChance field for given Spell.dbc entry, defines chance of proc to occur, not used if ProcsPerMinute set
     Milliseconds Cooldown;                                   // if nonzero - cooldown in secs for aura proc, applied to aura
     uint32       Charges;                                    // if nonzero - owerwrite procCharges field for given Spell.dbc entry, defines how many times proc can occur before aura remove, 0 - infinite
+    Milliseconds ChargeDropDelay;                            // if nonzero - keeps the aura alive (out of charges, can no longer proc) for this long after its last charge is consumed instead of removing it immediately - emulates 3.3.5's spell-batching window for an instant cast already queued at that moment
 };
 
 typedef std::unordered_map<uint32, SpellProcEntry> SpellProcMap;

--- a/src/server/scripts/Spells/spell_mage.cpp
+++ b/src/server/scripts/Spells/spell_mage.cpp
@@ -961,6 +961,11 @@ class spell_mage_fingers_of_frost : public AuraScript
         return ValidateSpellInfo({ SPELL_MAGE_FINGERS_OF_FROST_AURASTATE_AURA });
     }
 
+    void HandleApply(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
+    {
+        _freshlyApplied = true;
+    }
+
     void PrepareProc(ProcEventInfo& eventInfo)
     {
         if (Spell const* spell = eventInfo.GetProcSpell())
@@ -971,11 +976,21 @@ class spell_mage_fingers_of_frost : public AuraScript
             bool prevent = false;
 
             if (isTriggered)
+            {
+                // Triggered procs (e.g. Blizzard ticks) consume charges normally and clear the guard
+                _freshlyApplied = false;
                 prevent = false;
+            }
             else if (isChanneled)
                 prevent = true;
             else if (!isCastPhase)
                 prevent = true;
+            else if (_freshlyApplied)
+            {
+                // The spell that procced FoF into existence must not also consume a charge
+                prevent = true;
+                _freshlyApplied = false;
+            }
 
             if (prevent)
                 PreventDefaultAction();
@@ -989,9 +1004,12 @@ class spell_mage_fingers_of_frost : public AuraScript
 
     void Register() override
     {
+        AfterEffectApply += AuraEffectApplyFn(spell_mage_fingers_of_frost::HandleApply, EFFECT_0, SPELL_AURA_DUMMY, AURA_EFFECT_HANDLE_REAL);
         DoPrepareProc += AuraProcFn(spell_mage_fingers_of_frost::PrepareProc);
         AfterEffectRemove += AuraEffectRemoveFn(spell_mage_fingers_of_frost::OnRemove, EFFECT_0, SPELL_AURA_DUMMY, AURA_EFFECT_HANDLE_REAL);
     }
+
+    bool _freshlyApplied = false;
 };
 
 // -31571 - Arcane Potency

--- a/src/server/scripts/Spells/spell_mage.cpp
+++ b/src/server/scripts/Spells/spell_mage.cpp
@@ -1004,7 +1004,8 @@ class spell_mage_fingers_of_frost : public AuraScript
 
     void Register() override
     {
-        AfterEffectApply += AuraEffectApplyFn(spell_mage_fingers_of_frost::HandleApply, EFFECT_0, SPELL_AURA_DUMMY, AURA_EFFECT_HANDLE_REAL);
+        AfterEffectApply += AuraEffectApplyFn(
+            spell_mage_fingers_of_frost::HandleApply, EFFECT_0, SPELL_AURA_DUMMY, AURA_EFFECT_HANDLE_REAL);
         DoPrepareProc += AuraProcFn(spell_mage_fingers_of_frost::PrepareProc);
         AfterEffectRemove += AuraEffectRemoveFn(spell_mage_fingers_of_frost::OnRemove, EFFECT_0, SPELL_AURA_DUMMY, AURA_EFFECT_HANDLE_REAL);
     }


### PR DESCRIPTION
## Changes Proposed:

Fingers of Frost's last charge gets consumed by the same Frostbolt that used it, so a queued Deep Freeze right after loses the guaranteed-crit/frozen-target bonus even though it should still count as "frozen" for that split second.

Two prior attempts at this, both closed:
- #26210 changed the proc's consumption phase (`PROC_SPELL_PHASE_CAST` -> `HIT`), which was the wrong direction - CAST-phase consumption is correct per 3.3 patch notes, closed same-day.
- #26216 fixed it for Fingers of Frost specifically with a spell-only hack (extend the buff's duration by 400ms on removal). Reviewed and video-confirmed working, but stalled: the maintainer asked whether this should be generalized through `spell_proc` instead of hardcoded per spell, since the same timing gap affects other charge-based procs (Divine Favor + Holy Shock is the same story). Closed unresolved after no follow-up.

This PR does that. Added a `ChargeDropDelay` column to `spell_proc` (ms). When a charge-based proc aura runs out of charges, instead of removing it immediately, the aura now stays up for `ChargeDropDelay` ms if that value is set - long enough for an instant cast issued right as the last charge lands to still catch it. It can't proc again in that window (out-of-charges already blocks new procs), so nothing double-dips.

Applied it to two unrelated cases as proof it's genuinely reusable:
- Fingers of Frost (74396): already had a `spell_proc` row, just added the delay.
- Divine Favor (20216): had no row at all before this (ran on the DBC-derived auto-generated proc entry). Added one that mirrors exactly what the engine currently auto-generates for it, plus the new delay - so this is a pure DB addition, zero C++.

Reverted the spell-specific 400ms hack from `spell_mage.cpp`'s Fingers of Frost script, keeping only the unrelated self-consumption guard (a Frostbolt that procs FoF shouldn't also consume the charge it just created - that's a separate bug from the ghost-charge one).

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Sonnet 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #25117

## SOURCE:
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

Frost Mage: Frostbolt-spam until Fingers of Frost is down to its last charge, then queue Deep Freeze right as that last-charge Frostbolt lands - Deep Freeze should still guarantee the frozen-target effect.

Paladin: pop Divine Favor, cast Holy Shock immediately - both effects should get the guaranteed crit, same as before this PR (this case has zero C++ changes, it's here to prove the DB mechanism generalizes).

## Known Issues and TODO List:

Not personally verified in-client yet - built and deployed cleanly (no spell_proc load errors), opening this now for others to test both combos since that's hard to verify solo.

<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs

When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
