### PR TITLE
fix(Scripts/Ulduar): rework Mimiron's Spinning Up cadence, arc anchoring and facing

### DIFF
--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_mimiron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_mimiron.cpp
@@ -1205,6 +1205,12 @@ private:
     uint8 _phase;
 };
 
+// Sniffed P3Wx2 Laser Barrage arcs start at a fixed room angle and advance 60 degrees
+// counterclockwise each cycle, independent of the player targeted during Spinning Up.
+// Phase 4 restarts the sequence from the initial angle.
+constexpr float VX001_BARRAGE_ARC_START = 6.17f;
+constexpr float VX001_BARRAGE_ARC_STEP = static_cast<float>(M_PI / 3);
+
 struct npc_ulduar_vx001 : public ScriptedAI
 {
     npc_ulduar_vx001(Creature* creature) : ScriptedAI(creature)
@@ -1218,8 +1224,8 @@ struct npc_ulduar_vx001 : public ScriptedAI
         _phase = 0;
         _fighting = false;
         _leftArm = false;
-        _spinningUpOrientation = 0;
-        _spinningUpTimer = 0;
+        _barrageOrientation = 0;
+        _nextBarrageArc = VX001_BARRAGE_ARC_START;
         me->SetRegeneratingHealth(false);
         _events.Reset();
     }
@@ -1241,6 +1247,7 @@ struct npc_ulduar_vx001 : public ScriptedAI
                 case 2:
                     _phase = 2;
                     _fighting = true;
+                    _nextBarrageArc = VX001_BARRAGE_ARC_START;
                     me->SetUInt32Value(UNIT_NPC_EMOTESTATE, EMOTE_ONESHOT_SPELL_CAST_OMNI);
                     me->RemoveUnitFlag(UNIT_FLAG_NOT_SELECTABLE);
                     _events.Reset();
@@ -1259,6 +1266,7 @@ struct npc_ulduar_vx001 : public ScriptedAI
                 case 4:
                     _phase = 4;
                     _fighting = true;
+                    _nextBarrageArc = VX001_BARRAGE_ARC_START;
                     me->RemoveUnitFlag(UNIT_FLAG_NOT_SELECTABLE);
                     _events.Reset();
                     _events.ScheduleEvent(EVENT_REINSTALL_ROCKETS, 3s);
@@ -1275,7 +1283,7 @@ struct npc_ulduar_vx001 : public ScriptedAI
 
     uint32 GetData(uint32  /*id*/) const override
     {
-        return _spinningUpOrientation;
+        return _barrageOrientation;
     }
 
     void DoAction(int32 action) override
@@ -1339,19 +1347,6 @@ struct npc_ulduar_vx001 : public ScriptedAI
 
         _events.Update(diff);
 
-        if (_spinningUpTimer) // executed about a second after starting casting to ensure players can see the correct direction
-        {
-            if (_spinningUpTimer <= diff)
-            {
-                float angle = (_spinningUpOrientation * 2 * M_PI) / 100.0f;
-                me->SetFacingTo(angle);
-
-                _spinningUpTimer = 0;
-            }
-            else
-                _spinningUpTimer -= diff;
-        }
-
         if (me->HasUnitState(UNIT_STATE_CASTING))
             return;
 
@@ -1414,15 +1409,15 @@ struct npc_ulduar_vx001 : public ScriptedAI
                 _events.Repeat(1750ms);
                 break;
             case EVENT_SPELL_SPINNING_UP:
-                _events.Repeat(45s);
-                if (Player* p = SelectTargetFromPlayerList(80.0f))
+                _events.Repeat(60s);
                 {
-                    float angle = me->GetAngle(p);
+                    float arc = _nextBarrageArc;
 
-                    _spinningUpOrientation = (uint32)((angle * 100.0f) / (2 * M_PI));
-                    _spinningUpTimer = 1500;
-                    me->SetFacingTo(angle);
-                    me->CastSpell(p, SPELL_SPINNING_UP, true);
+                    _barrageOrientation = (uint32)((arc * 100.0f) / (2 * M_PI));
+                    _nextBarrageArc = Position::NormalizeOrientation(arc + VX001_BARRAGE_ARC_STEP);
+                    // The beams follow unit facing, so facing the arc start doubles as the telegraph
+                    me->SetFacingTo(arc);
+                    me->CastSpell(me, SPELL_SPINNING_UP, true);
                     if (Unit* vehicle = me->GetVehicleBase())
                     {
                         vehicle->SetUInt32Value(UNIT_NPC_EMOTESTATE, EMOTE_STATE_CUSTOM_SPELL_01);
@@ -1497,8 +1492,8 @@ private:
     bool _isEvading;
     bool _fighting;
     bool _leftArm;
-    uint32 _spinningUpOrientation;
-    uint16 _spinningUpTimer;
+    uint32 _barrageOrientation;
+    float _nextBarrageArc;
     uint8 _phase;
 };
 


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Reworks VX-001's Spinning Up / P3Wx2 Laser Barrage based on a fresh retail sniff of a full Mimiron kill (12.0.7.68887, normal mode):

- Spinning Up repeats every 60s instead of 45s. The sniff shows a steady 62.2s cast-to-cast cadence in phase 2 and 61.1s in phase 4 across 9 cycles (the existing 30s initial delay matches the sniff and is unchanged).
- The barrage arc is decoupled from players. Sniffed arcs start at a fixed room angle (~6.17 rad measured from VX-001's position) and advance exactly 60 degrees counterclockwise each cycle, with phase 4 restarting the sequence. The previous behavior of starting the sweep on a randomly picked player does not occur in the sniff.
- Spinning Up is cast on self, without turning towards a player. The sniffed casts carry target flags Self with no unit target, and VX-001's facing holds its spawn orientation through the entire fight (every FaceDirection packet repeats ~3.815 rad). The script now faces the arc start at cast time instead, which doubles as the player-visible telegraph since 3.3.5 renders the beams along unit facing.

The sweep direction (clockwise) and rate were left unchanged; the sniffed rate (~10.8 deg/s) is close to the script's 12 deg/s.

Caveat: the evidence is a modern retail sniff, so the deterministic arc pattern could in principle be a later rework. A WotLK-era sniff would settle it definitively; the packet structure (63414 self-cast, 4s lead-in, 63274 with 250ms ticks, 10s barrage) matches the 3.3.5 DBC data exactly, which supports the mechanics being unchanged.

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Fable 5), used for sniff analysis and drafting the changes.
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:

## SOURCE:
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [x] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Retail sniff of a complete Mimiron encounter plus in-game observation on retail that VX-001 does not turn towards a player when Spinning Up starts. Sniff available on request.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Builds without errors (MSVC 2022, Release). Verified in-game against Mimiron.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Start the Mimiron encounter and reach phase 2 (VX-001).
2. Observe Spinning Up: VX-001 should not snap towards a player; it should face the arc start and begin the laser barrage there roughly once per minute.
3. Over consecutive barrages, the start direction should advance 60 degrees counterclockwise each cycle.
4. Reach phase 4 and verify the same behavior, with the arc sequence restarting from its initial direction.

## Known Issues and TODO List:

- [ ] Rapid Burst still turns VX-001 towards its target each cast, which the same sniff shows retail not doing; left for a follow-up since it only affects where the burst visual points.

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
