### PR TITLE
feat(Deps/libsidecar): Libsidecar (clustering) ABI versions check and portable shared-library loading

### DIFF
--- a/deps/PackageList.txt
+++ b/deps/PackageList.txt
@@ -86,6 +86,6 @@ fkYAML (A C++ header-only YAML library)
   https://github.com/fktn-k/fkYAML
   Version: 721edb3e1a817e527fd9e1e18a3bea300822522e
 
-libsidecar (enables interaction with other components when the worldserver is running in cluster mode. It requires building a shared library first and putting it in the corresponding folder.)
-  https://github.com/walkline/ToCloud9/tree/master/game-server/libsidecar
-  Version: master
+libsidecar (enables interaction with other components when the worldserver is running in cluster mode. Place the shared library in deps/libsidecar for builds. UNIX: BUILD_RPATH finds deps/libsidecar; install copies to ${prefix}/lib; runtime also searches next to worldserver and ../lib. Windows: no rpath — build copies the DLL next to worldserver; install places it next to worldserver. Headers under deps/libsidecar/include — including tc9_version.h — must come from the same libsidecar build/release as the linked binary. worldserver checks ABI at cluster init.)
+  https://github.com/walkline/ToCloud9/tree/master/game-server/libsidecar-cpp
+  Version: 1.0.0 (TC9_VERSION in deps/libsidecar/include/tc9_version.h)

--- a/deps/PackageList.txt
+++ b/deps/PackageList.txt
@@ -86,6 +86,6 @@ fkYAML (A C++ header-only YAML library)
   https://github.com/fktn-k/fkYAML
   Version: 721edb3e1a817e527fd9e1e18a3bea300822522e
 
-libsidecar (enables interaction with other components when the worldserver is running in cluster mode. Place the shared library in deps/libsidecar for builds. UNIX: BUILD_RPATH finds deps/libsidecar; install copies to ${prefix}/lib; runtime also searches next to worldserver and ../lib. Windows: no rpath — build copies the DLL next to worldserver; install places it next to worldserver. Headers under deps/libsidecar/include — including tc9_version.h — must come from the same libsidecar build/release as the linked binary. worldserver checks ABI at cluster init.)
-  https://github.com/walkline/ToCloud9/tree/master/game-server/libsidecar-cpp
+libsidecar (enables interaction with other components when the worldserver is running in cluster mode. Place the shared library from the release assets in deps/libsidecar for builds. UNIX: BUILD_RPATH finds deps/libsidecar; install copies to ${prefix}/lib; runtime also searches next to worldserver and ../lib. Windows: no rpath - build copies the DLL next to worldserver; install places it next to worldserver. Headers under deps/libsidecar/include - including tc9_version.h - must come from the same libsidecar build/release as the linked binary. worldserver checks ABI early when Cluster.Enabled.)
+  https://github.com/walkline/ToCloud9/releases/tag/libsidecar-v1.0.0
   Version: 1.0.0 (TC9_VERSION in deps/libsidecar/include/tc9_version.h)

--- a/deps/libsidecar/CMakeLists.txt
+++ b/deps/libsidecar/CMakeLists.txt
@@ -74,12 +74,6 @@ else()
             IMPORTED_NO_SONAME
               true)
 
-        set_target_properties(libsidecar PROPERTIES
-            IMPORTED_LOCATION_NOCONFIG
-              "${CMAKE_INSTALL_RPATH}/libsidecar.${LIBSIDECAR_EXTENSION}"
-            IMPORTED_SONAME_NOCONFIG
-              "libsidecar.${LIBSIDECAR_EXTENSION}")
-
         # Source-tree dir for BUILD_RPATH only (dev runs from the build tree).
         # Do not put this path on INSTALL_RPATH — that would bake the build
         # machine's source tree into installed binaries.

--- a/deps/libsidecar/CMakeLists.txt
+++ b/deps/libsidecar/CMakeLists.txt
@@ -37,20 +37,38 @@ else()
         set(LIBSIDECAR_EXTENSION "so")
     endif()
 
