### PR TITLE
fix(Scripts/ScarletEnclave): the Light of Dawn armies now charge into the battle

### DIFF
--- a/src/server/scripts/EasternKingdoms/zone_the_scarlet_enclave.cpp
+++ b/src/server/scripts/EasternKingdoms/zone_the_scarlet_enclave.cpp
@@ -1979,7 +1979,9 @@ struct npc_highlord_darion_mograine : public ScriptedAI
         // Scourge reinforcements march back in from Darion's line instead of popping
         // on the corpse they replace, which used to drop them right on top of whoever
         // just killed the last one. Defenders keep coming from where they fell.
-        Position spawnPos = creature->GetEntry() >= NPC_RAMPAGING_ABOMINATION ? LightOfDawnPos[urand(0, 1)] : creature->GetPosition();
+        Position spawnPos = creature->GetEntry() >= NPC_RAMPAGING_ABOMINATION
+            ? LightOfDawnPos[urand(0, 1)]
+            : creature->GetPosition();
         me->m_Events.AddEventAtOffset(new DelayedSummonEvent(me, creature->GetEntry(), spawnPos), 3s);
         if (creature->GetEntry() >= NPC_RAMPAGING_ABOMINATION)
         {
@@ -2218,7 +2220,8 @@ struct npc_highlord_darion_mograine : public ScriptedAI
 
                         Position pos = LightOfDawnFightPos[urand(0, 9)];
                         summon->SetHomePosition(pos);
-                        summon->GetMotionMaster()->MoveCharge(pos.GetPositionX(), pos.GetPositionY(), pos.GetPositionZ(), summon->GetSpeed(MOVE_RUN));
+                        summon->GetMotionMaster()->MoveCharge(pos.GetPositionX(), pos.GetPositionY(),
+                            pos.GetPositionZ(), summon->GetSpeed(MOVE_RUN));
                     }
                 events.ScheduleEvent(EVENT_BATTLE_ENGAGE, 5s);
                 break;
@@ -2231,7 +2234,8 @@ struct npc_highlord_darion_mograine : public ScriptedAI
                     for (SummonList::const_iterator itr = summons.begin(); itr != summons.end(); ++itr)
                         if (Creature* summon = ObjectAccessor::GetCreature(*me, *itr))
                         {
-                            if (!summon->IsAlive() || summon->GetVictim() || summon->GetEntry() == NPC_HIGHLORD_TIRION_FORDRING)
+                            if (!summon->IsAlive() || summon->GetVictim()
+                                || summon->GetEntry() == NPC_HIGHLORD_TIRION_FORDRING)
                                 continue;
 
                             if (Creature* enemy = SelectBattleOpponent(summon))

--- a/src/server/scripts/EasternKingdoms/zone_the_scarlet_enclave.cpp
+++ b/src/server/scripts/EasternKingdoms/zone_the_scarlet_enclave.cpp
@@ -1627,6 +1627,8 @@ enum LightOfDawnEncounter
     EVENT_START_COUNTDOWN_12,
     EVENT_START_COUNTDOWN_13,
     EVENT_START_COUNTDOWN_14,
+    EVENT_BATTLE_CHARGE,
+    EVENT_BATTLE_ENGAGE,
     // Fight Events
     EVENT_SPELL_ANTI_MAGIC_ZONE,
     EVENT_SPELL_DEATH_STRIKE,
@@ -1902,6 +1904,7 @@ struct npc_highlord_darion_mograine : public ScriptedAI
             events.ScheduleEvent(EVENT_START_COUNTDOWN_12, 335s);
             events.ScheduleEvent(EVENT_START_COUNTDOWN_13, 337s + 500ms);
             events.ScheduleEvent(EVENT_START_COUNTDOWN_14, 345s);
+            events.ScheduleEvent(EVENT_BATTLE_CHARGE, 347s);
         }
     }
 
@@ -1973,7 +1976,11 @@ struct npc_highlord_darion_mograine : public ScriptedAI
         if (battleStarted != ENCOUNTER_STATE_FIGHT)
             return;
 
