### PR TITLE
fix(Scripts/Ulduar): Mimiron proximity mines now despawn on wipe

### DIFF
--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_mimiron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_mimiron.cpp
@@ -717,6 +717,7 @@ struct boss_mimiron : public BossAI
                     LMK2->InterruptNonMeleeSpells(false);
                     LMK2->AttackStop();
                     LMK2->AI()->SetData(1, 0);
+                    LMK2->AI()->DoAction(1337);
                     LMK2->DespawnOrUnsummon(7s);
                     LMK2->SetReactState(REACT_PASSIVE);
                     VX001->InterruptNonMeleeSpells(false);
@@ -943,7 +944,7 @@ private:
 
 struct npc_ulduar_leviathan_mkii : public ScriptedAI
 {
-    npc_ulduar_leviathan_mkii(Creature* creature) : ScriptedAI(creature)
+    npc_ulduar_leviathan_mkii(Creature* creature) : ScriptedAI(creature), _summons(me)
     {
         instance = me->GetInstanceScript();
         _isEvading = false;
@@ -952,6 +953,7 @@ struct npc_ulduar_leviathan_mkii : public ScriptedAI
     void Reset() override
     {
         _phase = 0;
+        _summons.DespawnAll();
         if (Unit* c = GetS3())
             c->ExitVehicle(); // this should never happen!
         if (Creature* c = me->SummonCreature(NPC_LEVIATHAN_MKII_CANNON, *me, TEMPSUMMON_MANUAL_DESPAWN))
@@ -973,6 +975,27 @@ struct npc_ulduar_leviathan_mkii : public ScriptedAI
             me->SetUInt32Value(UNIT_NPC_EMOTESTATE, EMOTE_STATE_CUSTOM_SPELL_01);
             me->HandleEmoteCommand(EMOTE_STATE_CUSTOM_SPELL_01);
         }
+    }
+
+    // The mines are summoned by the MK II, not by Mimiron, so they are not part of
+    // Mimiron's SummonList and have to be cleaned up here.
+    void JustSummoned(Creature * summon) override
+    {
+        // The cannon lives in the vehicle kit and is handled by PassengerBoarded.
+        if (summon->GetEntry() == NPC_PROXIMITY_MINE)
+            _summons.Summon(summon);
+    }
+
+    void SummonedCreatureDespawn(Creature * summon) override
+    {
+        _summons.Despawn(summon);
+    }
+
+    void DoAction(int32 action) override
+    {
+        // Reset() covers the evade path; this covers the encounter being finished.
+        if (action == 1337)
+            _summons.DespawnAll();
     }
 
     void SetData(uint32 id, uint32 value) override
@@ -1201,6 +1224,7 @@ struct npc_ulduar_leviathan_mkii : public ScriptedAI
 private:
     InstanceScript* instance;
     EventMap _events;
+    SummonList _summons;
     bool _isEvading;
     uint8 _phase;
 };

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_mimiron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_mimiron.cpp
@@ -230,6 +230,7 @@ enum Actions
 {
     DO_DISABLE_AERIAL = 1,
     DO_ENABLE_AERIAL,
+    DO_DESPAWN_SUMMONS,
 };
 
 enum Texts
@@ -717,7 +718,6 @@ struct boss_mimiron : public BossAI
                     LMK2->InterruptNonMeleeSpells(false);
                     LMK2->AttackStop();
                     LMK2->AI()->SetData(1, 0);
-                    LMK2->AI()->DoAction(1337);
                     LMK2->DespawnOrUnsummon(7s);
                     LMK2->SetReactState(REACT_PASSIVE);
                     VX001->InterruptNonMeleeSpells(false);
@@ -735,7 +735,7 @@ struct boss_mimiron : public BossAI
                     me->_ExitVehicle(&exitPos);
                     me->AttackStop();
                     me->GetMotionMaster()->Clear();
-                    summons.DoAction(1337); // despawn summons of summons
+                    summons.DoAction(DO_DESPAWN_SUMMONS); // despawn summons of summons
                     summons.DespawnEntry(NPC_FLAMES_INITIAL);
                     summons.DespawnEntry(33576);
 
@@ -821,7 +821,7 @@ struct boss_mimiron : public BossAI
             c->DespawnOrUnsummon();
         }
 
-        summons.DoAction(1337); // despawn summons of summons
+        summons.DoAction(DO_DESPAWN_SUMMONS); // despawn summons of summons
 
         me->RemoveAllAuras();
         me->ExitVehicle();
@@ -977,25 +977,16 @@ struct npc_ulduar_leviathan_mkii : public ScriptedAI
         }
     }
 
