### PR TITLE
fix(Scripts/Ulduar): stop Hodir mages from starving their own spell schedule

### DIFF
--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_hodir.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_hodir.cpp
@@ -733,7 +733,7 @@ struct npc_ulduar_hodir_priest : public ScriptedAI
         if (spell->Id == SPELL_FLASH_FREEZE_TRAPPED_NPC)
         {
             events.Reset();
-            events.ScheduleEvent(EVENT_TRY_FREE_HELPER, 2s);
+            events.ScheduleEvent(EVENT_TRY_FREE_HELPER, 1s);
         }
     }
 
@@ -758,7 +758,7 @@ struct npc_ulduar_hodir_priest : public ScriptedAI
                                     ScheduleAbilities();
                                     break;
                                 }
-                    events.Repeat(2s);
+                    events.Repeat(1s);
                 }
                 break;
             case EVENT_PRIEST_DISPELL_MAGIC:
@@ -849,7 +849,7 @@ struct npc_ulduar_hodir_druid : public ScriptedAI
         if (spell->Id == SPELL_FLASH_FREEZE_TRAPPED_NPC)
         {
             events.Reset();
-            events.ScheduleEvent(EVENT_TRY_FREE_HELPER, 2s);
+            events.ScheduleEvent(EVENT_TRY_FREE_HELPER, 1s);
         }
     }
 
@@ -874,7 +874,7 @@ struct npc_ulduar_hodir_druid : public ScriptedAI
                                     ScheduleAbilities();
                                     break;
                                 }
-                    events.Repeat(2s);
+                    events.Repeat(1s);
                 }
                 break;
             case EVENT_DRUID_WRATH:
@@ -958,7 +958,7 @@ struct npc_ulduar_hodir_shaman : public ScriptedAI
     void ScheduleAbilities()
     {
         events.ScheduleEvent(EVENT_SHAMAN_LAVA_BURST, 2600ms);
-        events.ScheduleEvent(EVENT_SHAMAN_STORM_CLOUD, 10s);
+        events.ScheduleEvent(EVENT_SHAMAN_STORM_CLOUD, 1s);
     }
 
     void SpellHit(Unit* /*caster*/, SpellInfo const* spell) override
@@ -966,7 +966,7 @@ struct npc_ulduar_hodir_shaman : public ScriptedAI
         if (spell->Id == SPELL_FLASH_FREEZE_TRAPPED_NPC)
         {
             events.Reset();
-            events.ScheduleEvent(EVENT_TRY_FREE_HELPER, 2s);
+            events.ScheduleEvent(EVENT_TRY_FREE_HELPER, 1s);
         }
     }
 
@@ -999,7 +999,7 @@ struct npc_ulduar_hodir_shaman : public ScriptedAI
                                     ScheduleAbilities();
                                     break;
                                 }
-                    events.Repeat(2s);
+                    events.Repeat(1s);
                 }
                 break;
             case EVENT_SHAMAN_LAVA_BURST:
@@ -1091,7 +1091,7 @@ struct npc_ulduar_hodir_mage : public ScriptedAI
         if (spell->Id == SPELL_FLASH_FREEZE_TRAPPED_NPC)
         {
             events.Reset();
-            events.ScheduleEvent(EVENT_TRY_FREE_HELPER, 2s);
+            events.ScheduleEvent(EVENT_TRY_FREE_HELPER, 1s);
         }
     }
 
@@ -1116,7 +1116,7 @@ struct npc_ulduar_hodir_mage : public ScriptedAI
                                     ScheduleAbilities();
                                     break;
                                 }
-                    events.Repeat(2s);
+                    events.Repeat(1s);
                 }
                 break;
             case EVENT_MAGE_FIREBALL:
@@ -1143,7 +1143,6 @@ struct npc_ulduar_hodir_mage : public ScriptedAI
 
                     if (found)
                     {
-                        events.DelayEvents(2s);
                         events.Repeat(2s);
                         break;
                     }


### PR DESCRIPTION
## Changes Proposed:

- Remove the `events.DelayEvents(2s)` call from the mage helper's Melt Ice handler. It pushed every other mage event back 2s per Melt Ice cast, so Fireball and Conjure Toasty Fire never ran while any Flash Freeze block was alive.
- Schedule the shaman helper's Storm Cloud 1s after it starts acting instead of 10s.
- Poll the unfreeze check (`EVENT_TRY_FREE_HELPER`) every 1s instead of 2s in all four helper AIs.

## Issues Addressed:

- Closes #26906
- Closes #26907

## SOURCE:

Retail sniff (12.0.7.68887): freed helpers start casting within about a second of breaking out, Melt Ice interleaves with the rest of the mage kit (no starvation), a freed mage drops its first campfire about 6.5s after being freed, and shamans open with Storm Cloud about 1-3s after acting. Detailed timeline in the issue comments.

TrinityCore schedules all helper abilities at 0s from unfreeze with no cross-delaying; cmangos DB spell lists use Storm Cloud initial 1s and Melt Ice initial 1-2s. Neither delays other abilities while melting ice.

## Tests Performed:

- Builds clean (Release).
- Verified timings against the sniff timeline above.

## How to Test the Changes:

1. `.tele Hodir`, engage, break the mages out of their ice blocks.
2. Freed mages must start casting within about a second and drop the first Toasty Campfire roughly 7s after breaking out, even while other ice blocks are still up.
3. Freed shamans must cast Storm Cloud within a couple of seconds instead of 10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)