### PR TITLE
fix(Scripts/HowlingFjord): Harrowmeiser and Petrov Gossips

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1785371667750135300.sql
+++ b/data/sql/updates/pending_db_world/rev_1785371667750135300.sql
@@ -1,0 +1,9 @@
+--
+-- Zeppelin, Alliance - Westguard Keep to Shattered Straits (taxi path 727)
+UPDATE `gameobject_template` SET `ScriptName` = 'go_transport_westguard_zeppelin' WHERE (`entry` = 186371);
+
+-- Harrowmeiser - dock announcements, fired from the taxi arrival event 15431
+DELETE FROM `creature_text` WHERE (`CreatureID` = 23823);
+INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `TextRange`, `comment`) VALUES
+(23823, 0, 0, 'My zeppelin has docked. Despite my being held captive, and the sorry state that she\'s in, she\'ll be departing the dock again in two minutes.', 14, 0, 100, 0, 0, 0, 22336, 0, 'Harrowmeiser - Arrival'),
+(23823, 1, 0, 'The zeppelin\'s leaving for a tour around the bay in less than one minute!  Oh, and if anyone feels like setting me free, I\'m on the dock.', 14, 0, 100, 0, 0, 0, 22337, 0, 'Harrowmeiser - Departure');

--- a/data/sql/updates/pending_db_world/rev_1785371667750135300.sql
+++ b/data/sql/updates/pending_db_world/rev_1785371667750135300.sql
@@ -7,3 +7,9 @@ DELETE FROM `creature_text` WHERE (`CreatureID` = 23823);
 INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `TextRange`, `comment`) VALUES
 (23823, 0, 0, 'My zeppelin has docked. Despite my being held captive, and the sorry state that she\'s in, she\'ll be departing the dock again in two minutes.', 14, 0, 100, 0, 0, 0, 22336, 0, 'Harrowmeiser - Arrival'),
 (23823, 1, 0, 'The zeppelin\'s leaving for a tour around the bay in less than one minute!  Oh, and if anyone feels like setting me free, I\'m on the dock.', 14, 0, 100, 0, 0, 0, 22337, 0, 'Harrowmeiser - Departure');
+
+-- Harrowmeiser and Bombardier Petrov - gossip text picked from the zeppelin's path
+-- progress, which also pushes the world state that npc_text 11322 and 11332 substitute
+-- into "in less than $3078w minutes"
+UPDATE `creature_template` SET `ScriptName` = 'npc_harrowmeiser' WHERE (`entry` = 23823);
+UPDATE `creature_template` SET `ScriptName` = 'npc_bombardier_petrov' WHERE (`entry` = 23895);

--- a/src/server/scripts/World/npcs_special.cpp
+++ b/src/server/scripts/World/npcs_special.cpp
@@ -24,7 +24,6 @@
 #include "GameEventMgr.h"
 #include "GameTime.h"
 #include "GridNotifiers.h"
-#include "Map.h"
 #include "ObjectMgr.h"
 #include "PassiveAI.h"
 #include "Pet.h"
@@ -34,13 +33,10 @@
 #include "SmartAI.h"
 #include "SpellAuras.h"
 #include "TaskScheduler.h"
-#include "Transport.h"
-#include "TransportMgr.h"
 #include "WaypointMgr.h"
 #include "World.h"
 #include "WorldState.h"
 #include "WorldStateDefines.h"
-#include "transport_zeppelin.h"
 
 /// @todo: this import is not necessary for compilation and marked as unused by the IDE
 //  however, for some reasons removing it would cause a damn linking issue
@@ -2692,123 +2688,6 @@ struct npc_traveler_mammoth_vendor : public ScriptedAI
     }
 };
 
