### PR TITLE
fix(Core/Authserver): list the possible causes of an empty realm list

### DIFF
--- a/src/server/apps/authserver/Main.cpp
+++ b/src/server/apps/authserver/Main.cpp
@@ -143,7 +143,11 @@ int main(int argc, char** argv)
 
     if (sRealmList->GetRealms().empty())
     {
-        LOG_ERROR("server.authserver", "No valid realms specified.");
+        LOG_ERROR("server.authserver", "No valid realms specified. Possible reasons:\n"
+            "- the realmlist table of the auth database is empty\n"
+            "- every realm has flag 3 (REALM_FLAG_VERSION_MISMATCH | REALM_FLAG_OFFLINE), which the realm list "
+            "query excludes. Reset it with: UPDATE realmlist SET flag = 0 WHERE id = <realm id>;\n"
+            "- no realm address could be resolved, see the resolver errors logged above");
         return 1;
     }
 

--- a/src/server/apps/authserver/Main.cpp
+++ b/src/server/apps/authserver/Main.cpp
@@ -143,11 +143,11 @@ int main(int argc, char** argv)
 
     if (sRealmList->GetRealms().empty())
     {
-        LOG_ERROR("server.authserver", "No valid realms specified. Possible reasons:\n"
-            "- the realmlist table of the auth database is empty\n"
-            "- every realm has flag 3 (REALM_FLAG_VERSION_MISMATCH | REALM_FLAG_OFFLINE), which the realm list "
-            "query excludes. Reset it with: UPDATE realmlist SET flag = 0 WHERE id = <realm id>;\n"
-            "- no realm address could be resolved, see the resolver errors logged above");
+        LOG_ERROR("server.authserver", "No valid realms specified. Possible reasons:");
+        LOG_ERROR("server.authserver", "- the realmlist table of the auth database is empty");
+        LOG_ERROR("server.authserver", "- every realm has flag 3 (REALM_FLAG_VERSION_MISMATCH | REALM_FLAG_OFFLINE), which the realm list "
+            "query excludes. Reset it with: UPDATE realmlist SET flag = 0 WHERE id = <realm id>;");
+        LOG_ERROR("server.authserver", "- no realm address could be resolved, see the resolver errors logged above");
         return 1;
     }
 


### PR DESCRIPTION
## Changes Proposed:

Extend the `No valid realms specified.` error so it names the cases that can lead to it.

`LOGIN_SEL_REALMLIST` ignores realms whose flag is exactly 3 (`REALM_FLAG_VERSION_MISMATCH | REALM_FLAG_OFFLINE`). That state is easy to reach without noticing: a worldserver stopped before it finished loading leaves `REALM_FLAG_VERSION_MISMATCH` behind, and since #26658 authserver adds `REALM_FLAG_OFFLINE` on top at every startup. The realm then drops out of the list and authserver exits with a message that gives nothing to go on.

Before:

```
No valid realms specified.
```

After:

```
No valid realms specified. Possible reasons:
- the realmlist table of the auth database is empty
- every realm has flag 3 (REALM_FLAG_VERSION_MISMATCH | REALM_FLAG_OFFLINE), which the realm list query excludes. Reset it with: UPDATE realmlist SET flag = 0 WHERE id = <realm id>;
- no realm address could be resolved, see the resolver errors logged above
```

Message text only, no behaviour change.

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Claude Opus 5)
- [ ] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:

None.

## SOURCE:

The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:

Built and run on Windows 10, MSVC, RelWithDebInfo. Both paths checked against a live auth database: with the realm at flag 3 authserver prints the new message and exits as it did before, with the realm at flag 0 it starts normally.

This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. `UPDATE realmlist SET flag = 1 WHERE id = 1;` (authserver adds `REALM_FLAG_OFFLINE` on top at startup, making it 3)
2. Start authserver. It exits with the new message naming flag 3 and the statement that resets it.
3. `UPDATE realmlist SET flag = 0 WHERE id = 1;` and start authserver again. It starts normally.

## Known Issues and TODO List:

- [ ] None.

## How to Test AzerothCore PRs

When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
