### PR TITLE
fix(Core/Unit): Respect Attribute ALLOW_ACTION_DURING_CHANNEL from triggered casts

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1785435206257470800.sql
+++ b/data/sql/updates/pending_db_world/rev_1785435206257470800.sql
@@ -1,0 +1,4 @@
+--
+DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 13) AND (`SourceGroup` = 1) AND (`SourceEntry` = 44270) AND (`SourceId` = 0) AND (`ElseGroup` = 0) AND (`ConditionTypeOrReference` = 31) AND (`ConditionTarget` = 0) AND (`ConditionValue1` = 3) AND (`ConditionValue2` = 24707) AND (`ConditionValue3` = 0);
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(13, 1, 44270, 0, 0, 31, 0, 3, 24707, 0, 0, 0, 0, '', 'Breathing Tube (44270) Targets Buoy (24707)');

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -4181,8 +4181,11 @@ void Unit::SetCurrentCastedSpell(Spell* pSpell)
             }
         case CURRENT_CHANNELED_SPELL:
             {
-                // channel spells always break generic non-delayed and any channeled spells
-                InterruptSpell(CURRENT_GENERIC_SPELL, false);
+                // channel spells always break generic non-delayed and any channeled spells,
+                // unless the channel itself is allowed to run alongside other actions
+                if (!pSpell->GetSpellInfo()->IsActionAllowedChannel())
+                    InterruptSpell(CURRENT_GENERIC_SPELL, false);
+
                 InterruptSpell(CURRENT_CHANNELED_SPELL, true, true, bySelf);
 
                 // it also does break autorepeat if not Auto Shot


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [X] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [X] Database (SAI, creatures, etc).

Spell 50002 triggers 44270, an infinite channel, every 1s.
Using the crate gob takes 1s.
The former interrupts the latter despite "ALLOW_ACTION_DURING_CHANNEL" flag

Or as Claude read it:

1. SPELL_ATTR4_ALLOW_CAST_WHILE_CASTING is only read at Spell.cpp:636, where it adds TRIGGERED_IGNORE_CAST_IN_PROGRESS | TRIGGERED_CAST_DIRECTLY. That lets 44270 get past the in-progress-cast gates — it says nothing about what the new channel does to the old cast.
2. SPELL_ATTR5_ALLOW_ACTION_DURING_CHANNEL is checked in the sibling branches of that same switch (4153 for generic, 4206 for autorepeat) — but the CURRENT_CHANNELED_SPELL branch was simply missing the check.

Rope now goes to buoy

<img width="864" height="713" alt="image" src="https://github.com/user-attachments/assets/a21e0db0-f590-4605-ad7e-b733ebad62c8" />

And we have no interrupts

https://github.com/user-attachments/assets/70e5152b-c3d4-46b0-864f-7f222701ddc2


From Claude:

Blast radius is narrower than the 155 channeled+ATTR5 spells suggest. A non-triggered channel can never reach this code while a generic cast is running: UNIT_STATE_CASTING is set for exactly the generic spells with GetCastTime() > 0 (Unit.cpp:4177), and Spell::CheckCast bails with SPELL_FAILED_SPELL_IN_PROGRESS on that state (Spell.cpp:6833). Those are the same spells InterruptSpell(..., false) would have hit. So this only changes behaviour for triggered channels — the rope/beam family (Dog Sled Rope, Kite String, Toy Plane Cable, Mosswalker Chains, Drag Mine Cart, Pet Leash - Rope, …), which all have the same latent bug. 

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [X] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Opus 5
- [ ] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/22333

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [X] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [X] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