-enum WestguardZeppelinGossip
-{
-    GOSSIP_TEXT_PETROV_EN_ROUTE       = 11322,
-    GOSSIP_TEXT_PETROV_ARRIVING       = 11324,
-    GOSSIP_TEXT_HARROWMEISER_DOCKED   = 11328,
-    GOSSIP_TEXT_HARROWMEISER_ARRIVING = 11330,
-    GOSSIP_TEXT_HARROWMEISER_EN_ROUTE = 11332,
-};
-
-// The two "en route" texts above read "in less than $3078w minutes". The client
-// substitutes that token with the world state below, so it renders 0 unless a value
-// has been pushed to the player first.
-enum WestguardZeppelinWorldState
-{
-    WORLD_STATE_ZEPPELIN_ETA = 3078,
-};
-
-enum WestguardZeppelinState
-{
-    ZEPPELIN_STATE_EN_ROUTE,
-    ZEPPELIN_STATE_ARRIVING,
-    ZEPPELIN_STATE_DOCKED,
-};
-
-// Reports where the Westguard Keep zeppelin is in its path. While it is still touring the
-// bay the remaining minutes are pushed to the player as WORLD_STATE_ZEPPELIN_ETA.
-WestguardZeppelinState GetWestguardZeppelinState(Player* player, Map* map)
-{
-    MotionTransport const* zeppelin = nullptr;
-    for (Transport* transport : map->GetAllTransports())
-        if (transport->GetEntry() == GO_WESTGUARD_ZEPPELIN)
-        {
-            zeppelin = transport->ToMotionTransport();
-            break;
-        }
-
-    if (!zeppelin || !zeppelin->GetPeriod())
-        return ZEPPELIN_STATE_EN_ROUTE;
-
-    uint32 dockArriveTime = 0;
-    uint32 dockDepartTime = 0;
-    for (KeyFrame const& frame : zeppelin->GetKeyFrames())
-    {
-        if (frame.Node->arrivalEventID == EVENT_WK_ARRIVAL)
-            dockArriveTime = frame.ArriveTime;
-        else if (frame.Node->departureEventID == EVENT_WK_DEPARTURE)
-            dockDepartTime = frame.DepartureTime;
-    }
-
-    if (!dockArriveTime)
-        return ZEPPELIN_STATE_EN_ROUTE;
-
-    uint32 const timer = zeppelin->GetPathProgress() % zeppelin->GetPeriod();
-
-    // the dock is covered by the last and the first stop frame of the path, so being
-    // docked spans the end of one period and the start of the next
-    if (timer >= dockArriveTime || timer < dockDepartTime)
-        return ZEPPELIN_STATE_DOCKED;
-
-    uint32 const msUntilArrival = dockArriveTime - timer;
-    if (msUntilArrival <= MINUTE * IN_MILLISECONDS)
-        return ZEPPELIN_STATE_ARRIVING;
-
-    // the texts read "less than X minutes", so round up
-    player->SendUpdateWorldState(WORLD_STATE_ZEPPELIN_ETA,
-        (msUntilArrival + MINUTE * IN_MILLISECONDS - 1) / (MINUTE * IN_MILLISECONDS));
-
-    return ZEPPELIN_STATE_EN_ROUTE;
-}
-
-// 23823 Harrowmeiser
-class npc_harrowmeiser : public CreatureScript
-{
-public:
-    npc_harrowmeiser() : CreatureScript("npc_harrowmeiser") { }
-
-    bool OnGossipHello(Player* player, Creature* creature) override
-    {
-        uint32 textId = GOSSIP_TEXT_HARROWMEISER_EN_ROUTE;
-        switch (GetWestguardZeppelinState(player, creature->GetMap()))
-        {
-            case ZEPPELIN_STATE_DOCKED:
-                textId = GOSSIP_TEXT_HARROWMEISER_DOCKED;
-                break;
-            case ZEPPELIN_STATE_ARRIVING:
-                textId = GOSSIP_TEXT_HARROWMEISER_ARRIVING;
-                break;
-            default:
-                break;
-        }
-
-        SendGossipMenuFor(player, textId, creature->GetGUID());
-        return true;
-    }
-};
-
-// 23895 Bombardier Petrov
-class npc_bombardier_petrov : public CreatureScript
-{
-public:
-    npc_bombardier_petrov() : CreatureScript("npc_bombardier_petrov") { }
-
-    bool OnGossipHello(Player* player, Creature* creature) override
-    {
-        if (creature->IsQuestGiver())
-            player->PrepareQuestMenu(creature->GetGUID());
-
-        // he has no docked text of his own, "she's almost here" covers being at the dock too
-        uint32 const textId = GetWestguardZeppelinState(player, creature->GetMap()) == ZEPPELIN_STATE_EN_ROUTE
-            ? GOSSIP_TEXT_PETROV_EN_ROUTE
-            : GOSSIP_TEXT_PETROV_ARRIVING;
-
-        SendGossipMenuFor(player, textId, creature->GetGUID());
-        return true;
-    }
-};
-
 void AddSC_npcs_special()
 {
     new npc_elder_clearwater();
@@ -2836,6 +2715,4 @@ void AddSC_npcs_special()
     RegisterCreatureAI(npc_crashin_thrashin_robot);
     RegisterCreatureAI(npc_controller);
     RegisterCreatureAI(npc_traveler_mammoth_vendor);
-    new npc_harrowmeiser();
-    new npc_bombardier_petrov();
 }

