### PR TITLE
fix(Core/Creature): don't charge corpse decay time on forced despawn of a living creature

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -2172,14 +2172,17 @@ void Creature::ForcedDespawn(Milliseconds timeMSToDespawn, Seconds forceRespawnT
     if (forceRespawnTimer > 0s)
         m_respawnDelay = forceRespawnTimer.count();
 
-    if (IsAlive())
+    bool const wasAlive = IsAlive();
+
+    if (wasAlive)
         setDeathState(DeathState::JustDied, true);
 
     // Xinef: Set new respawn time, ignore corpse decay time...
-    // After setDeathState, m_respawnTime includes m_corpseDelay which we don't
-    // want for a forced respawn. Override it so RemoveCorpse's max() picks ours.
-    if (forceRespawnTimer > 0s)
-        m_respawnTime = GameTime::GetGameTime().count() + forceRespawnTimer.count();
+    // setDeathState(JustDied) folds m_corpseDelay into m_respawnTime, but a creature
+    // despawned while alive never leaves a corpse, so the decay must not be charged.
+    // Recompute so RemoveCorpse's max() has nothing stale to pick up.
+    if (forceRespawnTimer > 0s || wasAlive)
+        m_respawnTime = GameTime::GetGameTime().count() + m_respawnDelay;
 
     RemoveCorpse(true);
 


### PR DESCRIPTION
## Changes Proposed:

When a creature is despawned while still alive and no explicit respawn timer is supplied (`DespawnOrUnsummon()` with no second argument, or `SMART_ACTION_FORCE_DESPAWN` with `forceRespawnTimer = 0`, which is the vast majority of uses), the dynamic (non compatibility) spawn path charges the creature's corpse decay time on top of `spawntimesecs`, even though the creature is removed outright and never leaves a corpse. Affected spawns respawn 60s late (normal rank) or 300s late (rare, elite, rare elite).

Cause: `setDeathState(JustDied)` folds `m_corpseDelay` into `m_respawnTime` on the assumption that a corpse will exist. `ForcedDespawn` already compensates for this, but only when an explicit `forceRespawnTimer` is given. With no timer the stale value survives, because the dynamic mode branch of `RemoveCorpse` clamps with `std::max` and always picks it. Compatibility mode assigns the respawn time directly in `RemoveCorpse` and has never charged the decay in this situation, so the two modes diverge.

Fix: apply the existing "ignore corpse decay time" correction whenever the creature was alive at the moment of the forced despawn, not only when a forced timer was supplied. Since `m_respawnDelay` is already overridden with the forced timer earlier in the function, both cases reduce to the same assignment.

Not affected: normal deaths, `DespawnOnEvade` (always passes a respawn timer of at least 2s), any call with an explicit timer, temporary summons (routed to `TempSummon::UnSummon`), and compatibility mode, which recomputes the respawn time itself and is bit for bit unchanged. A creature that was already a corpse when force despawned also keeps its current behaviour, since a corpse did exist and charging the decay is correct there.

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Fable 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- None. Behavioural divergence between dynamic and compatibility respawn mode introduced by the spawn system port (https://github.com/azerothcore/azerothcore-wotlk/pull/25206).

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Validated against the compatibility mode code path (`Creature::RemoveCorpse`, legacy branch), which drops the corpse decay in the same situation. This PR restores parity between the two modes.

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Codestyle checks pass.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Ensure `Respawn.ForceCompatibilityMode = 0` (default) in worldserver.conf.
2. Pick a non-elite DB creature with a known `creature.spawntimesecs`, e.g. 30.
3. Give it a SmartAI script using `SMART_ACTION_FORCE_DESPAWN` with all action parameters at 0 (or despawn it via any script calling `DespawnOrUnsummon()` with no respawn timer).
4. Trigger the despawn and check the remaining respawn time:
   ```sql
   SELECT spawnId, respawnTime - UNIX_TIMESTAMP() AS seconds_left
   FROM creature_respawn WHERE spawnId = <spawnId>;
   ```
5. Before the fix `seconds_left` is `spawntimesecs + 60` (or + 300 for rare/elite). After the fix it matches `spawntimesecs`.
6. Regression checks: kill a creature normally (corpse decay must still delay the respawn as before), force despawn with an explicit respawn timer (timer must be honoured as before), and repeat the steps with `Respawn.ForceCompatibilityMode = 1` (behaviour must be unchanged).

## Known Issues and TODO List:

- [ ] The same `std::max` clamp in the dynamic mode branch of `RemoveCorpse` also defeats `Respawn.DynamicRateCreature` scaling (it raises the shortened delay back to the full one). Out of scope here, no effect under the default configuration.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
