### PR TITLE
fix(Scripts/Ulduar): icicles should not destroy Hodir's Toasty Fires

### DIFF
--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_hodir.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_hodir.cpp
@@ -691,17 +691,6 @@ struct npc_ulduar_toasty_fire : public NullCreatureAI
             me->DespawnOrUnsummon(); // this will remove DynObjects
         }
     }
-
-    void SpellHit(Unit*  /*caster*/, SpellInfo const* spell) override
-    {
-        switch (spell->Id)
-        {
-            case SPELL_ICE_SHARDS_SMALL:
-            case SPELL_ICE_SHARDS_BIG:
-                DoAction(1);
-                break;
-        }
-    }
 };
 
 struct npc_ulduar_hodir_priest : public ScriptedAI


### PR DESCRIPTION
## Changes Proposed:

Remove the `SpellHit` handler on `npc_ulduar_toasty_fire` that despawned the campfire when hit by Ice Shards (62457/65370). Only Flash Freeze should clear Toasty Fires, and that path already exists: the boss removes every fire in range when Flash Freeze Visual (62148) hits.

## Issues Addressed:

- Closes #26904

## SOURCE:

Retail sniff (12.0.7.68887): Ice Shards hit the same Toasty Fire NPCs repeatedly over six seconds, including one direct 65370 hit, and none despawned. All five fires and their gameobjects were destroyed in a single object update about a second after Flash Freeze landed. Details in the issue comments.

TrinityCore has the same Ice Shards despawn with a comment admitting sniffs and videos don't show it. It matches the WotLK Classic footage linked in the issue.

## Tests Performed:

- Builds clean (Release).
- Verified against the sniff timeline above.

## How to Test the Changes:

1. `.tele Hodir`, engage, free the mages and wait for Toasty Campfires.
2. Let an Icicle land on a campfire: it must survive.
3. Wait for Flash Freeze: all campfires must be removed when it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)