+    # Visible to worldserver CMake (rpath on UNIX; POST_BUILD copy on Windows).
+    set(LIBSIDECAR_SHARED_FILE
+        "${CMAKE_CURRENT_SOURCE_DIR}/libsidecar.${LIBSIDECAR_EXTENSION}"
+        CACHE INTERNAL "Path to the real libsidecar shared library file")
+
+    if (NOT EXISTS "${LIBSIDECAR_SHARED_FILE}")
+        message(WARNING
+            "USE_REAL_LIBSIDECAR is ON but ${LIBSIDECAR_SHARED_FILE} was not found. "
+            "Place the matching shared library (and headers) from the same libsidecar "
+            "build/release before linking or installing.")
+    endif()
+
     if(WIN32)
         set_target_properties(libsidecar
           PROPERTIES
             IMPORTED_LOCATION
-              ${CMAKE_CURRENT_SOURCE_DIR}/libsidecar.${LIBSIDECAR_EXTENSION}
+              ${LIBSIDECAR_SHARED_FILE}
             IMPORTED_IMPLIB
               ${CMAKE_CURRENT_SOURCE_DIR}/${LIBSIDECAR_IMPORT_LIB}
             INTERFACE_INCLUDE_DIRECTORIES
               ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
+        # worldserver installs to CMAKE_INSTALL_PREFIX root; DLL must sit next to it.
+        # Build-tree runs: apps/CMakeLists.txt copies this DLL next to worldserver
+        # (Windows has no rpath; the loader only searches the exe directory / PATH).
+        install(FILES "${LIBSIDECAR_SHARED_FILE}"
+            DESTINATION "${CMAKE_INSTALL_PREFIX}")
     else()
         set_target_properties(libsidecar
           PROPERTIES
             IMPORTED_LOCATION
-              ${CMAKE_CURRENT_SOURCE_DIR}/libsidecar.${LIBSIDECAR_EXTENSION}
+              ${LIBSIDECAR_SHARED_FILE}
             INTERFACE_INCLUDE_DIRECTORIES
               ${CMAKE_CURRENT_SOURCE_DIR}/include
             IMPORTED_NO_SONAME
@@ -61,6 +79,18 @@ else()
               "${CMAKE_INSTALL_RPATH}/libsidecar.${LIBSIDECAR_EXTENSION}"
             IMPORTED_SONAME_NOCONFIG
               "libsidecar.${LIBSIDECAR_EXTENSION}")
+
+        # Source-tree dir for BUILD_RPATH only (dev runs from the build tree).
+        # Do not put this path on INSTALL_RPATH — that would bake the build
+        # machine's source tree into installed binaries.
+        # Do not use INTERFACE_LINK_OPTIONS -rpath: game, scripts, and
+        # worldserver all link libsidecar and would get duplicate -rpath warnings.
+        set(LIBSIDECAR_RUNTIME_DIR "${CMAKE_CURRENT_SOURCE_DIR}" CACHE INTERNAL
+            "Directory containing the real libsidecar shared library (build tree)")
+
+        # Install next to the rest of the prefix libraries (worldserver → bin/,
+        # so runtime rpath uses $ORIGIN/../lib and CMAKE_INSTALL_RPATH = prefix/lib).
+        install(FILES "${LIBSIDECAR_SHARED_FILE}" DESTINATION lib)
     endif()
 
 endif()

--- a/deps/libsidecar/include/libsidecar.h
+++ b/deps/libsidecar/include/libsidecar.h
@@ -19,6 +19,9 @@
     #endif
 #endif
 
+/* Compile-time version macros (must match the libsidecar you link) */
+#include "tc9_version.h"
+
 /* Include all API headers */
 #include "battleground-api.h"
 #include "events-group.h"
@@ -32,6 +35,13 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/* ABI / package version of the *linked* library (not the caller's headers).
+ * Pass TC9_VERSION_MAJOR / TC9_VERSION_MINOR from the headers you compiled
+ * against into TC9CheckAbiCompatible. Returns 0 if compatible. */
+TC9_API void TC9GetVersion(int* major, int* minor, int* patch);
+TC9_API const char* TC9GetVersionString(void);
+TC9_API int TC9CheckAbiCompatible(int required_major, int required_minor);
 
 /* Main library functions */
 TC9_API void TC9InitLib(uint16_t port, uint32_t realmID, uint8_t isCrossRealm, char* availableMaps, uint32_t** assignedMaps, int* assignedMapsSize);

--- a/deps/libsidecar/include/tc9_version.h
+++ b/deps/libsidecar/include/tc9_version.h
@@ -1,0 +1,20 @@
+#ifndef TC9_VERSION_H
+#define TC9_VERSION_H
+
+/* Vendored snapshot of libsidecar-cpp generated version header.
+ * Keep in sync with the libsidecar binary in this deps folder.
+ * Upstream source of truth: project(libsidecar VERSION ...) in
+ * game-server/libsidecar-cpp/CMakeLists.txt (generates this file).
+ */
+
+#define TC9_VERSION_MAJOR 1
+#define TC9_VERSION_MINOR 0
+#define TC9_VERSION_PATCH 0
+
+#define TC9_VERSION_STRING "1.0.0"
+
+/* major*10000 + minor*100 + patch */
+#define TC9_VERSION_NUMBER \
+    (TC9_VERSION_MAJOR * 10000 + TC9_VERSION_MINOR * 100 + TC9_VERSION_PATCH)
+
+#endif /* TC9_VERSION_H */

--- a/deps/libsidecar/stub/libsidecar.c
+++ b/deps/libsidecar/stub/libsidecar.c
@@ -7,6 +7,32 @@ void panicWithTC9Unavailable(const char* message) {
     exit(EXIT_FAILURE);
 }
 
+// Version APIs work without a real libsidecar so callers can always query
+// the header version this tree was built against.
+void TC9GetVersion(int* major, int* minor, int* patch)
+{
+    if (major)
+        *major = TC9_VERSION_MAJOR;
+    if (minor)
+        *minor = TC9_VERSION_MINOR;
+    if (patch)
+        *patch = TC9_VERSION_PATCH;
+}
+
+const char* TC9GetVersionString(void)
+{
+    return TC9_VERSION_STRING;
+}
+
+int TC9CheckAbiCompatible(int required_major, int required_minor)
+{
+    if (TC9_VERSION_MAJOR != required_major)
+        return 1;
+    if (TC9_VERSION_MINOR < required_minor)
+        return 2;
+    return 0;
+}
+
 // TC9SetBattlegroundStartHandler sets handler for starting battleground.
 //
 extern void TC9SetBattlegroundStartHandler(BattlegroundStartHandler h) { panicWithTC9Unavailable("TC9SetBattlegroundStartHandler"); }

--- a/deps/libsidecar/stub/libsidecar.h
+++ b/deps/libsidecar/stub/libsidecar.h
@@ -4,6 +4,9 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+/* Compile-time version macros (vendored with real headers under include/) */
+#include "tc9_version.h"
+
 /* Include all API headers */
 #include "battleground-api.h"
 #include "events-group.h"
@@ -17,6 +20,11 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/* Version APIs (implemented by stub without panic; real lib reports its build) */
+void TC9GetVersion(int* major, int* minor, int* patch);
+const char* TC9GetVersionString(void);
+int TC9CheckAbiCompatible(int required_major, int required_minor);
 
 /* Main library functions */
 void TC9InitLib(uint16_t port, uint32_t realmID, uint8_t isCrossRealm, char* availableMaps, uint32_t** assignedMaps, int* assignedMapsSize);

--- a/deps/libsidecar/stub/tc9_version.h
+++ b/deps/libsidecar/stub/tc9_version.h
@@ -1,0 +1,18 @@
+#ifndef TC9_VERSION_H
+#define TC9_VERSION_H
+
+/* Vendored snapshot of libsidecar-cpp generated version header.
+ * Keep in sync with include/tc9_version.h and the linked libsidecar binary.
+ */
+
+#define TC9_VERSION_MAJOR 1
+#define TC9_VERSION_MINOR 0
+#define TC9_VERSION_PATCH 0
+
+#define TC9_VERSION_STRING "1.0.0"
+
+/* major*10000 + minor*100 + patch */
+#define TC9_VERSION_NUMBER \
+    (TC9_VERSION_MAJOR * 10000 + TC9_VERSION_MINOR * 100 + TC9_VERSION_PATCH)
+
+#endif /* TC9_VERSION_H */

--- a/deps/libsidecar/stub/tc9_version.h
+++ b/deps/libsidecar/stub/tc9_version.h
@@ -3,7 +3,10 @@
 
 /* Vendored snapshot of libsidecar-cpp generated version header.
  * Keep in sync with include/tc9_version.h and the linked libsidecar binary.
+ * Built only when USE_REAL_LIBSIDECAR is OFF (static stub, not the real .so/.dll).
  */
+
+#define TC9_LIBSIDECAR_IS_STUB 1
 
 #define TC9_VERSION_MAJOR 1
 #define TC9_VERSION_MINOR 0

--- a/src/cmake/showoptions.cmake
+++ b/src/cmake/showoptions.cmake
@@ -127,6 +127,17 @@ else()
   message("* Use stub for libsidecar         : Yes")
 endif()
 
+# Report vendored libsidecar ABI version expected by this tree
+if (EXISTS "${CMAKE_SOURCE_DIR}/deps/libsidecar/include/tc9_version.h")
+  file(STRINGS "${CMAKE_SOURCE_DIR}/deps/libsidecar/include/tc9_version.h" _tc9_ver_line
+    REGEX "^#define TC9_VERSION_STRING ")
+  if (_tc9_ver_line)
+    string(REGEX REPLACE "^#define TC9_VERSION_STRING \"([^\"]+)\".*" "\\1" TC9_VENDORED_VERSION "${_tc9_ver_line}")
+    message("* libsidecar required ABI         : ${TC9_VENDORED_VERSION}")
+  endif()
+  unset(_tc9_ver_line)
+endif()
+
 if ( NOJEM )
   message("")
   message(" *** NOJEM - WARNING!")

--- a/src/cmake/showoptions.cmake
+++ b/src/cmake/showoptions.cmake
@@ -123,19 +123,18 @@ endif()
 
 if ( USE_REAL_LIBSIDECAR )
   message("* Use stub for libsidecar         : No")
+  # Required ABI only applies when linking the real shared library (include/).
+  if (EXISTS "${CMAKE_SOURCE_DIR}/deps/libsidecar/include/tc9_version.h")
+    file(STRINGS "${CMAKE_SOURCE_DIR}/deps/libsidecar/include/tc9_version.h" _tc9_ver_line
+      REGEX "^#define TC9_VERSION_STRING ")
+    if (_tc9_ver_line)
+      string(REGEX REPLACE "^#define TC9_VERSION_STRING \"([^\"]+)\".*" "\\1" TC9_VENDORED_VERSION "${_tc9_ver_line}")
+      message("* libsidecar required ABI         : ${TC9_VENDORED_VERSION}")
+    endif()
+    unset(_tc9_ver_line)
+  endif()
 else()
   message("* Use stub for libsidecar         : Yes")
-endif()
-
-# Report vendored libsidecar ABI version expected by this tree
-if (EXISTS "${CMAKE_SOURCE_DIR}/deps/libsidecar/include/tc9_version.h")
-  file(STRINGS "${CMAKE_SOURCE_DIR}/deps/libsidecar/include/tc9_version.h" _tc9_ver_line
-    REGEX "^#define TC9_VERSION_STRING ")
-  if (_tc9_ver_line)
-    string(REGEX REPLACE "^#define TC9_VERSION_STRING \"([^\"]+)\".*" "\\1" TC9_VENDORED_VERSION "${_tc9_ver_line}")
-    message("* libsidecar required ABI         : ${TC9_VENDORED_VERSION}")
-  endif()
-  unset(_tc9_ver_line)
 endif()
 
 if ( NOJEM )

--- a/src/server/apps/CMakeLists.txt
+++ b/src/server/apps/CMakeLists.txt
@@ -153,8 +153,8 @@ foreach(APPLICATION_NAME ${APPLICATIONS_BUILD_LIST})
     #
     # UNIX/macOS — rpath search order:
     #   BUILD:  deps/libsidecar → next to binary → ../lib
-    #   INSTALL: next to binary → ../lib → ${CMAKE_INSTALL_PREFIX}/lib
-    #            (last entry from global CMAKE_INSTALL_RPATH; no source-tree path)
+    #   INSTALL: target inherits CMAKE_INSTALL_RPATH (${prefix}/lib) first, then
+    #            APPEND next to binary and ../lib (no source-tree path)
     #
     # Windows — no rpath; loader only searches the exe directory (then PATH).
     #   BUILD:  POST_BUILD copy DLL next to worldserver

--- a/src/server/apps/CMakeLists.txt
+++ b/src/server/apps/CMakeLists.txt
@@ -148,6 +148,45 @@ foreach(APPLICATION_NAME ${APPLICATIONS_BUILD_LIST})
 
     set_target_properties(${APP_PROJECT_NAME} PROPERTIES LINK_FLAGS "${${APP_PROJECT_NAME}_LINK_FLAGS}")
 
+    # Real libsidecar runtime location (not via imported-target INTERFACE -rpath:
+    # game, scripts, and worldserver all link libsidecar and would get duplicates).
+    #
+    # UNIX/macOS — rpath search order:
+    #   BUILD:  deps/libsidecar → next to binary → ../lib
+    #   INSTALL: next to binary → ../lib → ${CMAKE_INSTALL_PREFIX}/lib
+    #            (last entry from global CMAKE_INSTALL_RPATH; no source-tree path)
+    #
+    # Windows — no rpath; loader only searches the exe directory (then PATH).
+    #   BUILD:  POST_BUILD copy DLL next to worldserver
+    #   INSTALL: install(FILES) places DLL next to worldserver (see deps/libsidecar)
+    if (USE_REAL_LIBSIDECAR)
+      if (WIN32 AND LIBSIDECAR_SHARED_FILE)
+        add_custom_command(TARGET ${APP_PROJECT_NAME} POST_BUILD
+          COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            "${LIBSIDECAR_SHARED_FILE}"
+            "$<TARGET_FILE_DIR:${APP_PROJECT_NAME}>"
+          COMMENT "Copy libsidecar.dll next to worldserver (Windows build tree)")
+      elseif (LIBSIDECAR_RUNTIME_DIR)
+        if (APPLE)
+          set_property(TARGET ${APP_PROJECT_NAME} APPEND PROPERTY BUILD_RPATH
+            "${LIBSIDECAR_RUNTIME_DIR}"
+            "@loader_path"
+            "@loader_path/../lib")
+          set_property(TARGET ${APP_PROJECT_NAME} APPEND PROPERTY INSTALL_RPATH
+            "@loader_path"
+            "@loader_path/../lib")
+        elseif (UNIX)
+          set_property(TARGET ${APP_PROJECT_NAME} APPEND PROPERTY BUILD_RPATH
+            "${LIBSIDECAR_RUNTIME_DIR}"
+            "$ORIGIN"
+            "$ORIGIN/../lib")
+          set_property(TARGET ${APP_PROJECT_NAME} APPEND PROPERTY INSTALL_RPATH
+            "$ORIGIN"
+            "$ORIGIN/../lib")
+        endif()
+      endif()
+    endif()
+
     # Add all dynamic projects as dependency to the worldserver
     if (WORLDSERVER_DYNAMIC_SCRIPT_MODULES_DEPENDENCIES)
       add_dependencies(${APP_PROJECT_NAME} ${WORLDSERVER_DYNAMIC_SCRIPT_MODULES_DEPENDENCIES})

--- a/src/server/apps/worldserver/Main.cpp
+++ b/src/server/apps/worldserver/Main.cpp
@@ -206,8 +206,9 @@ int main(int argc, char** argv)
         });
 
     // Cluster.Enabled is known from config here. Fail before DB/network if the
