### PR TITLE
fix(Scripts/Ulduar): fire Mimiron's Rocket Strike non-triggered so the cast reaches the client

### DIFF
--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_mimiron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_mimiron.cpp
@@ -1359,8 +1359,7 @@ struct npc_ulduar_vx001 : public ScriptedAI
                 _events.Repeat(10s);
                 break;
             case EVENT_SPELL_ROCKET_STRIKE:
-                // Not triggered: the client only fires UNIT_SPELLCAST_SUCCEEDED (used by boss mod addons) if SMSG_SPELL_GO is sent
-                me->CastSpell(me, _phase == 2 ? SPELL_ROCKET_STRIKE_SINGLE : SPELL_ROCKET_STRIKE_BOTH, false);
+                me->CastSpell(me, _phase == 2 ? SPELL_ROCKET_STRIKE_SINGLE : SPELL_ROCKET_STRIKE_BOTH);
                 _events.Repeat(20s);
                 _events.ScheduleEvent(EVENT_REINSTALL_ROCKETS, 10s);
                 break;

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_mimiron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_mimiron.cpp
@@ -1359,7 +1359,8 @@ struct npc_ulduar_vx001 : public ScriptedAI
                 _events.Repeat(10s);
                 break;
             case EVENT_SPELL_ROCKET_STRIKE:
-                me->CastSpell(me, _phase == 2 ? SPELL_ROCKET_STRIKE_SINGLE : SPELL_ROCKET_STRIKE_BOTH, true);
+                // Not triggered: the client only fires UNIT_SPELLCAST_SUCCEEDED (used by boss mod addons) if SMSG_SPELL_GO is sent
+                me->CastSpell(me, _phase == 2 ? SPELL_ROCKET_STRIKE_SINGLE : SPELL_ROCKET_STRIKE_BOTH, false);
                 _events.Repeat(20s);
                 _events.ScheduleEvent(EVENT_REINSTALL_ROCKETS, 10s);
                 break;


### PR DESCRIPTION
## Changes Proposed:
VX-001 casts Rocket Strike (64402 in phase 2, 65034 in phase 4) with `TRIGGERED_FULL_MASK`. Since these spells have no spell visual, no travel speed and are not channeled, `Spell::IsNeedSendToClient()` suppresses `SMSG_SPELL_START`/`SMSG_SPELL_GO` for the fully triggered cast, so the client never fires `UNIT_SPELLCAST_SUCCEEDED` and there is no combat log entry. Boss mod addons (DBM warns off `UNIT_SPELLCAST_SUCCEEDED` for 64402/65034, see [Mimiron.lua](https://github.com/DeadlyBossMods/DBM-WotLK/blob/master/DBM-Raids-WoTLK/Ulduar/Mimiron.lua)) never announce Rocket Strike.

This PR casts the spell non-triggered instead, matching both upstream implementations:
- TrinityCore: [`DoCastAOE(...)`](https://github.com/TrinityCore/TrinityCore/blob/3.3.5/src/server/scripts/Northrend/Ulduar/Ulduar/boss_mimiron.cpp#L1069)
- cmangos: [`DoCastSpellIfCan(m_creature, SPELL_ROCKET_STRIKE)`](https://github.com/cmangos/mangos-wotlk/blob/master/src/game/AI/ScriptDevAI/scripts/northrend/ulduar/ulduar/boss_mimiron.cpp) (no `CAST_TRIGGERED`)

The cast is safe non-triggered: the event only executes while VX-001 is not channeling (`UNIT_STATE_CASTING` gate at the top of `UpdateAI`, same gating TrinityCore uses) and the spell is instant with no cost.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #26836

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Retail reference video showing the combat log event: https://youtu.be/F051-eHuxIE?t=131

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:
- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. `.tele Mimiron`, `.cheat god`, engage Mimiron and bring him to phase 2.
2. Wait for VX-001 to fire a Rocket Strike.
3. Check the combat log for the Rocket Strike cast (or run DBM and observe the Rocket Strike warning now fires). `/eventtrace` also shows `UNIT_SPELLCAST_SUCCEEDED` for spell 64402 (phase 2) / 65034 (phase 4).

## Known Issues and TODO List:

- [ ] The explosion lands ~4 seconds after the rocket missile visually hits the ground (the 64064 fuse only starts when the delayed 63036 summon executes). Same behavior exists on TrinityCore/cmangos; needs sniff data to fix properly and is out of scope here.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