--- a/src/server/scripts/World/npcs_special.cpp
+++ b/src/server/scripts/World/npcs_special.cpp
@@ -24,6 +24,7 @@
 #include "GameEventMgr.h"
 #include "GameTime.h"
 #include "GridNotifiers.h"
+#include "Map.h"
 #include "ObjectMgr.h"
 #include "PassiveAI.h"
 #include "Pet.h"
@@ -33,10 +34,13 @@
 #include "SmartAI.h"
 #include "SpellAuras.h"
 #include "TaskScheduler.h"
+#include "Transport.h"
+#include "TransportMgr.h"
 #include "WaypointMgr.h"
 #include "World.h"
 #include "WorldState.h"
 #include "WorldStateDefines.h"
+#include "transport_zeppelin.h"
 
 /// @todo: this import is not necessary for compilation and marked as unused by the IDE
 //  however, for some reasons removing it would cause a damn linking issue
@@ -2688,6 +2692,123 @@ struct npc_traveler_mammoth_vendor : public ScriptedAI
     }
 };
 
+enum WestguardZeppelinGossip
+{
+    GOSSIP_TEXT_PETROV_EN_ROUTE       = 11322,
+    GOSSIP_TEXT_PETROV_ARRIVING       = 11324,
+    GOSSIP_TEXT_HARROWMEISER_DOCKED   = 11328,
+    GOSSIP_TEXT_HARROWMEISER_ARRIVING = 11330,
+    GOSSIP_TEXT_HARROWMEISER_EN_ROUTE = 11332,
+};
+
+// The two "en route" texts above read "in less than $3078w minutes". The client
+// substitutes that token with the world state below, so it renders 0 unless a value
+// has been pushed to the player first.
+enum WestguardZeppelinWorldState
+{
+    WORLD_STATE_ZEPPELIN_ETA = 3078,
+};
+
+enum WestguardZeppelinState
+{
+    ZEPPELIN_STATE_EN_ROUTE,
+    ZEPPELIN_STATE_ARRIVING,
+    ZEPPELIN_STATE_DOCKED,
+};
+
+// Reports where the Westguard Keep zeppelin is in its path. While it is still touring the
+// bay the remaining minutes are pushed to the player as WORLD_STATE_ZEPPELIN_ETA.
+WestguardZeppelinState GetWestguardZeppelinState(Player* player, Map* map)
+{
+    MotionTransport const* zeppelin = nullptr;
+    for (Transport* transport : map->GetAllTransports())
+        if (transport->GetEntry() == GO_WESTGUARD_ZEPPELIN)
+        {
+            zeppelin = transport->ToMotionTransport();
+            break;
+        }
+
+    if (!zeppelin || !zeppelin->GetPeriod())
+        return ZEPPELIN_STATE_EN_ROUTE;
+
+    uint32 dockArriveTime = 0;
+    uint32 dockDepartTime = 0;
+    for (KeyFrame const& frame : zeppelin->GetKeyFrames())
+    {
+        if (frame.Node->arrivalEventID == EVENT_WK_ARRIVAL)
+            dockArriveTime = frame.ArriveTime;
+        else if (frame.Node->departureEventID == EVENT_WK_DEPARTURE)
+            dockDepartTime = frame.DepartureTime;
+    }
+
+    if (!dockArriveTime)
+        return ZEPPELIN_STATE_EN_ROUTE;
+
+    uint32 const timer = zeppelin->GetPathProgress() % zeppelin->GetPeriod();
+
+    // the dock is covered by the last and the first stop frame of the path, so being
+    // docked spans the end of one period and the start of the next
+    if (timer >= dockArriveTime || timer < dockDepartTime)
+        return ZEPPELIN_STATE_DOCKED;
+
+    uint32 const msUntilArrival = dockArriveTime - timer;
+    if (msUntilArrival <= MINUTE * IN_MILLISECONDS)
+        return ZEPPELIN_STATE_ARRIVING;
+
+    // the texts read "less than X minutes", so round up
+    player->SendUpdateWorldState(WORLD_STATE_ZEPPELIN_ETA,
+        (msUntilArrival + MINUTE * IN_MILLISECONDS - 1) / (MINUTE * IN_MILLISECONDS));
+
+    return ZEPPELIN_STATE_EN_ROUTE;
+}
+
+// 23823 Harrowmeiser
+class npc_harrowmeiser : public CreatureScript
+{
+public:
+    npc_harrowmeiser() : CreatureScript("npc_harrowmeiser") { }
+
+    bool OnGossipHello(Player* player, Creature* creature) override
+    {
+        uint32 textId = GOSSIP_TEXT_HARROWMEISER_EN_ROUTE;
+        switch (GetWestguardZeppelinState(player, creature->GetMap()))
+        {
+            case ZEPPELIN_STATE_DOCKED:
+                textId = GOSSIP_TEXT_HARROWMEISER_DOCKED;
+                break;
+            case ZEPPELIN_STATE_ARRIVING:
+                textId = GOSSIP_TEXT_HARROWMEISER_ARRIVING;
+                break;
+            default:
+                break;
+        }
+
+        SendGossipMenuFor(player, textId, creature->GetGUID());
+        return true;
+    }
+};
+
+// 23895 Bombardier Petrov
+class npc_bombardier_petrov : public CreatureScript
+{
+public:
+    npc_bombardier_petrov() : CreatureScript("npc_bombardier_petrov") { }
+
+    bool OnGossipHello(Player* player, Creature* creature) override
+    {
+        if (creature->IsQuestGiver())
+            player->PrepareQuestMenu(creature->GetGUID());
+
+        // he has no docked text of his own, "she's almost here" covers being at the dock too
+        uint32 const textId = GetWestguardZeppelinState(player, creature->GetMap()) == ZEPPELIN_STATE_EN_ROUTE
+            ? GOSSIP_TEXT_PETROV_EN_ROUTE
+            : GOSSIP_TEXT_PETROV_ARRIVING;
+
+        SendGossipMenuFor(player, textId, creature->GetGUID());
+        return true;
+    }
+};
+
 void AddSC_npcs_special()
 {
     new npc_elder_clearwater();
@@ -2715,4 +2836,6 @@ void AddSC_npcs_special()
     RegisterCreatureAI(npc_crashin_thrashin_robot);
     RegisterCreatureAI(npc_controller);
     RegisterCreatureAI(npc_traveler_mammoth_vendor);
+    new npc_harrowmeiser();
+    new npc_bombardier_petrov();
 }

