### PR TITLE
fix(Core/Movement): followers now walk when their leader walks

### DIFF
--- a/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.cpp
@@ -458,6 +458,16 @@ static float GetTargetSpeedInMotion(Unit* target)
     return target->GetSpeed(target->m_movementInfo.GetSpeedType());
 }
 
+// A creature walking a path only carries walk mode on the spline, never in its movement
+// flags, so IsWalking() reads false for it and a follower would run after it and stutter.
+static bool IsTargetWalkingInMotion(Unit* target)
+{
+    if (!target->movespline->Finalized())
+        return target->movespline->IsWalking();
+
+    return target->IsWalking();
+}
+
 static Optional<float> GetVelocity(Unit* owner, Unit* target, G3D::Vector3 const& dest, bool playerPet)
 {
     Optional<float> speed = {};
@@ -705,7 +715,7 @@ bool FollowMovementGenerator<T>::DoUpdate(T* owner, uint32 time_diff)
         Movement::MoveSplineInit init(owner);
         init.MovebyPath(i_path->GetPath());
         if (_inheritWalkState)
-            init.SetWalk(target->IsWalking());
+            init.SetWalk(IsTargetWalkingInMotion(target));
 
         if (_inheritSpeed)
             if (Optional<float> velocity = GetVelocity(owner, target, i_path->GetActualEndPosition(), owner->IsGuardian()))

--- a/src/server/game/Movement/Spline/MoveSpline.cpp
+++ b/src/server/game/Movement/Spline/MoveSpline.cpp
@@ -167,6 +167,7 @@ namespace Movement
         vertical_acceleration = 0.f;
         effect_start_time = 0;
         velocity = args.velocity;
+        walk = args.walk;
 
         // Check if its a stop spline
         if (args.flags.done)
@@ -191,7 +192,8 @@ namespace Movement
     }
 
     MoveSpline::MoveSpline() : m_Id(0), time_passed(0),
-        vertical_acceleration(0.f), initialOrientation(0.f), velocity(0.f), effect_start_time(0), point_Idx(0), point_Idx_offset(0),
+        vertical_acceleration(0.f), initialOrientation(0.f), velocity(0.f), walk(false), effect_start_time(0),
+        point_Idx(0), point_Idx_offset(0),
         onTransport(false)
     {
         splineflags.done = true;

--- a/src/server/game/Movement/Spline/MoveSpline.h
+++ b/src/server/game/Movement/Spline/MoveSpline.h
@@ -65,6 +65,7 @@ namespace Movement
         float           vertical_acceleration;
         float           initialOrientation;
         float           velocity;
+        bool            walk;
         int32           effect_start_time;
         int32           point_Idx;
         int32           point_Idx_offset;
@@ -87,6 +88,9 @@ namespace Movement
         [[nodiscard]] MySpline const& _Spline() const { return spline; }
         [[nodiscard]] int32 _currentSplineIdx() const { return point_Idx; }
         [[nodiscard]] float Velocity() const { return velocity; }
+        // walk mode is picked per spline and never reaches the unit's movement flags,
+        // so IsWalking() can't answer this for a creature moving along a path
+        [[nodiscard]] bool IsWalking() const { return walk; }
         void _Finalize();
         void _Interrupt() { splineflags.done = true; }
 


### PR DESCRIPTION
## Changes Proposed:

NPCs set to follow a walking leader run after it instead, so they catch up, stop, wait, and run again. Janey Anship and the Stormwind school children are the visible cases.

A creature walking a waypoint path only carries walk mode on its **spline**, and that is deliberate. `MoveSplineInit` spells it out:

```cpp
// If spline is initialized with SetWalk method it only means we need to select
// walk move speed for it but not add walk flag to unit
```

So `MOVEMENTFLAG_WALKING` never reaches the leader's movement info, `Unit::IsWalking()` reads false for it, and `FollowMovementGenerator` asked exactly that before choosing how to move. The follower ran.

The follower now asks the leader's active spline instead, mirroring what `GetTargetSpeedInMotion` already does a few lines above for speed. `MoveSpline` keeps `velocity` from its init args already; it now keeps `walk` the same way and exposes it.

Deliberately **not** touching `inheritSpeed`. #26539 turned that off for SmartAI because inheriting the leader's exact speed "fixed one or several bugs, but it also caused a lot of errors", and flipping it back would reopen that. This only fixes the walk/run decision, so followers keep moving at their own walk speed, which is what stops the stutter.

That leaves one gap worth stating: a leader whose walk speed is modified by an aura would still not be matched exactly. Only speed inheritance covers that case, and it is the one with the regression history.

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Opus 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #26564
- Same report on the ChromieCraft tracker: chromiecraft/chromiecraft#9883

Related background, not changed here:
- #26539 set `inheritSpeed` to false for SmartAI follows. Left as is.
- #19498 added `inheritWalkState`. This makes it work for creature leaders moving along a path.

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

The issue carries video of the stutter, and a Wowhead screenshot of Suzanne walking.

Code inspection:

- `WaypointMovementGenerator` calls `init.SetWalk(true)` for `WAYPOINT_MOVE_TYPE_WALK`, and nothing calls `Unit::SetWalk` alongside it.
- `Unit::IsWalking()` only reads `m_movementInfo`, so it cannot see that.
- `MoveSpline::Initialize` already stores `velocity` from the init args, so storing `walk` follows the same shape.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Tested on a local Windows build (RelWithDebInfo).

Before, the followers ran and stuttered behind Janey Anship. After, they walk evenly behind her. Pets still follow at running speed and escort NPCs were unchanged.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. `.go c i 1413` and watch Janey Anship and whoever follows her. They should walk evenly behind her rather than run, stop and run again. Creature GUID 90439 and the school children around Suzanne (npc 1415) show the same thing.
2. Since this touches the follow generator rather than a script, worth confirming nothing that should run now walks: a pet following a running player, and escort NPCs.

## Known Issues and TODO List:

A leader with a modified walk speed is still not matched exactly, since followers use their own walk speed. Covering that needs speed inheritance, which #26539 disabled for SmartAI on purpose.

`SMART_ACTION_FOLLOW` still has no way to opt into `inheritSpeed` per script, as suggested in the #26539 review. It already uses all six action params, so that would need a schema change and is left out of here.

🤖 Generated with Claude Code (Opus 5)+AzerothMCP

<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs

When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
