### PR TITLE
fix(Scripts/BlackTemple): fix crash on Shade of Akama evade

### DIFF
--- a/src/server/scripts/Outland/BlackTemple/boss_shade_of_akama.cpp
+++ b/src/server/scripts/Outland/BlackTemple/boss_shade_of_akama.cpp
@@ -99,8 +99,6 @@ struct boss_shade_of_akama : public BossAI
 {
     boss_shade_of_akama(Creature* creature) : BossAI(creature, DATA_SHADE_OF_AKAMA) { }
 
-    // Store guids, not Creature*: in dynamic spawn mode dead channelers are
-    // deleted on corpse removal, leaving cached pointers dangling until evade.
     GuidVector channelers;
     GuidVector generators;
 

--- a/src/server/scripts/Outland/BlackTemple/boss_shade_of_akama.cpp
+++ b/src/server/scripts/Outland/BlackTemple/boss_shade_of_akama.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "CreatureScript.h"
+#include "ObjectAccessor.h"
 #include "ScriptedCreature.h"
 #include "SpellScriptLoader.h"
 #include "black_temple.h"
@@ -98,8 +99,10 @@ struct boss_shade_of_akama : public BossAI
 {
     boss_shade_of_akama(Creature* creature) : BossAI(creature, DATA_SHADE_OF_AKAMA) { }
 
-    std::list<Creature*> channelers;
-    std::list<Creature*> generators;
+    // Store guids, not Creature*: in dynamic spawn mode dead channelers are
+    // deleted on corpse removal, leaving cached pointers dangling until evade.
+    GuidVector channelers;
+    GuidVector generators;
 
     void Reset() override
     {
@@ -114,11 +117,13 @@ struct boss_shade_of_akama : public BossAI
 
     void EnterEvadeMode(EvadeReason why) override
     {
-        for (Creature* generator : generators)
-            generator->AI()->DoAction(ACTION_GENERATOR_DESPAWN_ALL);
+        for (ObjectGuid const& generatorGuid : generators)
+            if (Creature* generator = ObjectAccessor::GetCreature(*me, generatorGuid))
+                generator->AI()->DoAction(ACTION_GENERATOR_DESPAWN_ALL);
 
-        for (Creature* channeler : channelers)
-            channeler->SetUnitFlag(UNIT_FLAG_NOT_SELECTABLE);
+        for (ObjectGuid const& channelerGuid : channelers)
+            if (Creature* channeler = ObjectAccessor::GetCreature(*me, channelerGuid))
+                channeler->SetUnitFlag(UNIT_FLAG_NOT_SELECTABLE);
 
         BossAI::EnterEvadeMode(why);
     }
@@ -128,8 +133,9 @@ struct boss_shade_of_akama : public BossAI
         BossAI::JustDied(killer);
         me->CastSpell(me, SPELL_SHADE_OF_AKAMA_TRIGGER, true);
 
-        for (Creature* generator : generators)
-            generator->AI()->DoAction(ACTION_GENERATOR_DESPAWN_ALL);
+        for (ObjectGuid const& generatorGuid : generators)
+            if (Creature* generator = ObjectAccessor::GetCreature(*me, generatorGuid))
+                generator->AI()->DoAction(ACTION_GENERATOR_DESPAWN_ALL);
 
         if (Creature* akama = instance->GetCreature(DATA_AKAMA_SHADE))
             akama->AI()->DoAction(ACTION_AKAMA_START_OUTRO);
@@ -141,14 +147,22 @@ struct boss_shade_of_akama : public BossAI
         {
             instance->SetBossState(DATA_SHADE_OF_AKAMA, IN_PROGRESS);
 
-            me->GetCreatureListWithEntryInGrid(channelers, NPC_ASHTONGUE_CHANNELER, 40.0f);
-            me->GetCreatureListWithEntryInGrid(generators, NPC_CREATURE_GENERATOR_AKAMA, 100.0f);
+            std::list<Creature*> channelerList;
+            std::list<Creature*> generatorList;
+            me->GetCreatureListWithEntryInGrid(channelerList, NPC_ASHTONGUE_CHANNELER, 40.0f);
+            me->GetCreatureListWithEntryInGrid(generatorList, NPC_CREATURE_GENERATOR_AKAMA, 100.0f);
 
-            for (Creature* channeler : channelers)
+            for (Creature* channeler : channelerList)
+            {
+                channelers.push_back(channeler->GetGUID());
                 channeler->RemoveUnitFlag(UNIT_FLAG_NOT_SELECTABLE);
+            }
 
-            for (Creature* generator : generators)
+            for (Creature* generator : generatorList)
+            {
+                generators.push_back(generator->GetGUID());
                 generator->AI()->DoAction(ACTION_GENERATOR_START);
+            }
 
             ScheduleTimedEvent(1200ms, [&]
             {
@@ -169,8 +183,9 @@ struct boss_shade_of_akama : public BossAI
             me->RemoveAurasDueToSpell(SPELL_AKAMA_SOUL_CHANNEL);
             scheduler.CancelAll();
 
-            for (Creature* generator : generators)
-                generator->AI()->DoAction(ACTION_GENERATOR_STOP);
+            for (ObjectGuid const& generatorGuid : generators)
+                if (Creature* generator = ObjectAccessor::GetCreature(*me, generatorGuid))
+                    generator->AI()->DoAction(ACTION_GENERATOR_STOP);
 
             if (Creature* akama = instance->GetCreature(DATA_AKAMA_SHADE))
             {
@@ -222,7 +237,6 @@ struct npc_akama_shade : public ScriptedAI
         _sayLowHealth = false;
         _died = false;
         scheduler.CancelAll();
-        _generators.clear();
     }
 
     void MovementInform(uint32 type, uint32 point) override
@@ -280,8 +294,9 @@ struct npc_akama_shade : public ScriptedAI
         else if (damage >= me->GetHealth() && !_died)
         {
             _died = true;
-            me->GetCreatureListWithEntryInGrid(_generators, NPC_CREATURE_GENERATOR_AKAMA, 100.0f);
-            for (Creature* generator : _generators)
+            std::list<Creature*> generators;
+            me->GetCreatureListWithEntryInGrid(generators, NPC_CREATURE_GENERATOR_AKAMA, 100.0f);
+            for (Creature* generator : generators)
                 generator->AI()->DoAction(ACTION_GENERATOR_DESPAWN_ALL);
 
             damage = me->GetHealth() - 1;
@@ -347,7 +362,6 @@ struct npc_akama_shade : public ScriptedAI
     private:
         bool _sayLowHealth;
         bool _died;
-        std::list<Creature *> _generators;
 };
 
 struct npc_creature_generator_akama : public ScriptedAI


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Fixes a worldserver crash (use-after-free) in the Shade of Akama encounter.

`boss_shade_of_akama` caches raw `Creature*` lists of the six Ashtongue Channelers and the creature generators when the encounter starts and keeps them for the whole fight. Since the dynamic spawn port (https://github.com/azerothcore/azerothcore-wotlk/commit/f5c4de92eb, #25206), DB-spawned creatures without a compatibility-mode spawn group are destroyed on corpse removal and recreated by `ProcessRespawns()`. Killing channelers is the encounter mechanic, so once a dead channeler's corpse despawns mid-fight, its cached pointer dangles. When Akama later dies to the waves, `npc_akama_shade::DamageTaken` forces the Shade to evade and `EnterEvadeMode` calls `SetUnitFlag` on the freed object, crashing the server.

The fix stores `ObjectGuid`s instead of raw pointers and resolves them via `ObjectAccessor::GetCreature` at use time, skipping creatures that no longer exist. A despawned channeler respawns with its DB unit flags anyway, so there is nothing to unflag on evade. `npc_akama_shade::_generators` was also turned into a local since it was only populated and consumed inside `DamageTaken`.

Crash log from production:

<details>
<summary>Backtrace</summary>

```
Thread 17 "worldserver" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x1554c47fc6c0 (LWP 323701)]
0x00005555564c0d79 in Object::SetFlag (this=0x154fd2bc0000, index=<optimized out>, newFlag=<optimized out>) at src/server/game/Entities/Object/Object.cpp:829
829	    ASSERT(index < m_valuesCount || PrintIndexError(index, true));
#0  0x00005555564c0d79 in Object::SetFlag (this=0x154fd2bc0000, index=<optimized out>, newFlag=<optimized out>) at src/server/game/Entities/Object/Object.cpp:829
#1  0x00005555560dd5e4 in Unit::SetUnitFlag (this=0x1554c47f9e60, flags=UNIT_FLAG_NOT_SELECTABLE) at src/server/game/Entities/Unit/Unit.h:749
#2  boss_shade_of_akama::EnterEvadeMode (this=0x15528b46fc00, why=CreatureAI::EVADE_REASON_OTHER) at src/server/scripts/Outland/BlackTemple/boss_shade_of_akama.cpp:121
        channeler = 0x1554c47f9e60
        __range1 = std::__cxx11::list = {[0] = 0x154fd3021000, [1] = 0x154fd2bc0000, [2] = 0x154fd2b76000, [3] = 0x154fd2764000, [4] = 0x154fd2b73000, [5] = 0x154fd2b1e000}
        __end1 = 0x6
        __begin1 = 0x154fd2bc0000
#3  0x00005555560de1b2 in npc_akama_shade::DamageTaken (this=0x1554ecc78540, damage=@0x1554c47f9f40: 1330) at src/server/scripts/Outland/BlackTemple/boss_shade_of_akama.cpp:292
#4  0x000055555658ab01 in Unit::DealDamage (attacker=attacker@entry=0x154f6f852000, victim=victim@entry=0x154c4b6d2000, damage=1330, cleanDamage=0x1554c47fa078, damagetype=damagetype@entry=DIRECT_DAMAGE, damageSchoolMask=SPELL_SCHOOL_MASK_NORMAL, spellProto=0x0, durabilityLoss=<optimized out>, damageSpell=0x0) at src/server/game/Entities/Unit/Unit.cpp:992
#5  0x000055555659412d in Unit::DealMeleeDamage (this=this@entry=0x154f6f852000, damageInfo=damageInfo@entry=0x1554c47fa178, durabilityLoss=true) at src/server/game/Entities/Unit/Unit.cpp:2073
#6  0x0000555556596f4d in Unit::AttackerStateUpdate (this=0x154f6f852000, victim=0x154c4b6d2000, attType=BASE_ATTACK, extra=<optimized out>, ignoreCasting=<optimized out>) at src/server/game/Entities/Unit/Unit.cpp:2816
#7  0x000055555631f7aa in UnitAI::DoMeleeAttackIfReady (this=0x15536a9f9200) at src/server/game/AI/CoreAI/UnitAI.cpp:61
#8  0x00005555564881af in Creature::Update (this=0x154f6f852000, diff=106) at src/server/game/Entities/Creature/Creature.cpp:884
#9  0x00005555564a0a38 in TempSummon::Update (this=0x1554c47f9e60, diff=3535536128) at src/server/game/Entities/Creature/TemporarySummon.cpp:68
#10 0x0000555556711d4e in Map::UpdateNonPlayerObjects (this=this@entry=0x154c67b45740, diff=diff@entry=106) at src/server/game/Maps/Map.cpp:573
#11 0x0000555556710da4 in Map::Update (this=0x154c67b45740, t_diff=106, s_diff=10) at src/server/game/Maps/Map.cpp:503
#12 0x00005555567183cf in InstanceMap::Update (this=0x1554c47f9e60, t_diff=3535536128, s_diff=4294967251) at src/server/game/Maps/Map.cpp:2082
#13 0x000055555672888d in MapUpdateRequest::call (this=0x1554ef308820) at src/server/game/Maps/MapUpdater.cpp:46
#14 0x00005555567281d8 in MapUpdater::WorkerThread (this=0x555557403d68 <MapMgr::instance()::instance+216>) at src/server/game/Maps/MapUpdater.cpp:186
```

The crashing pointer `0x154fd2bc0000` is entry `[1]` of the cached channeler list.

</details>

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Fable 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- None linked, crash observed on a production server (log above).

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Make sure `Respawn.ForceCompatibilityMode` is disabled (default) so the channelers run in dynamic spawn mode.
2. In Black Temple, start the Shade of Akama encounter via Akama's gossip.
3. Kill at least one Ashtongue Channeler and wait for its corpse to despawn while the fight is still running.
4. Let the Ashtongue waves kill Akama so the Shade is forced to evade.
5. Without this PR the worldserver crashes in `boss_shade_of_akama::EnterEvadeMode`; with it the encounter resets normally.

## Known Issues and TODO List:

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
