### PR TITLE
fix(DB/Immunities): allow Mind Control on 25-man Naxxramas Worshippers

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1785029398836777100.sql
+++ b/data/sql/updates/pending_db_world/rev_1785029398836777100.sql
@@ -1,0 +1,4 @@
+-- Naxxramas Worshipper must not be charm-immune: Mind Controlling her to cast
+-- Widow's Embrace is the core mechanic of the Grand Widow Faerlina encounter.
+-- -414 (with CHARM) -> -413 (same set without CHARM), TC has no immunities here.
+UPDATE `creature_template` SET `CreatureImmunitiesId` = -413 WHERE `entry` IN (16506, 29274);

--- a/data/sql/updates/pending_db_world/rev_1785029398836777100.sql
+++ b/data/sql/updates/pending_db_world/rev_1785029398836777100.sql
@@ -1,4 +1,6 @@
--- Naxxramas Worshipper must not be charm-immune: Mind Controlling her to cast
--- Widow's Embrace is the core mechanic of the Grand Widow Faerlina encounter.
--- -414 (with CHARM) -> -413 (same set without CHARM), TC has no immunities here.
-UPDATE `creature_template` SET `CreatureImmunitiesId` = -413 WHERE `entry` IN (16506, 29274);
+-- On 25-man, Faerlina's Frenzy is countered by Mind Controlling a Naxxramas
+-- Worshipper to cast Widow's Embrace, so the 25-man entry must not be
+-- charm-immune: -414 (with CHARM) -> -413 (same set without CHARM).
+-- The 10-man entry (16506) keeps -414: there the Worshipper cannot be MC'd
+-- and is killed next to Faerlina instead (casts Widow's Embrace on death).
+UPDATE `creature_template` SET `CreatureImmunitiesId` = -413 WHERE `entry` = 29274;


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

The 25-man Naxxramas Worshipper (29274) is currently assigned immunity set -414, which includes CHARM. That makes her immune to Mind Control, and on 25-man MCing a Worshipper to cast Widow's Embrace is the intended counter to Grand Widow Faerlina's Frenzy.

The entry regressed in https://github.com/azerothcore/azerothcore-wotlk/pull/26465 (commit https://github.com/azerothcore/azerothcore-wotlk/commit/106bae8a147097cee92db66a5ae3875656a59fc2), which synced difficulty entries to their base template and moved 29274 from -413 to -414. For the Worshipper the pre-sync difficulty split was correct and deliberate:

- 10-man (16506, set -414 with CHARM): Worshippers cannot be Mind Controlled on retail. They are killed next to Faerlina and cast Widow's Embrace on death, which the existing SmartAI covers ("On Just Died - Cast 'Widow`s Embrace' (Normal Dungeon)").
- 25-man (29274, set -413 without CHARM): a priest must Mind Control a Worshipper and use her Widow's Embrace ability.

This restores -413 on the 25-man entry only. The two sets are bit-identical except for CHARM.

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Fable 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- None filed; reported by players as Faerlina adds being immune to MC on 25-man.

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

https://warcraft.wiki.gg/wiki/Grand_Widow_Faerlina documents the difficulty split: in 10-man the Worshippers "cannot be mind controlled" and are killed near Faerlina to remove Frenzy, while in 25-man "a priest will mind control one of the Worshippers and move it near Faerlina then use Widow's Embrace when frenzy is cast". The encounter abilities are also documented on https://www.wowhead.com/wotlk/npc=15953/grand-widow-faerlina and https://www.wowhead.com/wotlk/spell=28732/widows-embrace.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Apply the pending update to the world database.
2. Enter 25-man Naxxramas with a priest and engage Grand Widow Faerlina.
3. Cast Mind Control (605) on a Naxxramas Worshipper. Before the fix it fails as immune, after the fix it applies.
4. While the Worshipper is charmed, use Widow's Embrace during Faerlina's Frenzy and verify the Frenzy is removed.
5. On 10-man, verify the Worshipper is still immune to Mind Control and that killing her next to Faerlina still removes Frenzy.

## Known Issues and TODO List:

- [ ] PR #26465 applied the same base-to-difficulty sync to other Naxxramas NPCs (e.g. construct quarter slimes gained snare immunity). Those are not covered here and may deserve a follow-up review.

<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
