### PR TITLE
fix(DB/SAI): Sifreldar Storm Maiden casting Storm Cloud instantly on …

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1785324390804133200.sql
+++ b/data/sql/updates/pending_db_world/rev_1785324390804133200.sql
@@ -1,0 +1,8 @@
+-- Sifreldar Storm Maiden (29323) - Storm Cloud (57408)
+-- The spell was bound to SMART_EVENT_AGGRO (fires at 0ms) with NOT_REPEATABLE,
+-- so it was cast instantly on pull and never re-applied, even though the aura
+-- only lasts 10 seconds. Moved to SMART_EVENT_UPDATE_IC: first cast ~5s after
+-- combat starts (as seen in the reference videos), then repeated.
+DELETE FROM `smart_scripts` WHERE (`source_type` = 0) AND (`entryorguid` = 29323);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(29323, 0, 0, 0, 0, 0, 100, 0, 5000, 5000, 15000, 20000, 0, 0, 11, 57408, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Sifreldar Storm Maiden - In Combat - Cast \'Storm Cloud\'');


### PR DESCRIPTION
…aggro

Reworked the SmartAI of `Sifreldar Storm Maiden` (29323) so that `Storm Cloud` (57408) is no longer cast the instant the creature enters combat.

The existing script bound the cast to `SMART_EVENT_AGGRO`, which fires at 0ms on combat start and therefore cannot express a delay. It also carried `event_flags = 1` (`SMART_EVENT_FLAG_NOT_REPEATABLE`), which meant the buff was applied exactly once per fight — while the aura itself only lasts 10 seconds. In practice the shield was up for the first 10 seconds of the pull and then gone for the rest of the encounter.

Moved the cast to `SMART_EVENT_UPDATE_IC` with a 5s initial delay and a repeat timer, so the creature melees briefly before shielding itself and re-applies the buff over the course of the fight.

<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Opus5
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/26651
- Closes https://github.com/chromiecraft/chromiecraft/issues/9900

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
