### PR TITLE
fix(Core/Players): DK runes are now usable as soon as they refresh

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -13739,7 +13739,12 @@ void Player::ResyncRunes(uint8 count)
     for (uint32 i = 0; i < count; ++i)
     {
         data << uint8(GetCurrentRune(i));                   // rune type
-        data << uint8(255 - (GetRuneCooldown(i) * 51));     // passed cooldown time (0-255)
+
+        // How much of the cooldown already elapsed, scaled to 0-255. Cooldowns are stored in
+        // milliseconds, so the old constant overflowed the byte and sent garbage.
+        uint32 baseCd = GetRuneBaseCooldown(i, true);
+        uint32 elapsed = baseCd - std::min<uint32>(GetRuneCooldown(i), baseCd);
+        data << uint8(baseCd ? elapsed * 255 / baseCd : 255);
     }
     SendDirectMessage(&data);
 }

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -5858,8 +5858,10 @@ void Spell::EffectActivateRune(SpellEffIndex effIndex)
         }
     }
 
-    // is needed to push through to the client that the rune is active
-    //player->ResyncRunes(MAX_RUNES);
+    // SMSG_SPELL_GO carries the rune masks, but it is sent before the effects run, so it
+    // still describes the runes as being on cooldown. Without this the client keeps counting
+    // its own timers down and refuses to spend runes the server already handed back.
+    player->ResyncRunes(MAX_RUNES);
     m_caster->CastSpell(m_caster, 47804, true);
 }
 


### PR DESCRIPTION
## Changes Proposed:

Death Knight abilities lock up for a few seconds with "Not enough runes" while the rune bar looks full.

The rune state does get sent to the client, inside `SMSG_SPELL_GO`, as a before/after mask plus the elapsed cooldown of each rune that just went on cooldown. That covers ordinary rune spending fine. What it does not cover is runes going the other way, from cooldown back to ready, because `SendSpellGo` runs before `handle_immediate`, so for Blood Tap and Empower Rune Weapon the packet still describes the runes it is about to hand back as being on cooldown.

Nothing corrects it afterwards. The regen loop deliberately sends nothing ("Runes act as cooldowns, and they don't need to send any data"), so the client keeps counting its own timers down and refuses to spend runes the server already considers ready. It clears itself once those client-side timers run out, which is the three to five seconds people describe.

`ResyncRunes` is what should fix that up, and the call was already sitting in `EffectActivateRune`, commented out, with a comment saying what it was for. It could not simply be re-enabled: rune cooldowns are stored in milliseconds and it packed them as `255 - cooldown * 51`, so a 10000 ms cooldown overflowed the byte and sent garbage. It now scales against the base cooldown, the same way `SendSpellGo` already does a few lines away.

This also explains the part of the report where Blood Tap sometimes appears to fix the lockup and usually does not: it is itself one of the two abilities whose own `SMSG_SPELL_GO` is sent before its effect.

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Opus 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #22469

## SOURCE:
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Code inspection:

- `Spell::cast` calls `SendSpellGo` before `handle_immediate`, so any rune state an effect changes is not in that packet.
- `EffectActivateRune` (Blood Tap 45529, Empower Rune Weapon 47568) zeroes rune cooldowns server side and, until now, told the client nothing. The spell it casts instead, 47804, is Blizzard's "Rune Test Spell" and is three dummy effects, so it cannot sync anything. Left alone here since it is unrelated to the fix.
- `RUNE_BASE_COOLDOWN` is 10000, so cooldowns are milliseconds and the old `* 51` could never fit a byte.
- `Player::RegenerateAll` says outright that rune cooldowns send no data, so there is no other path that would correct the client.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Tested on a local Windows build (RelWithDebInfo) with a level 80 Death Knight.

Before, spending runes down and then using Empower Rune Weapon left the abilities unusable until the client's own timers expired, even though the server had already returned the runes. After, they are usable immediately and the bar fills straight away. No flicker or backwards jump on the rune bar.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

Quickest way, since it does not need the desync to build up on its own:

1. On a Death Knight, hit a training dummy until several runes are on cooldown
2. Use Empower Rune Weapon
3. Try to use an ability straight away. It should work immediately and the rune bar should fill at once

The report's own repro also works: hit a dummy with a normal rotation for a few minutes and watch for the abilities locking up with "Not enough runes" while runes look available. Blood Tap should now clear it every time.

## Known Issues and TODO List:

Only covers the desync introduced by effects that hand runes back. If any other source of drift exists it is not addressed here.

🤖 Generated with Claude Code (Opus 5)+AzerothMCP

<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs

When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
