### PR TITLE
fix(ICC/Putricide): Ooze casting spell interrupted

### DIFF
--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_professor_putricide.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_professor_putricide.cpp
@@ -844,6 +844,11 @@ public:
         void CastMainSpell() override
         {
             me->CastSpell(me, SPELL_VOLATILE_OOZE_ADHESIVE, false);
+            // Fix for upstream #26710 (1eb3749b3): channel spells with SPELL_ATTR5_ALLOW_ACTION_DURING_CHANNEL
+            // no longer set UNIT_STATE_CASTING in SetCurrentCastedSpell, causing ooze AI UpdateAI to
+            // repeatedly trigger SelectNewTarget and interrupt the channel. Manually set the state here;
+            // it is cleared automatically by Spell::cancel() when the channel ends or is interrupted.
+            me->AddUnitState(UNIT_STATE_CASTING);
         }
     };
 
@@ -868,6 +873,9 @@ public:
         void CastMainSpell() override
         {
             me->CastCustomSpell(SPELL_GASEOUS_BLOAT, SPELLVALUE_AURA_STACK, 10, me, false);
+            // Same fix as Volatile Ooze: prevent UpdateAI from repeatedly triggering SelectNewTarget
+            // while the spell is active, which would break Gas Cloud targeting.
+            me->AddUnitState(UNIT_STATE_CASTING);
         }
 
     private:


### PR DESCRIPTION
## Changes Proposed

This PR proposes changes to:
- [ ] Core (units, players, creatures, game systems).
- [x] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [ ] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
- [ ] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Root Cause

Upstream commit `1eb3749b3` (PR #26710) changed `SetCurrentCastedSpell` to skip setting `UNIT_STATE_CASTING` for channeled spells that carry `SPELL_ATTR5_ALLOW_ACTION_DURING_CHANNEL`. Both `SPELL_VOLATILE_OOZE_ADHESIVE` (70447/72453) and `SPELL_GASEOUS_BLOAT` (70672/72832) carry this attribute, confirmed via `.spellinfo attributes` in-game.

`npc_putricide_oozeAI::UpdateAI` relies on `HasUnitState(UNIT_STATE_CASTING)` to detect whether a channel is in progress. After #26710 the flag is never set when `CastMainSpell` fires, causing the AI to repeatedly call `SelectNewTarget()` every update tick and interrupt the channel ? resulting in an infinite interrupt loop.

## Fix

Manually call `AddUnitState(UNIT_STATE_CASTING)` after `CastMainSpell` casts in both `npc_volatile_oozeAI` and `npc_gas_cloudAI`. The state is cleared automatically by `Spell::cancel()` when the channel ends or is interrupted.

## Issues Addressed

- Closes

## SOURCE

The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Tests Performed

This PR has been:
- [x] Tested in-game by the author
- [ ] Tested by the community
- [ ] Added unit tests
- [ ] Signed-off on a formal certification
- [ ] This is a CI/CD pipeline change, so no gameplay tests needed

## How to Test

1. Enter the Professor Putricide encounter in Icecrown Citadel (10N/25N/10H/25H).
2. Spawn Volatile Oozes (entry 37662) and/or Gas Clouds (entry 37562).
3. Observe that the ooze NPCs successfully channel their spells (Volatile Ooze Adhesive / Expunged Gas) without repeated interruption.
4. Previously, spells were interrupted infinitely; after this fix, channel persists normally and the ooze retargets correctly when the current target dies or moves out of range.

## Known Issues

None.