-    // loaded libsidecar does not match the headers this binary was built with.
-    sToCloud9Sidecar->CheckLibsidecarAbi();
+    // loaded libsidecar is the stub or does not match the headers we built with.
+    if (!sToCloud9Sidecar->CheckLibsidecarAbi())
+        return 1;
 
     OpenSSLCrypto::threadsSetup();
 

--- a/src/server/apps/worldserver/Main.cpp
+++ b/src/server/apps/worldserver/Main.cpp
@@ -205,6 +205,10 @@ int main(int argc, char** argv)
             LOG_INFO("server.worldserver", "> Using Boost version:           {}.{}.{}", BOOST_VERSION / 100000, BOOST_VERSION / 100 % 1000, BOOST_VERSION % 100);
         });
 
+    // Cluster.Enabled is known from config here. Fail before DB/network if the
+    // loaded libsidecar does not match the headers this binary was built with.
+    sToCloud9Sidecar->CheckLibsidecarAbi();
+
     OpenSSLCrypto::threadsSetup();
 
     std::shared_ptr<void> opensslHandle(nullptr, [](void*) { OpenSSLCrypto::threadsCleanup(); });

--- a/src/server/game/TC9Sidecar/TC9Sidecar.cpp
+++ b/src/server/game/TC9Sidecar/TC9Sidecar.cpp
@@ -17,7 +17,6 @@
 
 #include "TC9Sidecar.h"
 #include "Config.h"
