### PR TITLE
fix(Scripts/Spells): the Mage T8 4P bonus now works with Hot Streak and Brain Freeze

### DIFF
--- a/src/server/scripts/Spells/spell_mage.cpp
+++ b/src/server/scripts/Spells/spell_mage.cpp
@@ -1134,6 +1134,14 @@ class spell_mage_gen_extra_effects : public AuraScript
                 (spellInfo->SpellFamilyFlags[0] & 0x00000800)) // Arcane Missiles
                 return false;
         }
+
+        // T8 4P bonus: chance to keep the proc instead of spending it. Player::RemoveSpellMods
+        // has this too, but it bails out for anything with a spell_proc entry, which these have,
+        // so the charge is spent through the proc system and never reaches that check.
+        if (AuraEffect const* aurEff = caster->GetAuraEffect(SPELL_MAGE_T8_4P_BONUS, EFFECT_0))
+            if (roll_chance_i(aurEff->GetAmount()))
+                return false;
+
         return true;
     }
 


### PR DESCRIPTION
## Changes Proposed:

The Mage T8 4-piece bonus never fires for Hot Streak or Brain Freeze, so those procs are always spent.

The bonus is implemented, in `Player::RemoveSpellMods`, matching the three auras by SpellIconID. The problem is the guard a few lines above it:

```cpp
// don't handle spells with spell_proc entry defined
// this is a temporary workaround, because all spellmods should be handled like that
if (sSpellMgr->GetSpellProcEntry(mod->spellId))
    continue;
```

Missile Barrage (44401), Hot Streak (48108) and Brain Freeze (57761) all have a `spell_proc` entry with `Charges = 1`, added with the QAston proc port. Their charges are spent through the proc system, so that function returns early and the bonus check below it is dead code for exactly the three auras it was written for.

Missile Barrage still works, because `spell_mage_missile_barrage_proc` rolls the chance in its own `CheckProc`. Hot Streak and Brain Freeze share `spell_mage_gen_extra_effects`, which does not, so for them the bonus could never happen. This rolls it there too, the same way.

Left alone on purpose: the dead check in `Player::RemoveSpellMods`, since it still applies to any affected aura without a `spell_proc` entry, and the workaround comment above it suggests that guard is meant to go away eventually.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Opus 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #26386
- Same report on the ChromieCraft tracker: chromiecraft/chromiecraft#9625

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

The issue carries video of the procs always being consumed.

Code inspection:

- Set 836's 4-piece spell is 64869, whose effect 0 is a dummy aura with an amount of 10.
- SpellIconIDs 3261, 2999 and 2938 in the `Player::RemoveSpellMods` check do match Missile Barrage, Hot Streak and Brain Freeze, so that check is correct, just unreachable for them.
- `spell_script_names` maps 48108 and 57761 to `spell_mage_gen_extra_effects`, and 44401 to `spell_mage_missile_barrage_proc`.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Tested on a local Windows build (RelWithDebInfo) with a mage wearing 4 pieces of the set, temporarily logging what the check saw on every Pyroblast.

Before the change nothing ran at all for Hot Streak. After it, the check fires on each cast, finds the bonus aura with its amount of 10, and rolls. Forcing the roll to always succeed confirmed the end of it: the buff stays up and Pyroblast can be cast instantly again, which never happened before.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Mage with `.learn all my class`, then `.add 46130`, `.add 46132`, `.add 46133`, `.add 46134` and equip all four
2. `.aura 48108` to get Hot Streak without waiting for two fire crits, cast the instant Pyroblast, and repeat
3. Every so often the buff should survive the cast. It is a 1 in 10 chance, so it needs a fair number of tries
4. Same with Brain Freeze (`.aura 57761`) and Fireball. Missile Barrage with Arcane Missiles should behave as before, since it is untouched

## Known Issues and TODO List:

The chance comes from the bonus spell's own aura amount, which is 10. The issue notes that the sims commonly used for WotLK code it at 20%, so if anyone has a source for 20 the value is worth revisiting, but I did not want to override Blizzard's own data on the strength of sim code alone.

🤖 Generated with Claude Code (Opus 5)+AzerothMCP

<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs

When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
