### PR TITLE
fix(Core/Player): delete invalid character_spell rows on login

### DIFF
--- a/src/server/game/Entities/Player/PlayerStorage.cpp
+++ b/src/server/game/Entities/Player/PlayerStorage.cpp
@@ -6610,7 +6610,16 @@ void Player::_LoadSpells(PreparedQueryResult result)
             if (CheckSkillLearnedBySpell(spellId))
                 addSpell(spellId, specMask, true);
             else
+            {
+                // Spell was never addSpell()'d, so removeSpell is often a no-op and would
+                // leave an orphan character_spell row (MySQL 1062 on later re-learn/save).
                 removeSpell(spellId, SPEC_MASK_ALL, false);
+
+                CharacterDatabasePreparedStatement* stmt = CharacterDatabase.GetPreparedStatement(CHAR_DEL_CHAR_SPELL_BY_SPELL);
+                stmt->SetData(0, GetGUID().GetRawValue());
+                stmt->SetData(1, spellId);
+                CharacterDatabase.Execute(stmt);
+            }
         } while (result->NextRow());
     }
 }


### PR DESCRIPTION
## Changes Proposed:

When `ValidateSkillLearnedBySpells` rejects a spell during `_LoadSpells`, the code only called `removeSpell()`. That is a no-op if the spell was never added to `m_spells` (validation runs *before* `addSpell`). The orphan `character_spell` row stayed in the database.

A later permanent re-learn of the same spell then issued a bare `INSERT`, hit MySQL **1062 Duplicate entry**, and aborted the entire character save transaction (inventory, position, gold, etc.). Memory had already been marked clean, so the loss became permanent on relog.

This PR always runs `DELETE FROM character_spell WHERE guid = ? AND spell = ?` when validation rejects a spell, so invalid rows are actually removed on login.

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Grok (xAI) — investigation, root-cause analysis, and the code change
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Related to #24216 (orphan `character_spell` + MySQL 1062 aborting full player save)
- Related to #22370 (incomplete delete path for invalid race/class spells)

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Code review of `_LoadSpells` / `CheckSkillLearnedBySpell` / `removeSpell` and production logs from #24216 (e.g. invalid spell 227 Staves on a Paladin GUID 347, then `INSERT character_spell` 1062).

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Compiled successfully: `game` library (`PlayerStorage.cpp`) on macOS arm64 (RelWithDebInfo). Full `worldserver` link was not verified here due to an unrelated local readline/SDK issue. No in-game verification yet.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Pick a class that cannot use Staves (e.g. Paladin). Confirm skill 136 is not valid for that class in `SkillRaceClassInfo`.
2. Insert an illegal permanent row:
   ```sql
   INSERT INTO character_spell (guid, spell, specMask) VALUES (<guid>, 227, 255);
   ```
3. Log in with that character. Server log should still report the invalid race/class spell (from `CheckSkillLearnedBySpell`).
4. After login (or after a short wait for the async delete), verify the row is gone:
   ```sql
   SELECT * FROM character_spell WHERE guid = <guid> AND spell = 227;
   ```
   Expect **0 rows** (with this PR). Without this PR the row remains forever.
5. While still online, force a permanent re-learn if possible (e.g. GM `.learn 227` if allowed), then wait for autosave / `.save`. Confirm no MySQL **1062** on `character_spell` and that normal inventory changes still persist across relog.
6. Regression: log in a normal Mage/Priest that legitimately has Staves skill/spells and confirm they still load and save correctly.

## Known Issues and TODO List:

- [ ] This only fixes orphan rows from failed login validation. Full save idempotency for other `PLAYERSPELL_NEW` collisions (upsert / dirty-state after commit) is still a separate follow-up.
- [ ] In-game test not yet performed by the author.

## How to Test AzerothCore PRs

When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.