--- a/src/server/scripts/World/transport_zeppelin.h
+++ b/src/server/scripts/World/transport_zeppelin.h
@@ -36,6 +36,7 @@ enum ZeppelinEvent
     EVENT_UC_TO_OG_DEPARTURE      = 15321,
     EVENT_UC_TO_GROMGOL_DEPARTURE = 15313,
     EVENT_GROMGOL_TO_UC_DEPARTURE = 15315,
+    EVENT_WK_DEPARTURE            = 15430,
 };
 
 enum ZeppelinMaster

--- a/src/server/scripts/World/transport_zeppelin.h
+++ b/src/server/scripts/World/transport_zeppelin.h
@@ -15,9 +15,6 @@
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef TRANSPORT_ZEPPELIN_H
-#define TRANSPORT_ZEPPELIN_H
-
 enum ZeppelinEvent
 {
     EVENT_UC_FROM_GROMGOL_ARRIVAL = 15312,
@@ -75,5 +72,3 @@ enum ZeppelinPassenger
     NPC_SKY_CAPTAIN_CABLELAMP   = 25105,
     NPC_WATCHER_UMJIN           = 25107,
 };
-
-#endif

--- a/src/server/scripts/World/transport_zeppelin.h
+++ b/src/server/scripts/World/transport_zeppelin.h
@@ -15,6 +15,9 @@
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef TRANSPORT_ZEPPELIN_H
+#define TRANSPORT_ZEPPELIN_H
+
 enum ZeppelinEvent
 {
     EVENT_UC_FROM_GROMGOL_ARRIVAL = 15312,
@@ -56,6 +59,11 @@ enum ZeppelinMaster
     NPC_KRENDLE_BIGPOCKETS = 34766,
 };
 