-#include "Errors.h"
 #include "InstanceSaveMgr.h"
 #include "libsidecar.h"
 #include "Log.h"
@@ -45,10 +44,10 @@ ToCloud9Sidecar::ToCloud9Sidecar() : _clusterModeEnabled(false), _isCrossrealm(f
 {
 }
 
-void ToCloud9Sidecar::CheckLibsidecarAbi()
+bool ToCloud9Sidecar::CheckLibsidecarAbi()
 {
     if (!sConfigMgr->GetOption<bool>("Cluster.Enabled", false))
-        return;
+        return true;
 
     int libMajor = 0;
     int libMinor = 0;
@@ -56,23 +55,40 @@ void ToCloud9Sidecar::CheckLibsidecarAbi()
     TC9GetVersion(&libMajor, &libMinor, &libPatch);
     char const* libVersionStr = TC9GetVersionString();
 
-    // Stub reports the same macros as headers; name it so operators know why
-    // TC9InitLib will still panic unless USE_REAL_LIBSIDECAR=ON.
 #if defined(TC9_LIBSIDECAR_IS_STUB)
     char const* libKind = "stub";
 #else
     char const* libKind = "shared library";
 #endif
 
+#if defined(TC9_LIBSIDECAR_IS_STUB)
+    // Stub always "matches" its own macros; fail here instead of after the realm
+    // is online when TC9InitLib panics.
+    // SetSynchronous first: this runs before the io_context pool starts, so async
+    // LOG_* would never print on early return. Success path leaves async alone.
+    sLog->SetSynchronous();
     LOG_INFO("server", "libsidecar ({}) runtime {}.{}.{} ({}) - headers {}.{}.{} ({})",
         libKind,
         libMajor, libMinor, libPatch,
         libVersionStr ? libVersionStr : "?",
         TC9_VERSION_MAJOR, TC9_VERSION_MINOR, TC9_VERSION_PATCH,
         TC9_VERSION_STRING);
-
+    LOG_ERROR("server",
+        "Cluster.Enabled requires the real libsidecar shared library. "
+        "This worldserver was built with the stub (default). "
+        "Rebuild with -DUSE_REAL_LIBSIDECAR=ON and place matching headers + library "
+        "from the same libsidecar release under deps/libsidecar.");
+    return false;
+#else
     if (TC9CheckAbiCompatible(TC9_VERSION_MAJOR, TC9_VERSION_MINOR) != 0)
     {
+        sLog->SetSynchronous();
+        LOG_INFO("server", "libsidecar ({}) runtime {}.{}.{} ({}) - headers {}.{}.{} ({})",
+            libKind,
+            libMajor, libMinor, libPatch,
+            libVersionStr ? libVersionStr : "?",
+            TC9_VERSION_MAJOR, TC9_VERSION_MINOR, TC9_VERSION_PATCH,
+            TC9_VERSION_STRING);
         LOG_ERROR("server",
             "libsidecar ABI mismatch: worldserver was built for {}.{}.{} (headers {}), "
             "but loaded library is {}.{}.{} ({}). "
@@ -80,10 +96,17 @@ void ToCloud9Sidecar::CheckLibsidecarAbi()
             TC9_VERSION_MAJOR, TC9_VERSION_MINOR, TC9_VERSION_PATCH, TC9_VERSION_STRING,
             libMajor, libMinor, libPatch,
             libVersionStr ? libVersionStr : "?");
-        ABORT("libsidecar ABI mismatch (headers {} vs library {})",
-            TC9_VERSION_STRING,
-            libVersionStr ? libVersionStr : "?");
+        return false;
     }
+
+    LOG_INFO("server", "libsidecar ({}) runtime {}.{}.{} ({}) - headers {}.{}.{} ({})",
+        libKind,
+        libMajor, libMinor, libPatch,
+        libVersionStr ? libVersionStr : "?",
+        TC9_VERSION_MAJOR, TC9_VERSION_MINOR, TC9_VERSION_PATCH,
+        TC9_VERSION_STRING);
+    return true;
+#endif
 }
 
 void ToCloud9Sidecar::Init(uint16 port, int realmId)

--- a/src/server/game/TC9Sidecar/TC9Sidecar.cpp
+++ b/src/server/game/TC9Sidecar/TC9Sidecar.cpp
@@ -17,6 +17,7 @@
 
 #include "TC9Sidecar.h"
 #include "Config.h"
+#include "Errors.h"
 #include "InstanceSaveMgr.h"
 #include "libsidecar.h"
 #include "Log.h"
@@ -50,6 +51,32 @@ void ToCloud9Sidecar::Init(uint16 port, int realmId)
 
     if (_clusterModeEnabled)
     {
+        int libMajor = 0;
+        int libMinor = 0;
+        int libPatch = 0;
+        TC9GetVersion(&libMajor, &libMinor, &libPatch);
+        char const* libVersionStr = TC9GetVersionString();
+
+        LOG_INFO("server", "libsidecar runtime {}.{}.{} ({}) — headers {}.{}.{} ({})",
+            libMajor, libMinor, libPatch,
+            libVersionStr ? libVersionStr : "?",
+            TC9_VERSION_MAJOR, TC9_VERSION_MINOR, TC9_VERSION_PATCH,
+            TC9_VERSION_STRING);
+
+        if (TC9CheckAbiCompatible(TC9_VERSION_MAJOR, TC9_VERSION_MINOR) != 0)
+        {
+            LOG_ERROR("server",
+                "libsidecar ABI mismatch: worldserver was built for {}.{}.{} (headers {}), "
+                "but loaded library is {}.{}.{} ({}). "
+                "Copy matching headers + library from the same libsidecar build/release.",
+                TC9_VERSION_MAJOR, TC9_VERSION_MINOR, TC9_VERSION_PATCH, TC9_VERSION_STRING,
+                libMajor, libMinor, libPatch,
+                libVersionStr ? libVersionStr : "?");
+            ABORT("libsidecar ABI mismatch (headers {} vs library {})",
+                TC9_VERSION_STRING,
+                libVersionStr ? libVersionStr : "?");
+        }
+
         uint32 *assignedMaps;
         int assignedMapsSize = 0;
 

--- a/src/server/game/TC9Sidecar/TC9Sidecar.cpp
+++ b/src/server/game/TC9Sidecar/TC9Sidecar.cpp
@@ -45,38 +45,53 @@ ToCloud9Sidecar::ToCloud9Sidecar() : _clusterModeEnabled(false), _isCrossrealm(f
 {
 }
 
+void ToCloud9Sidecar::CheckLibsidecarAbi()
+{
+    if (!sConfigMgr->GetOption<bool>("Cluster.Enabled", false))
+        return;
+
+    int libMajor = 0;
+    int libMinor = 0;
+    int libPatch = 0;
+    TC9GetVersion(&libMajor, &libMinor, &libPatch);
+    char const* libVersionStr = TC9GetVersionString();
+
+    // Stub reports the same macros as headers; name it so operators know why
+    // TC9InitLib will still panic unless USE_REAL_LIBSIDECAR=ON.
+#if defined(TC9_LIBSIDECAR_IS_STUB)
+    char const* libKind = "stub";
+#else
+    char const* libKind = "shared library";
+#endif
+
+    LOG_INFO("server", "libsidecar ({}) runtime {}.{}.{} ({}) - headers {}.{}.{} ({})",
+        libKind,
+        libMajor, libMinor, libPatch,
+        libVersionStr ? libVersionStr : "?",
+        TC9_VERSION_MAJOR, TC9_VERSION_MINOR, TC9_VERSION_PATCH,
+        TC9_VERSION_STRING);
+
+    if (TC9CheckAbiCompatible(TC9_VERSION_MAJOR, TC9_VERSION_MINOR) != 0)
+    {
+        LOG_ERROR("server",
+            "libsidecar ABI mismatch: worldserver was built for {}.{}.{} (headers {}), "
+            "but loaded library is {}.{}.{} ({}). "
+            "Copy matching headers + library from the same libsidecar build/release.",
+            TC9_VERSION_MAJOR, TC9_VERSION_MINOR, TC9_VERSION_PATCH, TC9_VERSION_STRING,
+            libMajor, libMinor, libPatch,
+            libVersionStr ? libVersionStr : "?");
+        ABORT("libsidecar ABI mismatch (headers {} vs library {})",
+            TC9_VERSION_STRING,
+            libVersionStr ? libVersionStr : "?");
+    }
+}
+
 void ToCloud9Sidecar::Init(uint16 port, int realmId)
 {
     _clusterModeEnabled = sConfigMgr->GetOption<bool>("Cluster.Enabled", false);
 
     if (_clusterModeEnabled)
     {
-        int libMajor = 0;
-        int libMinor = 0;
-        int libPatch = 0;
-        TC9GetVersion(&libMajor, &libMinor, &libPatch);
-        char const* libVersionStr = TC9GetVersionString();
-
-        LOG_INFO("server", "libsidecar runtime {}.{}.{} ({}) — headers {}.{}.{} ({})",
-            libMajor, libMinor, libPatch,
-            libVersionStr ? libVersionStr : "?",
-            TC9_VERSION_MAJOR, TC9_VERSION_MINOR, TC9_VERSION_PATCH,
-            TC9_VERSION_STRING);
-
-        if (TC9CheckAbiCompatible(TC9_VERSION_MAJOR, TC9_VERSION_MINOR) != 0)
-        {
-            LOG_ERROR("server",
-                "libsidecar ABI mismatch: worldserver was built for {}.{}.{} (headers {}), "
-                "but loaded library is {}.{}.{} ({}). "
-                "Copy matching headers + library from the same libsidecar build/release.",
-                TC9_VERSION_MAJOR, TC9_VERSION_MINOR, TC9_VERSION_PATCH, TC9_VERSION_STRING,
-                libMajor, libMinor, libPatch,
-                libVersionStr ? libVersionStr : "?");
-            ABORT("libsidecar ABI mismatch (headers {} vs library {})",
-                TC9_VERSION_STRING,
-                libVersionStr ? libVersionStr : "?");
-        }
-
         uint32 *assignedMaps;
         int assignedMapsSize = 0;
 

--- a/src/server/game/TC9Sidecar/TC9Sidecar.h
+++ b/src/server/game/TC9Sidecar/TC9Sidecar.h
@@ -34,9 +34,10 @@ private:
 public:
     static ToCloud9Sidecar* instance();
 
-    /// When Cluster.Enabled, log libsidecar version and ABORT on ABI mismatch.
+    /// When Cluster.Enabled, validate libsidecar (real library required; ABI match).
     /// Call after config and logging are ready, before DB/network startup.
-    void CheckLibsidecarAbi();
+    /// @return false if worldserver should exit with code 1.
+    bool CheckLibsidecarAbi();
 
     void Init(uint16 port, int realmId);
     void Deinit();

--- a/src/server/game/TC9Sidecar/TC9Sidecar.h
+++ b/src/server/game/TC9Sidecar/TC9Sidecar.h
@@ -34,6 +34,10 @@ private:
 public:
     static ToCloud9Sidecar* instance();
 
+    /// When Cluster.Enabled, log libsidecar version and ABORT on ABI mismatch.
+    /// Call after config and logging are ready, before DB/network startup.
+    void CheckLibsidecarAbi();
+
     void Init(uint16 port, int realmId);
     void Deinit();
 


### PR DESCRIPTION
Cluster mode needs a real libsidecar that matches the headers in this tree. It is easy to mix an old or wrong build with new headers (or the other way around). That used to show up late as confusing crashes or load errors.

This change makes the expected version obvious (1.0.0 / tc9_version.h) and checks it when cluster starts. If the loaded library does not match what worldserver was built for, it stops with a clear error: use headers and library from the same libsidecar build.

It also installs and finds the library in predictable places (build tree vs install prefix / next to the binary on Windows), so people are less likely to run with the “wrong file from somewhere on disk".

<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Grok (xAI / Grok Build)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Build and run with cluster mode.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
