### PR TITLE
fix(Scripts/Ulduar): Mimiron - deploy Magnetic Core beneath the Aeria…

### DIFF
--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_mimiron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_mimiron.cpp
@@ -2044,17 +2044,50 @@ class spell_mimiron_magnetic_core_summon : public SpellScript
 {
     PrepareSpellScript(spell_mimiron_magnetic_core_summon);
 
-    void ModDest(SpellDestination& dest)
+    Creature* GetAerialCommandUnit()
+    {
+        if (InstanceScript* instance = GetCaster()->GetInstanceScript())
+            return instance->GetCreature(DATA_MIMIRON_ACU);
+
+            return nullptr;
+    }
+
+    SpellCastResult CheckCast()
+    {
+        Creature * acu = GetAerialCommandUnit();
+        if (!acu || !acu->IsAlive())
+            return SPELL_FAILED_BAD_TARGETS;
+
+        if (GetCaster()->GetExactDist2d(acu) > GetSpellInfo()->GetMaxRange(true))
+            return SPELL_FAILED_OUT_OF_RANGE;
+
+            return SPELL_CAST_OK;
+    }
+
+    void HandleSummon(SpellEffIndex effIndex)
     {
         Unit* caster = GetCaster();
-        Position pos = caster->GetPosition();
+        Creature * acu = GetAerialCommandUnit();
+        if (!acu)
+            return;
+
+        PreventHitDefaultEffect(effIndex);
+
+        Position pos = acu->GetPosition();
         pos.m_positionZ = caster->GetMap()->GetHeight(pos);
-        dest.Relocate(pos);
+
+        uint32 entry = uint32(GetSpellInfo()->Effects[effIndex].MiscValue);
+        if (!entry)
+            entry = NPC_MAGNETIC_CORE;
+
+        int32 duration = GetSpellInfo()->GetDuration();
+        caster->SummonCreature(entry, pos, TEMPSUMMON_TIMED_DESPAWN, duration > 0 ? uint32(duration) : 30 * IN_MILLISECONDS);
     }
 
     void Register() override
     {
-        OnDestinationTargetSelect += SpellDestinationTargetSelectFn(spell_mimiron_magnetic_core_summon::ModDest, EFFECT_0, TARGET_DEST_NEARBY_ENTRY);
+        OnCheckCast += SpellCheckCastFn(spell_mimiron_magnetic_core_summon::CheckCast);
+        OnEffectHit += SpellEffectFn(spell_mimiron_magnetic_core_summon::HandleSummon, EFFECT_0, SPELL_EFFECT_SUMMON);
     }
 };
 

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_mimiron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_mimiron.cpp
@@ -2049,25 +2049,25 @@ class spell_mimiron_magnetic_core_summon : public SpellScript
         if (InstanceScript* instance = GetCaster()->GetInstanceScript())
             return instance->GetCreature(DATA_MIMIRON_ACU);
 
-            return nullptr;
+        return nullptr;
     }
 
     SpellCastResult CheckCast()
     {
-        Creature * acu = GetAerialCommandUnit();
+        Creature* acu = GetAerialCommandUnit();
         if (!acu || !acu->IsAlive())
             return SPELL_FAILED_BAD_TARGETS;
 
         if (GetCaster()->GetExactDist2d(acu) > GetSpellInfo()->GetMaxRange(true))
             return SPELL_FAILED_OUT_OF_RANGE;
 
-            return SPELL_CAST_OK;
+        return SPELL_CAST_OK;
     }
 
     void HandleSummon(SpellEffIndex effIndex)
     {
         Unit* caster = GetCaster();
-        Creature * acu = GetAerialCommandUnit();
+        Creature* acu = GetAerialCommandUnit();
         if (!acu)
             return;
 

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_mimiron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_mimiron.cpp
@@ -2066,12 +2066,12 @@ class spell_mimiron_magnetic_core_summon : public SpellScript
 
     void HandleSummon(SpellEffIndex effIndex)
     {
-        Unit* caster = GetCaster();
-        Creature* acu = GetAerialCommandUnit();
-        if (!acu)
-            return;
-
         PreventHitDefaultEffect(effIndex);
+
+        Unit* caster = GetCaster();
+        Creature const* acu = GetAerialCommandUnit();
+        if (!acu || !acu->IsAlive())
+            return;
 
         Position pos = acu->GetPosition();
         pos.m_positionZ = caster->GetMap()->GetHeight(pos);


### PR DESCRIPTION
…l Command Unit

- Deploy the Magnetic Core (item `46029`, spell `64444`) on the ground beneath the Aerial Command Unit instead of at the caster's feet.
- Replace the existing `OnDestinationTargetSelect` hook in `spell_mimiron_magnetic_core_summon` with a `SPELL_EFFECT_SUMMON` handler that summons NPC `34068` at the ACU's position, with the Z snapped to ground height.
- Add an `OnCheckCast` handler that validates the deploy range horizontally, returning `SPELL_FAILED_OUT_OF_RANGE` when the player is too far from the ACU.

### Root cause

Spell `64444` uses `SPELL_EFFECT_SUMMON` on `EFFECT_0` with `TARGET_DEST_NEARBY_ENTRY`
(verified by dumping the spell's effect data at cast time). Two separate problems stack up:

1. `OnDestinationTargetSelect` is never invoked for that target type — the destination handlers
   are not called from `Spell::SelectImplicitNearbyTargets` — so the existing `ModDest` hook was
   dead code. Confirmed by logging: `OnCast` fires for `64444`, `ModDest` never does.
2. There is no `conditions` row restricting `TARGET_CHECK_ENTRY` for this spell, so the nearby
   search falls back to default targets (the core logs `no conditions entry for target with
   TARGET_CHECK_ENTRY of spell ID 64444, effect 0 - selecting default targets`) and resolves to
   the nearest object — the caster himself, at distance ~0. Hence the trap landing at the
   player's feet.

Adding the missing `conditions` row does fix the placement, but the resulting deploy range
becomes unusable: the spell's range is 10 yd and the nearby search measures distance in 2D,
while the ACU sits at its `HoverHeight` of 15. Nearly the whole range budget is consumed by
the vertical gap, leaving only a couple of yards of ground room and producing
`SPELL_FAILED_BAD_IMPLICIT_TARGETS` ("You can't do that yet") almost everywhere.

The approach taken here resolves the destination in the script instead, so placement no longer
depends on implicit target resolution, and keeps the spell's own max range while measuring it
horizontally. No spell or creature data is modified.

<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Opus5
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/26847
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/26848

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. `.tele Mimiron`
2. `.cheat god`
3. Engage Mimiron and bring the encounter to phase 3
4. Wait for the Assault Bots, kill and loot one (or `.additem 46029`)
5. Use the item near the Aerial Command Unit and observe the core being deployed beneath it

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