-        me->m_Events.AddEventAtOffset(new DelayedSummonEvent(me, creature->GetEntry(), *creature), 3s);
+        // Scourge reinforcements march back in from Darion's line instead of popping
+        // on the corpse they replace, which used to drop them right on top of whoever
+        // just killed the last one. Defenders keep coming from where they fell.
+        Position spawnPos = creature->GetEntry() >= NPC_RAMPAGING_ABOMINATION ? LightOfDawnPos[urand(0, 1)] : creature->GetPosition();
+        me->m_Events.AddEventAtOffset(new DelayedSummonEvent(me, creature->GetEntry(), spawnPos), 3s);
         if (creature->GetEntry() >= NPC_RAMPAGING_ABOMINATION)
         {
             --scourgeRemaining;
@@ -2062,6 +2069,29 @@ struct npc_highlord_darion_mograine : public ScriptedAI
 
         SendInitialWorldStates();
         me->SummonCreatureGroup(30);
+    }
+
+    // Closest summon on the other side. Only summons are considered, so the two armies
+    // keep fighting each other and the player still pulls whatever they choose to.
+    Creature* SelectBattleOpponent(Creature* fighter)
+    {
+        Creature* closest = nullptr;
+        float closestDist = 60.0f;
+        for (SummonList::const_iterator itr = summons.begin(); itr != summons.end(); ++itr)
+            if (Creature* other = ObjectAccessor::GetCreature(*me, *itr))
+            {
+                if (other == fighter || !other->IsAlive() || !fighter->IsValidAttackTarget(other))
+                    continue;
+
+                float dist = fighter->GetDistance(other);
+                if (dist < closestDist)
+                {
+                    closestDist = dist;
+                    closest = other;
+                }
+            }
+
+        return closest;
     }
 
     Creature* GetEntryFromSummons(uint32 entry)
@@ -2175,6 +2205,42 @@ struct npc_highlord_darion_mograine : public ScriptedAI
                 me->SetImmuneToAll(false);
                 me->SummonCreatureGroup(5);
                 return;
+            case EVENT_BATTLE_CHARGE:
+                // Both armies form up behind their leaders for the speech and, until now,
+                // just stood there once it ended. Send them into the field the same way
+                // reinforcements already arrive, so the Behemoths actually run at the
+                // chapel and the two sides end up within reach of each other.
+                for (SummonList::const_iterator itr = summons.begin(); itr != summons.end(); ++itr)
+                    if (Creature* summon = ObjectAccessor::GetCreature(*me, *itr))
+                    {
+                        if (!summon->IsAlive() || summon->GetEntry() == NPC_HIGHLORD_TIRION_FORDRING)
+                            continue;
+
+                        Position pos = LightOfDawnFightPos[urand(0, 9)];
+                        summon->SetHomePosition(pos);
+                        summon->GetMotionMaster()->MoveCharge(pos.GetPositionX(), pos.GetPositionY(), pos.GetPositionZ(), summon->GetSpeed(MOVE_RUN));
+                    }
+                events.ScheduleEvent(EVENT_BATTLE_ENGAGE, 5s);
+                break;
+            case EVENT_BATTLE_ENGAGE:
+                // Nothing ever ordered these to attack - the battle relied on proximity
+                // aggro, which is only evaluated while a creature is relocating, so
+                // anyone who arrived without an enemy in range stayed idle for good.
+                if (battleStarted == ENCOUNTER_STATE_FIGHT)
+                {
+                    for (SummonList::const_iterator itr = summons.begin(); itr != summons.end(); ++itr)
+                        if (Creature* summon = ObjectAccessor::GetCreature(*me, *itr))
+                        {
+                            if (!summon->IsAlive() || summon->GetVictim() || summon->GetEntry() == NPC_HIGHLORD_TIRION_FORDRING)
+                                continue;
+
+                            if (Creature* enemy = SelectBattleOpponent(summon))
+                                summon->AI()->AttackStart(enemy);
+                        }
+
+                    events.ScheduleEvent(EVENT_BATTLE_ENGAGE, 3s);
+                }
+                break;
             case EVENT_FINISH_FIGHT_1:
                 summons.DespawnEntry(NPC_DEFENDER_OF_THE_LIGHT);
                 battleStarted = ENCOUNTER_STATE_OUTRO;

--- a/src/server/scripts/EasternKingdoms/zone_the_scarlet_enclave.cpp
+++ b/src/server/scripts/EasternKingdoms/zone_the_scarlet_enclave.cpp
@@ -1976,9 +1976,8 @@ struct npc_highlord_darion_mograine : public ScriptedAI
         if (battleStarted != ENCOUNTER_STATE_FIGHT)
             return;
 
-        // Scourge reinforcements march back in from Darion's line instead of popping
-        // on the corpse they replace, which used to drop them right on top of whoever
-        // just killed the last one. Defenders keep coming from where they fell.
+        // Reinforcements march in from Darion's line instead of popping on the corpse they
+        // replace, right on top of whoever just killed the last one.
         Position spawnPos = creature->GetEntry() >= NPC_RAMPAGING_ABOMINATION
             ? LightOfDawnPos[urand(0, 1)]
             : creature->GetPosition();
@@ -2208,10 +2207,8 @@ struct npc_highlord_darion_mograine : public ScriptedAI
                 me->SummonCreatureGroup(5);
                 return;
             case EVENT_BATTLE_CHARGE:
-                // Both armies form up behind their leaders for the speech and, until now,
-                // just stood there once it ended. Send them into the field the same way
-                // reinforcements already arrive, so the Behemoths actually run at the
-                // chapel and the two sides end up within reach of each other.
+                // Both armies just stood there once the speech ended. Send them out the same
+                // way reinforcements arrive, so the two sides end up within reach.
                 for (SummonList::const_iterator itr = summons.begin(); itr != summons.end(); ++itr)
                     if (Creature* summon = ObjectAccessor::GetCreature(*me, *itr))
                     {
@@ -2226,9 +2223,8 @@ struct npc_highlord_darion_mograine : public ScriptedAI
                 events.ScheduleEvent(EVENT_BATTLE_ENGAGE, 5s);
                 break;
             case EVENT_BATTLE_ENGAGE:
-                // Nothing ever ordered these to attack - the battle relied on proximity
-                // aggro, which is only evaluated while a creature is relocating, so
-                // anyone who arrived without an enemy in range stayed idle for good.
+                // Nothing ordered these to attack, and proximity aggro is only evaluated while
+                // relocating, so anyone arriving with no enemy in range stayed idle.
                 if (battleStarted == ENCOUNTER_STATE_FIGHT)
                 {
                     for (SummonList::const_iterator itr = summons.begin(); itr != summons.end(); ++itr)


### PR DESCRIPTION
## Changes Proposed:

Covers three of the problems still open in #20112, all in the Light of Dawn battle.

**The armies never left the staging line.** When the speech ends, every summon is sent to one of the two "home" positions behind its leader and left there, so the Flesh Behemoths never run at the chapel and the fight happens wherever the player happens to drag it. They now charge into the field once the defenders are up, using the same fight positions and the same `MoveCharge` that reinforcements summoned mid-fight already get.

**Nothing ever told them to attack.** There is no attack action anywhere in the battle, in the script or in the SmartAI of any of the five combatant entries: it relied entirely on proximity aggro. That is only evaluated while a creature is relocating (`AIRelocationNotifier` → `MoveInLineOfSight`), so once both sides arrived and stopped, anyone who happened to have no enemy in range stood idle for the rest of the battle. A short repeating pass now hands an opponent to any summon that is alive and has no victim.

**Scourge respawned on the corpse they replaced.** `SummonedCreatureDies` re-summoned at the dead creature's exact position, so killing one dropped its replacement on top of you three seconds later. They now come back in from Darion's line. Defenders are left as they were, since they belong on the chapel side and the report is only about the Scourge.

The opponent search only looks at the encounter's own summons, so the two armies fight each other and the player still pulls whatever they choose to. Tirion is excluded from both passes, matching what the existing code already does for him.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Opus 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Progress #20112 — covers points 5, 6 and 7. The rest of that list is already struck out as fixed.

Not closing it, since the reporter tracks the remaining points there.

## SOURCE:
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

The issue links retail footage of the event for the expected behaviour of all three points.

Code inspection:

- The countdown sends every summon to `LightOfDawnPos[0]` / `[1]`, the two staging spots, and sets their home there. The chapel and the ten `LightOfDawnFightPos` sit well away from those.
- `JustSummoned` already charges summons to a random fight position, but only when the fight is already running, so the initial army never gets it.
- None of the combatant entries (29174, 29186, 29190, 29206, 29219) has a single SmartAI row that starts combat; every row is "in combat, cast X".
- `AIRelocationNotifier::Visit` is what feeds `MoveInLineOfSight`, and it runs on relocation, so a creature standing still never re-evaluates aggro.
- `SummonedCreatureDies` passed the dead creature's own position straight into `DelayedSummonEvent`.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Tested on a local Windows build (RelWithDebInfo), running the event through from the gossip to the battle.

Before: the army stopped at the staging line and stayed there, groups stood around with enemies next to them, and killing a Scourge put its replacement on the same spot. After: they charge the chapel when the speech ends, the two sides engage on their own, and replacements come in from the back.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. `.quest add 12801` then talk to Highlord Darion Mograine and pick the gossip option. The quest chain is not needed, only the quest status.
2. Wait out the five minute muster timer.
3. Around 5:47 the whole army should run at the chapel instead of holding the staging line. The Flesh Behemoths are the easiest to spot.
4. Watch for anyone standing idle next to an enemy for the rest of the fight.
5. Kill a Scourge and watch where its replacement shows up three seconds later.

Worth checking the outro still plays out normally, since the engage pass touches every summon.

## Known Issues and TODO List:

Reinforcements come back from the staging line rather than a proper edge spawn; no sniffed positions for those exist that I could find.

🤖 Generated with Claude Code (Opus 5)+AzerothMCP

<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs

When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