+enum ZeppelinTransport
+{
+    GO_WESTGUARD_ZEPPELIN = 186371,
+};
+
 const float SEARCH_RANGE_ZEPPELIN_MASTER = 32.0f;
 
 enum ZeppelinPassenger
@@ -67,3 +75,5 @@ enum ZeppelinPassenger
     NPC_SKY_CAPTAIN_CABLELAMP   = 25105,
     NPC_WATCHER_UMJIN           = 25107,
 };
+
+#endif

--- a/src/server/scripts/World/transport_zeppelins.cpp
+++ b/src/server/scripts/World/transport_zeppelins.cpp
@@ -191,14 +191,20 @@ WestguardZeppelinState GetWestguardZeppelinState(Player* player, Map* map)
     if (!dockArriveTime)
         return ZEPPELIN_STATE_EN_ROUTE;
 
-    uint32 const timer = zeppelin->GetPathProgress() % zeppelin->GetPeriod();
+    uint32 const period = zeppelin->GetPeriod();
+    uint32 const timer = zeppelin->GetPathProgress() % period;
 
-    // the dock is covered by the last and the first stop frame of the path, so being
-    // docked spans the end of one period and the start of the next
-    if (timer >= dockArriveTime || timer < dockDepartTime)
+    // the dock is covered by the last and the first stop frame of the path, so the docked
+    // window normally wraps the end of one period into the start of the next
+    bool const docked = dockArriveTime > dockDepartTime
+        ? timer >= dockArriveTime || timer < dockDepartTime
+        : timer >= dockArriveTime && timer < dockDepartTime;
+
+    if (docked)
         return ZEPPELIN_STATE_DOCKED;
 
-    uint32 const msUntilArrival = dockArriveTime - timer;
+    // modular so it stays correct whichever way around the two stop frames sit
+    uint32 const msUntilArrival = (dockArriveTime + period - timer) % period;
     if (msUntilArrival <= MINUTE * IN_MILLISECONDS)
         return ZEPPELIN_STATE_ARRIVING;
 

--- a/src/server/scripts/World/transport_zeppelins.cpp
+++ b/src/server/scripts/World/transport_zeppelins.cpp
@@ -17,6 +17,7 @@
 
 #include "GameObjectAI.h"
 #include "GameObjectScript.h"
+#include "TaskScheduler.h"
 #include "WorldState.h"
 #include "transport_zeppelin.h"
 
@@ -101,9 +102,41 @@ struct go_transport_the_purple_princess : GameObjectAI
     }
 };
 
