### PR TITLE
fix(Scripts/Ulduar): rework Hodir hard mode timer to use Shatter Chest aura

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1785678970043008400.sql
+++ b/data/sql/updates/pending_db_world/rev_1785678970043008400.sql
@@ -1,0 +1,3 @@
+--
+DELETE FROM `spell_script_names` WHERE `ScriptName` IN ('spell_hodir_shatter_chest', 'spell_hodir_shatter_chest_timer_aura');
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES (65272, 'spell_hodir_shatter_chest_timer_aura');

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_hodir.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_hodir.cpp
@@ -46,6 +46,7 @@ enum HodirSpellData
     SPELL_SAFE_AREA                     = 65705,
     SPELL_SAFE_AREA_TRIGGERED           = 62464,
     SPELL_SHATTER_CHEST                 = 62501,
+    SPELL_SHATTER_CHEST_TIMER           = 65272,
 
     SPELL_ICICLE_BOSS_AURA              = 62227,
     SPELL_ICICLE_TBBA                   = 63545,
@@ -123,8 +124,6 @@ enum HodirEvents
     EVENT_FREEZE                        = 4,
     EVENT_SMALL_ICICLES_ENABLE          = 5,
     EVENT_HARD_MODE_MISSED              = 6,
-    EVENT_DESPAWN_CHEST                 = 7,
-    EVENT_FAIL_HM                       = 8,
 
     EVENT_TRY_FREE_HELPER               = 10,
     EVENT_PRIEST_DISPELL_MAGIC          = 11,
@@ -258,12 +257,13 @@ struct boss_hodir : public BossAI
     void JustEngagedWith(Unit*  /*who*/) override
     {
         me->CastSpell(me, SPELL_BITING_COLD_BOSS_AURA, true);
+        // Hard mode timer: periodic dummy aura whose tick shatters the Rare Cache (sniffed on retail)
+        me->CastSpell(me, SPELL_SHATTER_CHEST_TIMER, true);
         SmallIcicles(true);
         events.Reset();
         events.ScheduleEvent(EVENT_FLASH_FREEZE, 48s, 49s);
         events.ScheduleEvent(EVENT_FREEZE, 17s, 20s);
         events.ScheduleEvent(EVENT_BERSERK, 8min);
-        events.ScheduleEvent(EVENT_HARD_MODE_MISSED, 3min);
         Talk(TEXT_AGGRO);
 
         // Helpers spawn IMMUNE_TO_NPC so idle bosses (e.g. Freya's Ground Tremor, #26330) can't tag
@@ -289,14 +289,13 @@ struct boss_hodir : public BossAI
         {
             switch (action)
             {
-                case EVENT_FAIL_HM:
+                case EVENT_HARD_MODE_MISSED:
+                    Talk(TEXT_HM_MISS);
+                    bAchievCacheRare = false;
                     if (instance)
                     {
                         if (GameObject* go = GetHardmodeChest())
-                        {
-                            go->SetGoState(GO_STATE_ACTIVE);
-                            events.ScheduleEvent(EVENT_DESPAWN_CHEST, 3s);
-                        }
+                            me->CastSpell(go, SPELL_SHATTER_CHEST, false);
                     }
                     break;
             }
@@ -408,21 +407,6 @@ struct boss_hodir : public BossAI
                     me->CastSpell(me, SPELL_BERSERK, true);
                     Talk(TEXT_BERSERK);
                 }
-                break;
-            case EVENT_HARD_MODE_MISSED:
-                {
-                    Talk(TEXT_HM_MISS);
-                    bAchievCacheRare = false;
-                    if (instance)
-                    {
-                        if (GameObject* go = GetHardmodeChest())
-                            me->CastSpell(go, SPELL_SHATTER_CHEST, false);
-                    }
-                }
-                break;
-            case EVENT_DESPAWN_CHEST:
-                if (instance && instance->GetBossState(BOSS_HODIR) != DONE)
-                    instance->SetData(TYPE_HODIR_HM_FAIL, 0);
                 break;
             case EVENT_FLASH_FREEZE:
                 {
@@ -1225,22 +1209,25 @@ struct npc_ulduar_hodir_mage : public ScriptedAI
     }
 };
 
-class spell_hodir_shatter_chest : public SpellScript
+class spell_hodir_shatter_chest_timer_aura : public AuraScript
 {
-    PrepareSpellScript(spell_hodir_shatter_chest);
+    PrepareAuraScript(spell_hodir_shatter_chest_timer_aura);
 
-    void DestroyWinterCache(SpellEffIndex effIndex)
+    bool Validate(SpellInfo const* /*spellInfo*/) override
     {
-        PreventHitDefaultEffect(effIndex);
+        return ValidateSpellInfo({ SPELL_SHATTER_CHEST });
+    }
 
-        if (Unit* hodir = GetCaster())
-            hodir->GetAI()->DoAction(EVENT_FAIL_HM);
+    void HandleEffectPeriodic(AuraEffect const* /*aurEff*/)
+    {
+        if (Unit* hodir = GetTarget())
+            hodir->GetAI()->DoAction(EVENT_HARD_MODE_MISSED);
     }
 
     void Register() override
     {
-        OnEffectHit += SpellEffectFn(spell_hodir_shatter_chest::DestroyWinterCache, EFFECT_0, SPELL_EFFECT_TRIGGER_MISSILE);
-    };
+        OnEffectPeriodic += AuraEffectPeriodicFn(spell_hodir_shatter_chest_timer_aura::HandleEffectPeriodic, EFFECT_0, SPELL_AURA_PERIODIC_DUMMY);
+    }
 };
 
 class spell_hodir_biting_cold_main_aura : public AuraScript
