### PR TITLE
fix(Scripts/Ulduar): General Vezax Shadow Crash can target melee

### DIFF
--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_general_vezax.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_general_vezax.cpp
@@ -207,13 +207,24 @@ struct boss_vezax : public BossAI
                     events.Repeat(10s);
 
                     std::vector<Player*> players;
+                    std::vector<Player*> meleePlayers;
                     Map::PlayerList const& pl = me->GetMap()->GetPlayers();
                     for (Map::PlayerList::const_iterator itr = pl.begin(); itr != pl.end(); ++itr)
                     {
                         Player* temp = itr->GetSource();
-                        if (temp->IsAlive() && temp->GetDistance(me) > 15.0f)
+                        if (!temp->IsAlive())
+                            continue;
+
+                        if (temp->GetDistance(me) > 15.0f)
                             players.push_back(temp);
+                        else
+                            meleePlayers.push_back(temp);
                     }
+
+                    // Shadow Crash can target melee players if nobody is at range
+                    if (players.empty())
+                        players = std::move(meleePlayers);
+
                     if (!players.empty())
                     {
                         me->setAttackTimer(BASE_ATTACK, 2000);

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_general_vezax.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_general_vezax.cpp
@@ -206,28 +206,14 @@ struct boss_vezax : public BossAI
             {
                 events.Repeat(10s);
 
-                std::vector<Player*> rangedPlayers;
-                std::vector<Player*> meleePlayers;
-                Map::PlayerList const& pl = me->GetMap()->GetPlayers();
-                for (Map::PlayerList::const_iterator itr = pl.begin(); itr != pl.end(); ++itr)
-                {
-                    Player* temp = itr->GetSource();
-                    if (!temp || !temp->IsAlive())
-                        continue;
+                constexpr float dist = 3.0f; // SelectTarget dist check includes CombatReach
+                Unit* target = SelectTarget(SelectTargetMethod::Random, 0, -dist, true, true, 0);
+                if (!target)
+                    target = SelectTarget(SelectTargetMethod::Random, 0, 0, true, true, 0);
 
-                    if (temp->GetDistance(me) > 15.0f)
-                        rangedPlayers.push_back(temp);
-                    else
-                        meleePlayers.push_back(temp);
-                }
-
-                // Shadow Crash can target melee players if nobody is at range
-                std::vector<Player*>& targets = rangedPlayers.empty() ? meleePlayers : rangedPlayers;
-
-                if (!targets.empty())
+                if (target)
                 {
                     me->setAttackTimer(BASE_ATTACK, 2000);
-                    Player* target = targets.at(urand(0, targets.size() - 1));
                     me->SetGuidValue(UNIT_FIELD_TARGET, target->GetGUID());
                     me->CastSpell(target, SPELL_VEZAX_SHADOW_CRASH, false);
                     events.ScheduleEvent(EVENT_RESTORE_TARGET, 750ms);

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_general_vezax.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_general_vezax.cpp
@@ -203,38 +203,37 @@ struct boss_vezax : public BossAI
                 Talk(SAY_BERSERK);
                 break;
             case EVENT_SPELL_VEZAX_SHADOW_CRASH:
+            {
+                events.Repeat(10s);
+
+                std::vector<Player*> rangedPlayers;
+                std::vector<Player*> meleePlayers;
+                Map::PlayerList const& pl = me->GetMap()->GetPlayers();
+                for (Map::PlayerList::const_iterator itr = pl.begin(); itr != pl.end(); ++itr)
                 {
-                    events.Repeat(10s);
+                    Player* temp = itr->GetSource();
+                    if (!temp || !temp->IsAlive())
+                        continue;
 
-                    std::vector<Player*> players;
-                    std::vector<Player*> meleePlayers;
-                    Map::PlayerList const& pl = me->GetMap()->GetPlayers();
-                    for (Map::PlayerList::const_iterator itr = pl.begin(); itr != pl.end(); ++itr)
-                    {
-                        Player* temp = itr->GetSource();
-                        if (!temp->IsAlive())
-                            continue;
-
-                        if (temp->GetDistance(me) > 15.0f)
-                            players.push_back(temp);
-                        else
-                            meleePlayers.push_back(temp);
-                    }
-
-                    // Shadow Crash can target melee players if nobody is at range
-                    if (players.empty())
-                        players = std::move(meleePlayers);
-
-                    if (!players.empty())
-                    {
-                        me->setAttackTimer(BASE_ATTACK, 2000);
-                        Player* target = players.at(urand(0, players.size() - 1));
-                        me->SetGuidValue(UNIT_FIELD_TARGET, target->GetGUID());
-                        me->CastSpell(target, SPELL_VEZAX_SHADOW_CRASH, false);
-                        events.ScheduleEvent(EVENT_RESTORE_TARGET, 750ms);
-                    }
+                    if (temp->GetDistance(me) > 15.0f)
+                        rangedPlayers.push_back(temp);
+                    else
+                        meleePlayers.push_back(temp);
                 }
-                break;
+
+                // Shadow Crash can target melee players if nobody is at range
+                std::vector<Player*>& targets = rangedPlayers.empty() ? meleePlayers : rangedPlayers;
+
+                if (!targets.empty())
+                {
+                    me->setAttackTimer(BASE_ATTACK, 2000);
+                    Player* target = targets.at(urand(0, targets.size() - 1));
+                    me->SetGuidValue(UNIT_FIELD_TARGET, target->GetGUID());
+                    me->CastSpell(target, SPELL_VEZAX_SHADOW_CRASH, false);
+                    events.ScheduleEvent(EVENT_RESTORE_TARGET, 750ms);
+                }
+            }
+            break;
             case EVENT_RESTORE_TARGET:
                 if (me->GetVictim())
                     me->SetGuidValue(UNIT_FIELD_TARGET, me->GetVictim()->GetGUID());


### PR DESCRIPTION
…yers

- General Vezax now falls back to melee range players when selecting a Shadow Crash target, if no player is standing beyond 15 yards.

Previously the target list was built exclusively from players farther than 15 yards away. When the whole raid stood in melee range the list came out empty, the cast was silently skipped and the boss never used Shadow Crash again for the rest of the encounter.

Ranged players are still preferred, so the ability behaves exactly as before whenever at least one player is at range. The fallback mirrors the approach already used by Mark of the Faceless in the same script, which builds an `outside`/`inside` list and falls back to the inner one.

<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Opus5
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/26839

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

https://wowpedia.fandom.com/wiki/General_Vezax#Strategy

> General Vezax's abilities, Mark of the Faceless and Shadow Crash, may hit
> players in melee range depending on the situation and player setup.

The Shadow Crash tooltip describes it as firing a missile towards a random
target, with no range requirement attached. The 15 yard restriction belongs
to Mark of the Faceless, which is documented as switching to melee players
when there are not enough casters at range.

The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