+// 186371 Zeppelin - Westguard Keep to Shattered Straits
+struct go_transport_westguard_zeppelin : GameObjectAI
+{
+    go_transport_westguard_zeppelin(GameObject* object) : GameObjectAI(object) { };
+
+    void EventInform(uint32 eventId) override
+    {
+        if (eventId != EVENT_WK_ARRIVAL)
+            return;
+
+        if (Creature* creature = me->FindNearestCreature(NPC_HARROWMEISER, SEARCH_RANGE_ZEPPELIN_MASTER))
+            creature->AI()->Talk(0);
+
+        // the dock is covered by two stop frames of 60s each, so EVENT_WK_DEPARTURE
+        // only fires two minutes later - warn one minute before it does
+        _scheduler.Schedule(1min, [this](TaskContext /*context*/)
+        {
+            if (Creature* creature = me->FindNearestCreature(NPC_HARROWMEISER, SEARCH_RANGE_ZEPPELIN_MASTER))
+                creature->AI()->Talk(1);
+        });
+    }
+
+    void UpdateAI(uint32 diff) override
+    {
+        _scheduler.Update(diff);
+    }
+
+private:
+    TaskScheduler _scheduler;
+};
+
 void AddSC_transport_zeppelins()
 {
     RegisterGameObjectAI(go_transport_the_iron_eagle);
     RegisterGameObjectAI(go_transport_the_thundercaller);
     RegisterGameObjectAI(go_transport_the_purple_princess);
+    RegisterGameObjectAI(go_transport_westguard_zeppelin);
 }

--- a/src/server/scripts/World/transport_zeppelins.cpp
+++ b/src/server/scripts/World/transport_zeppelins.cpp
@@ -15,9 +15,15 @@
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "CreatureScript.h"
 #include "GameObjectAI.h"
 #include "GameObjectScript.h"
+#include "Map.h"
+#include "Player.h"
+#include "ScriptedGossip.h"
 #include "TaskScheduler.h"
+#include "Transport.h"
+#include "TransportMgr.h"
 #include "WorldState.h"
 #include "transport_zeppelin.h"
 
@@ -133,10 +139,129 @@ private:
     TaskScheduler _scheduler;
 };
 