-    // The mines are summoned by the MK II, not by Mimiron, so they are not part of
-    // Mimiron's SummonList and have to be cleaned up here.
-    void JustSummoned(Creature * summon) override
+    // Mines are summoned by the MK II, not by Mimiron, so they are not in his SummonList.
+    void JustSummoned(Creature* summon) override
     {
-        // The cannon lives in the vehicle kit and is handled by PassengerBoarded.
         if (summon->GetEntry() == NPC_PROXIMITY_MINE)
             _summons.Summon(summon);
     }
 
-    void SummonedCreatureDespawn(Creature * summon) override
+    void SummonedCreatureDespawn(Creature* summon) override
     {
         _summons.Despawn(summon);
-    }
-
-    void DoAction(int32 action) override
-    {
-        // Reset() covers the evade path; this covers the encounter being finished.
-        if (action == 1337)
-            _summons.DespawnAll();
     }
 
     void SetData(uint32 id, uint32 value) override
@@ -1304,7 +1295,7 @@ struct npc_ulduar_vx001 : public ScriptedAI
 
     void DoAction(int32 action) override
     {
-        if (action == 1337)
+        if (action == DO_DESPAWN_SUMMONS)
             if (Vehicle* vk = me->GetVehicleKit())
                 for (uint8 i = 0; i < 2; ++i)
                     if (Unit* r = vk->GetPassenger(5 + i))
@@ -1615,7 +1606,7 @@ struct npc_ulduar_aerial_command_unit : public ScriptedAI
                     me->SetReactState(REACT_AGGRESSIVE);
                 }, 2s);
                 break;
-            case 1337:
+            case DO_DESPAWN_SUMMONS:
                 _summons.DespawnAll();
                 break;
         }
@@ -1807,6 +1798,7 @@ struct npc_ulduar_proximity_mine : public ScriptedAI
             {
                 _exploded = true;
                 me->CastSpell(me, SPELL_MINE_EXPLOSION, false);
+                me->DespawnOrUnsummon(2s);
             }
         }
         else
@@ -1819,6 +1811,7 @@ struct npc_ulduar_proximity_mine : public ScriptedAI
             {
                 _exploded = true;
                 me->CastSpell(me, SPELL_MINE_EXPLOSION, false);
+                me->DespawnOrUnsummon(2s);
             }
         }
         else
@@ -2243,7 +2236,7 @@ struct npc_ulduar_flames_initial : public NullCreatureAI
 
     void DoAction(int32 action) override
     {
-        if (action == 1337)
+        if (action == DO_DESPAWN_SUMMONS)
             RemoveAll();
     }
 

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_mimiron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_mimiron.cpp
@@ -735,7 +735,7 @@ struct boss_mimiron : public BossAI
                     me->_ExitVehicle(&exitPos);
                     me->AttackStop();
                     me->GetMotionMaster()->Clear();
-                    summons.DoAction(DO_DESPAWN_SUMMONS); // despawn summons of summons
+                    summons.DoAction(DO_DESPAWN_SUMMONS);
                     summons.DespawnEntry(NPC_FLAMES_INITIAL);
                     summons.DespawnEntry(33576);
 


### PR DESCRIPTION
…or kill

- Proximity Mines are summoned by the Leviathan MK II, which had no `SummonList`.
  Mimiron's own `summons` list — cleaned up on evade and in `EVENT_FINISH` — never
  contained them, so the mines were owned by no script and stayed on the floor
  until their TempSummon timer ran out. Both the Phase 1 and the Phase 4 mines are
  affected, since both are scheduled by the MK II.

- Added a `SummonList` to `npc_ulduar_leviathan_mkii`, tracking `NPC_PROXIMITY_MINE`
  only (the cannon is handled by the vehicle kit / `PassengerBoarded`).

- `Reset()` clears the list, covering the wipe path: the MK II calls
  `ScriptedAI::EnterEvadeMode()` before propagating to Mimiron, and when Mimiron
  starts the evade he calls the MK II's `EnterEvadeMode` in turn. This matches the
  sniff, where every live mine is destroyed in the same batch as Mimiron and the
  MK II right after the encounter ends.

- The mines are deliberately NOT cleared when the boss is killed: the sniff shows
  the last volley surviving the outro and expiring on its own fuse. To make that
  work, the mine now despawns shortly after detonating — 63016 has no DBC duration
  and the AI previously only set `_exploded`, so a post-kill mine would linger
  indefinitely. This reproduces the sniffed ~37.5s lifetime and also clears spent
  mine models mid-fight.

- Replaced the `1337` literals used for "despawn summons" with a new
  `DO_DESPAWN_SUMMONS` entry in `enum Actions`, covering all call sites and handlers
  in this file (Mimiron, VX-001, ACU, initial flames). No behaviour change.

<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Opus5
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/26831

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
