### PR TITLE
fix(Scripts/Ulduar): use Icicle force-cast for Hodir Flash Freeze snowdrifts

### DIFF
--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_hodir.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_hodir.cpp
@@ -52,6 +52,7 @@ enum HodirSpellData
 
     SPELL_ICICLE_VISUAL_UNPACKED        = 62234,
     SPELL_ICICLE_VISUAL_PACKED          = 62462,
+    SPELL_ICICLE_PACKED_TBBA            = 62477,
     SPELL_ICICLE_VISUAL_FALLING         = 62453,
     SPELL_ICICLE_FALL_EFFECT_UNPACKED   = 62236,
     SPELL_ICICLE_FALL_EFFECT_PACKED     = 62460,
@@ -433,13 +434,8 @@ struct boss_hodir : public BossAI
                     targets.remove_if(Acore::ObjectTypeIdCheck(TYPEID_PLAYER, false));
                     targets.remove_if(Acore::UnitAuraCheck(true, SPELL_FLASH_FREEZE_TRAPPED_PLAYER));
                     Acore::Containers::RandomResize(targets, (RAID_MODE(2,3)));
-                    for (std::list<Unit*>::const_iterator itr = targets.begin(); itr != targets.end(); ++itr)
-                    {
-                        float prevZ = (*itr)->GetPositionZ();
-                        (*itr)->m_positionZ = 432.7f;
-                        (*itr)->CastSpell((*itr), SPELL_ICICLE_VISUAL_PACKED, true);
-                        (*itr)->m_positionZ = prevZ;
-                    }
+                    for (Unit* target : targets)
+                        me->CastSpell(target, SPELL_ICICLE_PACKED_TBBA, true); // Force-cast: victim casts Icicle (62462) on themselves
 
                     me->CastSpell((Unit*)nullptr, SPELL_FLASH_FREEZE_CAST, false);
                     me->PlayDirectSound(SOUND_HODIR_FLASH_FREEZE, 0);

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_hodir.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_hodir.cpp
@@ -435,7 +435,7 @@ struct boss_hodir : public BossAI
                     targets.remove_if(Acore::UnitAuraCheck(true, SPELL_FLASH_FREEZE_TRAPPED_PLAYER));
                     Acore::Containers::RandomResize(targets, (RAID_MODE(2,3)));
                     for (Unit* target : targets)
-                        me->CastSpell(target, SPELL_ICICLE_PACKED_TBBA, true); // Force-cast: victim casts Icicle (62462) on themselves
+                        me->CastSpell(target, SPELL_ICICLE_PACKED_TBBA, true); // Forces victim to cast Icicle (62462)
 
                     me->CastSpell((Unit*)nullptr, SPELL_FLASH_FREEZE_CAST, false);
                     me->PlayDirectSound(SOUND_HODIR_FLASH_FREEZE, 0);


### PR DESCRIPTION
## Changes Proposed:

Retail sniffs of the Ulduar Hodir encounter show that at Flash Freeze cast start, Hodir casts Icicle (62477) on each chosen victim. 62477 is a force-cast ("Trigger Spell from Target with Caster as Target"): the hit player casts the snowpacked icicle summon (62462) on themselves at their real position.

The script currently fakes this by making the selected players self-cast 62462 while temporarily overwriting their `m_positionZ` with a hardcoded 432.7f. This PR replaces that with Hodir casting 62477 on each victim, letting the DBC force-cast effect (`Spell::EffectForceCast`) produce the player self-cast, which matches the sniffed packets (player casts 62462 with self target, no dest).

Victim selection stays script-side (random unfrozen players, 2 in 10-player / 3 in 25-player) since 62477 carries no max-target count in DBC.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Claude Fable 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- None

## SOURCE:
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [x] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Retail 12.0.7.68887 sniff of the Ulduar Hodir encounter, spell data per Wowhead: [62477](https://www.wowhead.com/wotlk/spell=62477), [62462](https://www.wowhead.com/wotlk/spell=62462).

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Builds without errors (MSVC 2022, Release).

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Pull Hodir with several players and wait for Flash Freeze (~50s in).
2. At cast start, snowpacked icicles must appear above 2 (10-player) / 3 (25-player) random unfrozen players and drop snowdrifts, exactly as before the change.
3. Check the icicle spawn position on uneven ground (stairs, snow piles): it should match the victim's actual position.

## Known Issues and TODO List:

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
