### PR TITLE
fix(Scripts/Ulduar): filter Hodir Icicle force-cast targets

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1785688849378470400.sql
+++ b/data/sql/updates/pending_db_world/rev_1785688849378470400.sql
@@ -1,0 +1,5 @@
+--
+DELETE FROM `spell_script_names` WHERE `ScriptName` = 'spell_hodir_icicle_force_cast';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(62476, 'spell_hodir_icicle_force_cast'),
+(62477, 'spell_hodir_icicle_force_cast');

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_hodir.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_hodir.cpp
@@ -53,7 +53,8 @@ enum HodirSpellData
 
     SPELL_ICICLE_VISUAL_UNPACKED        = 62234,
     SPELL_ICICLE_VISUAL_PACKED          = 62462,
-    SPELL_ICICLE_PACKED_TBBA            = 62477,
+    SPELL_ICICLE_FORCE_CAST             = 62476,
+    SPELL_ICICLE_FORCE_CAST_H           = 62477,
     SPELL_ICICLE_VISUAL_FALLING         = 62453,
     SPELL_ICICLE_FALL_EFFECT_UNPACKED   = 62236,
     SPELL_ICICLE_FALL_EFFECT_PACKED     = 62460,
@@ -411,16 +412,7 @@ struct boss_hodir : public BossAI
                 break;
             case EVENT_FLASH_FREEZE:
                 {
-                    std::list<Unit*> targets;
-                    Map::PlayerList const& pl = me->GetMap()->GetPlayers();
-                    for (Map::PlayerList::const_iterator itr = pl.begin(); itr != pl.end(); ++itr)
-                        targets.push_back(itr->GetSource());
-                    targets.remove_if(Acore::ObjectTypeIdCheck(TYPEID_PLAYER, false));
-                    targets.remove_if(Acore::UnitAuraCheck(true, SPELL_FLASH_FREEZE_TRAPPED_PLAYER));
-                    Acore::Containers::RandomResize(targets, (RAID_MODE(2,3)));
-                    for (Unit* target : targets)
-                        me->CastSpell(target, SPELL_ICICLE_PACKED_TBBA, true); // Forces victim to cast Icicle (62462)
-
+                    DoCastSelf(RAID_MODE(SPELL_ICICLE_FORCE_CAST, SPELL_ICICLE_FORCE_CAST_H), true);
                     me->CastSpell((Unit*)nullptr, SPELL_FLASH_FREEZE_CAST, false);
                     me->PlayDirectSound(SOUND_HODIR_FLASH_FREEZE, 0);
                     Talk(TEXT_FLASH_FREEZE);
@@ -1338,6 +1330,24 @@ class spell_hodir_periodic_icicle : public SpellScript
     }
 };
 
+// 62476, 62477 - Icicle: force-casts the snowdrift icicle (62462) on the selected players
+class spell_hodir_icicle_force_cast : public SpellScript
+{
+    PrepareSpellScript(spell_hodir_icicle_force_cast);
+
+    void FilterTargets(std::list<WorldObject*>& targets)
+    {
+        targets.remove_if(Acore::ObjectTypeIdCheck(TYPEID_PLAYER, false));
+        targets.remove_if(Acore::UnitAuraCheck(true, SPELL_FLASH_FREEZE_TRAPPED_PLAYER));
+        Acore::Containers::RandomResize(targets, GetCaster()->GetMap()->Is25ManRaid() ? 3 : 2);
+    }
+
+    void Register() override
+    {
+        OnObjectAreaTargetSelect += SpellObjectAreaTargetSelectFn(spell_hodir_icicle_force_cast::FilterTargets, EFFECT_0, TARGET_UNIT_SRC_AREA_ENEMY);
+    }
+};
+
 class FlashFreezeCheck
 {
 public:
@@ -1586,6 +1596,7 @@ void AddSC_boss_hodir()
     RegisterSpellScript(spell_hodir_biting_cold_main_aura);
     RegisterSpellScript(spell_hodir_biting_cold_player_aura);
     RegisterSpellScript(spell_hodir_periodic_icicle);
+    RegisterSpellScript(spell_hodir_icicle_force_cast);
     RegisterSpellAndAuraScriptPair(spell_hodir_flash_freeze, spell_hodir_flash_freeze_aura);
     RegisterSpellScript(spell_hodir_storm_power_aura);
     RegisterSpellScript(spell_hodir_storm_cloud_aura);


### PR DESCRIPTION
## Changes Proposed:

Follow-up to #26911, fixing the group-play bug sudlud reported there. The Icicle force-cast (62476/62477) is an area spell centered on Hodir (`TARGET_UNIT_SRC_AREA_ENEMY`, 99 yards, no target cap), so the explicit unit target in the per-victim cast was ignored: every cast hit the whole raid, everyone got a snowdrift and its Safe Area aura, and Flash Freeze could no longer trap anyone. The solo sniff that motivated #26911 could not show this.

This PR ports TrinityCore's shape: Hodir self-casts the difficulty rank once (`RAID_MODE(62476, 62477)`) at Flash Freeze start, and a new `spell_hodir_icicle_force_cast` SpellScript trims EFFECT_0 / `TARGET_UNIT_SRC_AREA_ENEMY` to 2 (10-player) / 3 (25-player) random targets. Unlike TC's bare `RandomResize`, the filter also keeps only players not already flash frozen, mirroring the pre-existing selection and AC's own `spell_hodir_periodic_icicle`: Hodir's helper NPCs are his enemies and would otherwise consume icicles.

Committed with `--author` crediting offl, whose TrinityCore Hodir rewrite this is ported from: https://github.com/TrinityCore/TrinityCore/commit/24dcc1f2000d5063e0d09b4c5cdd04bd52d10dcc (https://github.com/TrinityCore/TrinityCore/pull/31682).

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Claude Fable 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- None (fixes the group-play bug @sudlud reported on #26911 after it was merged)

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

TrinityCore 3.3.5 `boss_hodir.cpp` (`spell_hodir_icicle_force_cast`), spell data per Wowhead: [62476](https://www.wowhead.com/wotlk/spell=62476), [62477](https://www.wowhead.com/wotlk/spell=62477).

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Builds without errors (MSVC 2022, Release).

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Pull Hodir with several players (more than 3) and wait for Flash Freeze.
2. Only 2 (10-player) / 3 (25-player) random unfrozen players get snowpacked icicles and snowdrifts, not the whole raid.
3. Players not on a snowdrift when the cast finishes are flash frozen; players on one are not.
4. Hodir's helper NPCs never receive icicles.

## Known Issues and TODO List:

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