@@ -1599,7 +1586,7 @@ void AddSC_boss_hodir()
     RegisterUlduarCreatureAI(npc_ulduar_hodir_shaman);
     RegisterUlduarCreatureAI(npc_ulduar_hodir_mage);
 
-    RegisterSpellScript(spell_hodir_shatter_chest);
+    RegisterSpellScript(spell_hodir_shatter_chest_timer_aura);
     RegisterSpellScript(spell_hodir_biting_cold_main_aura);
     RegisterSpellScript(spell_hodir_biting_cold_player_aura);
     RegisterSpellScript(spell_hodir_periodic_icicle);

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp
@@ -326,6 +326,18 @@ public:
             // destory towers
             if (eventId >= EVENT_TOWER_OF_LIFE_DESTROYED && eventId <= EVENT_TOWER_OF_FLAMES_DESTROYED)
                 SetData(eventId, 0);
+            else if (eventId == EVENT_HODIR_SHATTER_CHEST)
+            {
+                if (GameObject* go = GetHodirChest(true))
+                {
+                    go->SetGoState(GO_STATE_ACTIVE);
+                    scheduler.Schedule(3s, [this](TaskContext /*context*/)
+                    {
+                        if (GetBossState(BOSS_HODIR) != DONE)
+                            SetData(TYPE_HODIR_HM_FAIL, 0);
+                    });
+                }
+            }
         }
 
         bool SetBossState(uint32 type, EncounterState state) override

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/ulduar.h
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/ulduar.h
@@ -356,6 +356,9 @@ enum UlduarMisc
     EVENT_TOWER_OF_FLAMES_DESTROYED         = 21033,
     EVENT_TOWER_OF_LIFE_DESTROYED           = 21030,
 
+    // Sent by Shatter Chest (62502), triggered by Hodir's hard mode timer missile (62501)
+    EVENT_HODIR_SHATTER_CHEST               = 20907,
+
     ACTION_LEVIATHAN_REFRESH_TOWERS         = -1,
     ACTION_TOWER_OF_STORM_DESTROYED         = 1,
     ACTION_TOWER_OF_FROST_DESTROYED         = 2,


### PR DESCRIPTION
## Changes Proposed:

Retail sniffs show that Hodir applies Shatter Chest (65272) to himself on engage. It is a 3 minute periodic dummy aura whose single tick (effect 0, 180s amplitude, matching the aura duration) is what shatters the Rare Cache when hard mode is missed. This PR replaces the scripted 3 minute event with that aura:

- Hodir casts 65272 on himself in `JustEngagedWith`; a new aura script fires the hard mode missed logic (yell, achievement flag, casting Shatter Chest 62501 at the cache) on the periodic tick. The spell's two other effects (the pre-nerf 2 minute ticks) are left unhandled.
- The 62501 missile chain now runs unblocked: Trigger Missile -> 62502 -> Send Script Event 20907. The `spell_hodir_shatter_chest` spell script that used `PreventHitDefaultEffect` to short-circuit this chain is removed, and the instance script handles event 20907 instead (chest to `GO_STATE_ACTIVE`, removed 3s later unless Hodir was defeated meanwhile). Players now see the missile actually fly at the cache.
- Timer cleanup on wipe or defeat comes for free from the existing `RemoveAllAuras()` calls, where the old version relied on `events.Reset()`.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Claude Fable 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- None

## SOURCE:
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [x] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Retail 12.0.7.68887 sniff of the Ulduar Hodir encounter (65272 cast at engage), spell data per Wowhead: [65272](https://www.wowhead.com/wotlk/spell=65272), [62501](https://www.wowhead.com/wotlk/spell=62501), [62502](https://www.wowhead.com/wotlk/spell=62502).

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Builds without errors (MSVC 2022, Release).

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Pull Hodir and stall for 3 minutes: at 3:00 he yells the hard mode miss line and a missile flies at the Rare Cache of Winter, which opens and despawns ~3s later.
2. Kill Hodir in under 3 minutes: the cache stays intact and lootable, and Rare Cache of Hodir (2179/2182) is granted.
3. Wipe before 3 minutes and re-pull: the timer restarts cleanly from the new engage.

## Known Issues and TODO List:

- [ ] The other two effects of 65272 (2 minute ticks, pre-nerf timer) are intentionally not handled.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
