### PR TITLE
fix(Core/Groups): chest loot now unlocks when the group disbands

### DIFF
--- a/src/server/game/Groups/Group.cpp
+++ b/src/server/game/Groups/Group.cpp
@@ -818,6 +818,13 @@ void Group::ForcedDisband(bool hideDestroy /* = false */)
 {
     sScriptMgr->OnGroupDisband(this);
 
+    // Settle rolls that are still open before the group goes away. Dropping them
+    // instead leaves the item is_blocked forever - only CountTheRoll clears that -
+    // and the looted object's roll timer can't save it either, since it looks the
+    // group up by guid and won't find one.
+    while (!RollId.empty())
+        CountTheRoll(RollId.begin());
+
     Player* player;
     uint32 instanceId = 0;
 


### PR DESCRIPTION
## Changes Proposed:

A chest whose Need/Greed roll is interrupted by the group disbanding stays visible but locked forever.

When a group disbands it drops its open rolls and nothing else touches them. The only code that clears an item's `is_blocked` flag is `CountTheRoll`, so the item keeps being sent to the client as `LOOT_SLOT_TYPE_LOCKED`. The looted object's 60 second roll timer cannot save it either: it resolves the roll by looking the group up by guid, and there is no group left to find. Relogging does not help since the state lives on the object.

Easiest way to hit it is a two player party, because there the whole group disbands when one player leaves instead of just losing a member. With three or more the other path runs, which already removes the leaver from the rolls properly.

Now the open rolls are counted before the group is torn down, so the item either goes to whoever voted or falls back to all-passed and stays lootable, which is what the issue asks for. This also stops leaking the `Roll` objects, which `clear()` dropped without deleting.

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Opus 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #26894
- Same report on the ChromieCraft tracker: chromiecraft/chromiecraft#9964

## SOURCE:
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Code inspection:

- `Group::RemoveMember` disbands when the group had 2 members or fewer before the removal, so the two player case never reaches `RemovePlayerFromRolls`.
- `ForcedDisband` did `RollId.clear()`, which neither resolves the rolls nor deletes them.
- `is_blocked` is only ever set back to false inside `Group::CountTheRoll`.
- `operator<<(ByteBuffer&, LootView const&)` (`LootMgr.cpp:974`) sends `LOOT_SLOT_TYPE_LOCKED` for a blocked item, and `Player::SendLoot` refuses to hand it over, which matches "visible in the chest but unlootable".
- `GameObject::Update` resolves the roll timeout with `sGroupMgr->GetGroupByGUID(lootingGroupLowGUID)` guarded by `if (group)`, so after a disband it silently does nothing.

`CountTheRoll` erases the roll on both of its exit paths, so the drain loop always terminates. It runs before members are detached so the winner can still be resolved and the packets still reach the group.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Tested on a local Windows build (RelWithDebInfo) with two accounts, following the reproduction steps from the issue.

Before the fix the roll window closed with nothing awarded and the chest kept showing the item as locked permanently. After it, the leaver disbanding the group ends the roll and the chest is lootable again as a normal unrolled chest.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Group accounts 1 and 2 into a two player party
2. `.gobject add 194821`
3. Open the chest with account 1 until the roll window shows up
4. Have account 2 leave the party
5. The chest should be lootable, either awarding the item to whoever already voted or leaving it free to loot

Worth also checking with three players that one leaving mid-roll still behaves as before, since that path is untouched.

## Known Issues and TODO List:

Only covers the disband path. #7896 describes a related unique-item roll problem that is not addressed here.

`~Group()` still drains `RollId` with a plain `delete`, never settling the rolls, which is what left the item blocked in the first place. With this change nothing should reach it still open, since `Disband` just forwards to `ForcedDisband` and every caller in the game goes through one of the two. Leaving it as it is rather than growing the diff, but it is a trap for whoever reads that loop next.

<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs

When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.


