### PR TITLE
fix(Scripts/ObsidianSanctum): Lava Strike

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1720754941115203700.sql
+++ b/data/sql/updates/pending_db_world/rev_1720754941115203700.sql
@@ -1,0 +1,2 @@
+DELETE FROM `spell_script_names` WHERE `spell_id` = 57572 AND `ScriptName` = 'spell_sartharion_lava_strike';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES (57572, 'spell_sartharion_lava_strike');

--- a/src/server/game/Spells/SpellInfoCorrections.cpp
+++ b/src/server/game/Spells/SpellInfoCorrections.cpp
@@ -1778,18 +1778,6 @@ void SpellMgr::LoadSpellInfoCorrections()
         spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_UNIT_SRC_AREA_ALLY);
     });
 
-    // Lava Strike damage
-    ApplySpellFix({ 57697 }, [](SpellInfo* spellInfo)
-    {
-        spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_DEST);
-    });
-
-    // Lava Strike trigger
-    ApplySpellFix({ 57578 }, [](SpellInfo* spellInfo)
-    {
-        spellInfo->MaxAffectedTargets = 1;
-    });
-
     // Gift of Twilight Shadow/Fire
     ApplySpellFix({ 57835, 58766 }, [](SpellInfo* spellInfo)
     {

--- a/src/server/scripts/Northrend/ChamberOfAspects/ObsidianSanctum/boss_sartharion.cpp
+++ b/src/server/scripts/Northrend/ChamberOfAspects/ObsidianSanctum/boss_sartharion.cpp
@@ -84,6 +84,7 @@ enum Spells
     SPELL_SARTHARION_FLAME_BREATH               = 56908,
     SPELL_SARTHARION_TAIL_LASH                  = 56910,
     SPELL_CYCLONE_AURA_PERIODIC                 = 57598,
+    SPELL_LAVA_STRIKE                           = 57571,
     SPELL_LAVA_STRIKE_DUMMY                     = 57578,
     SPELL_LAVA_STRIKE_DUMMY_TRIGGER             = 57697,
     SPELL_LAVA_STRIKE_SUMMON                    = 57572,
@@ -213,11 +214,11 @@ const Position TenebronEggsPos[2][MAX_TENEBORN_EGGS_SUMMONS] =
 
 const Position CycloneSummonPos[MAX_CYCLONE_COUNT] =
 {
-    { 3235.28f, 591.180f, 57.0833f, 0.59037f },
-    { 3200.97f, 480.929f, 57.0833f, 5.86197f },
-    { 3281.57f, 507.984f, 57.0833f, 5.54346f },
-    { 3210.11f, 531.957f, 57.0833f, 3.76777f },
-    { 3286.42f, 585.010f, 57.0833f, 4.10307f },
+    { 3238.55f, 589.14f, 57.0f, 0.59037f },
+    { 3209.70f, 475.85f, 57.0f, 5.86197f },
+    { 3282.10f, 504.02f, 57.0f, 5.54346f },
+    { 3209.42f, 532.55f, 57.0f, 3.76777f },
+    { 3283.50f, 581.75f, 57.0f, 4.10307f },
 };
 
 const Position AreaTriggerSummonPos[MAX_AREA_TRIGGER_COUNT] =
@@ -1380,20 +1381,23 @@ class spell_sartharion_lava_strike : public SpellScript
     bool Load() override
     {
         _spawned = false;
+        _dummyFired = false;
         return true;
     }
 
     void HandleDummy(SpellEffIndex /*effIndex*/)
     {
-        if (!GetCaster() || !GetHitUnit())
+        if (!GetCaster() || !GetHitUnit() || _dummyFired)
             return;
 
-        GetCaster()->CastSpell(GetHitUnit()->GetPositionX(), GetHitUnit()->GetPositionY(), GetHitUnit()->GetPositionZ(), SPELL_LAVA_STRIKE_DUMMY_TRIGGER, true);
+        _dummyFired = true;
+
+        GetCaster()->CastSpell(GetHitUnit(), SPELL_LAVA_STRIKE, true);
     }
 
     void HandleSchoolDamage(SpellEffIndex /*effIndex*/)
     {
-        if (!GetCaster() || !GetHitUnit() || _spawned)
+        if (!GetCaster() || !GetHitUnit() || !GetHitUnit()->IsPlayer() || _spawned)
             return;
 
         if (InstanceScript* instance = GetCaster()->GetInstanceScript())
@@ -1402,21 +1406,31 @@ class spell_sartharion_lava_strike : public SpellScript
             {
                 sarth->AI()->SetData(DATA_VOLCANO_BLOWS, GetHitUnit()->GetGUID().GetCounter());
                 sarth->CastSpell(GetHitUnit(), SPELL_LAVA_STRIKE_SUMMON, true);
-                _spawned = true;
             }
         }
+
+        _spawned = true;
+    }
+
+    void HandleSummon(SpellEffIndex effIndex)
+    {
+        if (GetCaster()->GetEntry() != NPC_SARTHARION)
+            PreventHitEffect(effIndex);
     }
 
     void Register() override
     {
         if (m_scriptSpellId == SPELL_LAVA_STRIKE_DUMMY)
             OnEffectHitTarget += SpellEffectFn(spell_sartharion_lava_strike::HandleDummy, EFFECT_0, SPELL_EFFECT_DUMMY);
+        else if (m_scriptSpellId == SPELL_LAVA_STRIKE_SUMMON)
+            OnEffectHit += SpellEffectFn(spell_sartharion_lava_strike::HandleSummon, EFFECT_0, SPELL_EFFECT_SUMMON);
         else
             OnEffectHitTarget += SpellEffectFn(spell_sartharion_lava_strike::HandleSchoolDamage, EFFECT_0, SPELL_EFFECT_SCHOOL_DAMAGE);
     }
 
 private:
     bool _spawned{false};
+    bool _dummyFired{false};
 };
 
 // 57491 - Flame Tsunami


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: DeepSeek V4 Flash + AzerothMCP
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/26378

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [x] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.


1. Lava Blaze despawns when Sartharion evades
2. Lava Strike only summons a Lava Blaze when a player is hit
3. When Lava Strike hits, only 1 Lava Blaze is spawned

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