+enum WestguardZeppelinGossip
+{
+    GOSSIP_TEXT_PETROV_EN_ROUTE       = 11322,
+    GOSSIP_TEXT_PETROV_ARRIVING       = 11324,
+    GOSSIP_TEXT_HARROWMEISER_DOCKED   = 11328,
+    GOSSIP_TEXT_HARROWMEISER_ARRIVING = 11330,
+    GOSSIP_TEXT_HARROWMEISER_EN_ROUTE = 11332,
+};
+
+// The two "en route" texts above read "in less than $3078w minutes". The client
+// substitutes that token with the world state below, so it renders 0 unless a value
+// has been pushed to the player first.
+enum WestguardZeppelinWorldState
+{
+    WORLD_STATE_ZEPPELIN_ETA = 3078,
+};
+
+enum WestguardZeppelinState
+{
+    ZEPPELIN_STATE_EN_ROUTE,
+    ZEPPELIN_STATE_ARRIVING,
+    ZEPPELIN_STATE_DOCKED,
+};
+
+// Reports where the Westguard Keep zeppelin is in its path. While it is still touring the
+// bay the remaining minutes are pushed to the player as WORLD_STATE_ZEPPELIN_ETA.
+WestguardZeppelinState GetWestguardZeppelinState(Player* player, Map* map)
+{
+    MotionTransport const* zeppelin = nullptr;
+    for (Transport* transport : map->GetAllTransports())
+        if (transport->GetEntry() == GO_WESTGUARD_ZEPPELIN)
+        {
+            zeppelin = transport->ToMotionTransport();
+            break;
+        }
+
+    if (!zeppelin || !zeppelin->GetPeriod())
+        return ZEPPELIN_STATE_EN_ROUTE;
+
+    uint32 dockArriveTime = 0;
+    uint32 dockDepartTime = 0;
+    for (KeyFrame const& frame : zeppelin->GetKeyFrames())
+    {
+        if (frame.Node->arrivalEventID == EVENT_WK_ARRIVAL)
+            dockArriveTime = frame.ArriveTime;
+        else if (frame.Node->departureEventID == EVENT_WK_DEPARTURE)
+            dockDepartTime = frame.DepartureTime;
+    }
+
+    if (!dockArriveTime)
+        return ZEPPELIN_STATE_EN_ROUTE;
+
+    uint32 const timer = zeppelin->GetPathProgress() % zeppelin->GetPeriod();
+
+    // the dock is covered by the last and the first stop frame of the path, so being
+    // docked spans the end of one period and the start of the next
+    if (timer >= dockArriveTime || timer < dockDepartTime)
+        return ZEPPELIN_STATE_DOCKED;
+
+    uint32 const msUntilArrival = dockArriveTime - timer;
+    if (msUntilArrival <= MINUTE * IN_MILLISECONDS)
+        return ZEPPELIN_STATE_ARRIVING;
+
+    // the texts read "less than X minutes", so round up
+    player->SendUpdateWorldState(WORLD_STATE_ZEPPELIN_ETA,
+        (msUntilArrival + MINUTE * IN_MILLISECONDS - 1) / (MINUTE * IN_MILLISECONDS));
+
+    return ZEPPELIN_STATE_EN_ROUTE;
+}
+
+// 23823 Harrowmeiser
+class npc_harrowmeiser : public CreatureScript
+{
+public:
+    npc_harrowmeiser() : CreatureScript("npc_harrowmeiser") { }
+
+    bool OnGossipHello(Player* player, Creature* creature) override
+    {
+        uint32 textId = GOSSIP_TEXT_HARROWMEISER_EN_ROUTE;
+        switch (GetWestguardZeppelinState(player, creature->GetMap()))
+        {
+            case ZEPPELIN_STATE_DOCKED:
+                textId = GOSSIP_TEXT_HARROWMEISER_DOCKED;
+                break;
+            case ZEPPELIN_STATE_ARRIVING:
+                textId = GOSSIP_TEXT_HARROWMEISER_ARRIVING;
+                break;
+            default:
+                break;
+        }
+
+        SendGossipMenuFor(player, textId, creature->GetGUID());
+        return true;
+    }
+};
+
+// 23895 Bombardier Petrov
+class npc_bombardier_petrov : public CreatureScript
+{
+public:
+    npc_bombardier_petrov() : CreatureScript("npc_bombardier_petrov") { }
+
+    bool OnGossipHello(Player* player, Creature* creature) override
+    {
+        if (creature->IsQuestGiver())
+            player->PrepareQuestMenu(creature->GetGUID());
+
+        // he has no docked text of his own, "she's almost here" covers being at the dock too
+        uint32 const textId = GetWestguardZeppelinState(player, creature->GetMap()) == ZEPPELIN_STATE_EN_ROUTE
+            ? GOSSIP_TEXT_PETROV_EN_ROUTE
+            : GOSSIP_TEXT_PETROV_ARRIVING;
+
+        SendGossipMenuFor(player, textId, creature->GetGUID());
+        return true;
+    }
+};
+
 void AddSC_transport_zeppelins()
 {
     RegisterGameObjectAI(go_transport_the_iron_eagle);
     RegisterGameObjectAI(go_transport_the_thundercaller);
     RegisterGameObjectAI(go_transport_the_purple_princess);
     RegisterGameObjectAI(go_transport_westguard_zeppelin);
+    new npc_harrowmeiser();
+    new npc_bombardier_petrov();
 }


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [X] Scripts (bosses, spell scripts, creature scripts).
-  [X] Database (SAI, creatures, etc).

<img width="1134" height="537" alt="image" src="https://github.com/user-attachments/assets/7a9b7dbb-f658-4031-ae43-8bcdd95c5eef" />

<img width="993" height="542" alt="image" src="https://github.com/user-attachments/assets/14155ca7-ad4d-4633-944b-4fb27f8fc504" />

<img width="459" height="296" alt="image" src="https://github.com/user-attachments/assets/ed882f22-daae-4477-a460-db20d0b0c02e" />

Harrowmeiser (23823) at Westguard Keep had four symptoms: no arrival announcement, no departure warning, gossip that never changed when the zeppelin docked, and a gossip timer permanently reading "0 minutes".

Two independent root causes:

1. GO 186371 (the zeppelin, transports id 13) had no ScriptName, so GameObject::EventInform had nothing to dispatch to — the taxi events fired into the void. transport_zeppelin.h already declared EVENT_WK_ARRIVAL and NPC_HARROWMEISER, both unused.
2. The gossip timer is a client-side world state substitution, and the core never sent the value.

The zeppelin runs taxi path 727. Only two of its 26 nodes carry events, and both sit at the dock (1413.95, -3091.47, 183.50) as stop frames with delay = 60:

<img width="787" height="108" alt="image" src="https://github.com/user-attachments/assets/ad3f3ae8-dd99-42a6-b079-079ede45c12f" />

Nodes 0 and 25 exist only as Catmull-Rom control points — they duplicate nodes 23 and 2, and TransportMgr::GeneratePath drops the first and last keyframe. keyFrames.back().Teleport is then set unconditionally, and since nodes 1 and 24 are 0.03 yd apart that "teleport" is positionally a no-op.

The consequence drives the whole fix: the dock stop is a continuous 120 seconds split across the period boundary.

```
t=0        arrive node 1 (dock)      — no event; mid-dock, period wrap
t=60s      event 15430               — departs on the bay tour
t≈419s     event 15431               — docks
t≈479s     period wraps to t=0
```

That's why the retail line says "departing the dock again in two minutes" — it's two 60 s stop frames back to back, not one.

Arrival yell hooks EVENT_WK_ARRIVAL in a new go_transport_westguard_zeppelin GameObjectAI, following the three existing zeppelin GO AIs in the same file.

Departure warning has no DBC event — it falls exactly on the t=0 wrap, where node 1's ArrivalEventID is 0. It's a TaskScheduler task 60 s after 15431. The zeppelin is still parked at the dock then, so the FindNearestCreature lookup resolves both times (Harrowmeiser is 24.3 yd out, inside the existing SEARCH_RANGE_ZEPPELIN_MASTER of 32).

Gossip reads the transport's live GetPathProgress() % GetPeriod(). The dock window is derived from the keyframes by matching arrivalEventID/departureEventID rather than hardcoding times, so it stays correct regardless of spline length. Three states → three texts, covering the period with no gaps: docked 120 s (11328), arriving 60 s (11330), en route 299 s (11332).

I did not use the conditions type 103 + WorldState pattern the other three zeppelins use. That only tracks the last event that fired, which can't express "arriving in under a minute" without inventing a synthetic state — and it can't supply a number at all, which point 4 needs.

The "0 minutes" timer. npc_text 11332 contains the token $3078w. This is the 3.3.5 client substituting world state 3078; it is not a spell reference (3078 doesn't exist in Spell.dbc). Corroborating uses of the same syntax: $2200w–$2207w is the Lunar Festival vote tally ("Thrall: $2200w / Cairne: $2201w / Total Horde: $2207w") and $2113w is the AQ war-effort caravan countdown — both plainly server-tracked counters. With nothing sent, the client renders 0. The script pushes the value via Player::SendUpdateWorldState just before the menu, rounded up since the text reads "less than X minutes".

Three things that look like the mechanism but aren't: moTransport.worldState1 (Data7, zero for this GO and never read by the core), CONDITION_WORLD_STATE, and sWorldState->getWorldState() — the latter two are a characters-DB-persisted store that never reaches the client.

Bombardier Petrov (23895) carries the identical $3078w bug in npc_text 11322, so he shares the same helper. He has no docked-specific text, so 11324 ("she's almost here… make sure you're onboard when she leaves") covers docked and arriving. He starts and ends quest 11153, so his hook does the IsQuestGiver() / PrepareQuestMenu() step first — without it the custom gossip would suppress his quest.

Both NPCs use CreatureScript::OnGossipHello rather than RegisterCreatureAI, because only its bool return suppresses SendPreparedGossip and lets the script choose the text. UnitAI::sGossipHello is void and fires after the menu is already sent.



### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [X] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Opus 5 Max for nearly all the work :^) At the very least it seems fun to work with Taxis, I didn't even know they had events until it was revealed by Claude while we were working on Sorlof. That one had more input on my end, though.
- [X] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/25865

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [X] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. .go c 85319
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
