### PR TITLE
fix(Scripts/Spells): the Combustion buff now falls off after an AoE pull

### DIFF
--- a/src/server/scripts/Spells/spell_mage.cpp
+++ b/src/server/scripts/Spells/spell_mage.cpp
@@ -1056,7 +1056,12 @@ class spell_mage_combustion : public AuraScript
             Unit* actor = eventInfo.GetActor();
             actor->m_Events.AddEventAtOffset([actor]()
             {
-                actor->CastSpell(static_cast<Unit*>(nullptr), SPELL_MAGE_COMBUSTION_PROC, true);
+                // An AoE volley procs once per target, all in the same tick, and a target that
+                // crits away the last charge removes Combustion right there - while these
+                // deferred stacks are still queued. Re-applying the buff after that leaves it
+                // up for good: 28682 has no duration, and the aura that removes it is gone.
+                if (actor->HasAura(SPELL_MAGE_COMBUSTION))
+                    actor->CastSpell(static_cast<Unit*>(nullptr), SPELL_MAGE_COMBUSTION_PROC, true);
             }, 1ms);
             return false;
         }


### PR DESCRIPTION
## Changes Proposed:

Fixes the Mage's Combustion buff staying up forever after an AoE pull.

Combustion is two auras working together. 11129 is the hidden one that counts down the 3 crits, and 28682 is the visible buff with the crit stacks. 28682 has no duration at all, so the only thing that ever takes it off is 11129 going away (`spell_linked_spell`: `-11129 -> -28682`).

Since #26644 the stack from a non-crit hit is applied on a deferred event instead of inline, which was the right call for the iterator problem that PR fixed. But an AoE spell procs once per target, all inside the same tick, so a target that crits away the last charge removes Combustion right there while the other targets' stacks are still sitting in the queue. Those land a tick later and put 28682 back up with nothing left to remove it.

The deferred event now checks Combustion is still on the caster before re-applying the stack. Nothing else changes: the cast stays deferred, and stacking during an active Combustion works exactly as before.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Opus 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #26895
- Same report on the ChromieCraft tracker: chromiecraft/chromiecraft#9965

Related, but **not** fixed here:
- #26195 - Molten Armor proc damage feeding Combustion stacks. That one is about which hits are allowed to feed the buff in the first place, a different cause, and this PR does not touch it.
- #24748 - the report that added the non-crit stacking branch being changed here (fixed by #24752).
- #13283 - much older report of the same symptom, "Combustion aura is never consumed", fixed back then and unrelated to this regression.

## SOURCE:
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Code inspection: Combustion's proc entry carries 3 charges and no script beyond `spell_mage_combustion`, so the whole lifetime runs through the proc engine.

- `Aura::GetProcEffectMask` calls the `CheckProc` hook, and returning false skips the charge (`src/server/game/Spells/Auras/SpellAuras.cpp`).
- On a crit it returns true, so `ConsumeProcCharges` hits 0 charges and calls `Remove()` synchronously, which runs the linked removal of 28682.
- `Spell.cpp` calls `Unit::ProcSkillsAndAuras` once per target while resolving a spell, so every target of an AoE procs in the same tick.
- 28682's `DurationIndex` 21 is -1 in `SpellDuration.dbc`, so an orphaned stack buff never expires on its own.

Matches the report: it only shows up sometimes, it is not Living Bomb specific, and it happens with Flamestrike at low level where Living Bomb is not available yet.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Tested on a local Windows build (RelWithDebInfo) with a level 70 mage, using the reproduction steps from the issue.

Before the fix the buff stayed up with its stacks after Combustion ended. After it, the stacks build up normally while Combustion is active and the whole thing disappears on the third crit.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Level 70 mage, `.learn all my class`, `.cheat god on`
2. `.go c 97075`
3. Cast Combustion, then Living Bomb on all 4 mobs and wait for them to explode
4. Watch the Combustion buff: it should gain a stack per fire spell hit while it is up, and disappear entirely on the third non periodic crit

Worth repeating a few times, since it needs crits and non crits landing in the same volley.

## Known Issues and TODO List:

Combustion gains a stack per target hit rather than per cast, so an AoE on 4 mobs adds 4 stacks at once. That is existing behaviour and is left alone here.

🤖 Generated with Claude Code (Opus 5)+AzerothMCP

<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs

When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
