### PR TITLE
fix(DB/Ulduar): Guardian of Yogg-Saron Shadow Nova double-hitting Sara

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1785719531527450600.sql
+++ b/data/sql/updates/pending_db_world/rev_1785719531527450600.sql
@@ -1,0 +1,9 @@
+-- Guardian of Yogg-Saron: Shadow Nova (62714) entry-targeted effect must hit other Guardians (33136),
+-- not Sara, who is already hit by the dedicated Shadow Nova (65719). Fixes double 25k damage on Sara.
+DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 13) AND (`SourceGroup` = 2) AND (`SourceEntry` = 62714) AND (`SourceId` = 0);
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(13, 2, 62714, 0, 0, 31, 0, 3, 33136, 0, 0, 0, 0, '', 'Shadow Nova');
+
+-- Remove dead condition: creatures keep their normal entry (33134) in all difficulties,
+-- so a check against Sara's 25-man difficulty entry (34332) can never match.
+DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 13) AND (`SourceGroup` = 1) AND (`SourceEntry` = 65719) AND (`SourceId` = 0) AND (`ElseGroup` = 1) AND (`ConditionValue2` = 34332);


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

When a Guardian of Yogg-Saron dies, the script casts two spells (same as TrinityCore): Shadow Nova (62714) and a second Shadow Nova (65719) whose entry-restricted effect is meant to deal the single 25k hit to Sara. Our `conditions` row for 62714 effect 1 targeted Sara (33134) instead of other Guardians of Yogg-Saron (33136), so Sara was hit by both spells for ~50k per guardian death.

This PR:
- points the 62714 effect 1 condition at 33136, matching TrinityCore's condition data (TDB 335) and restoring the nova chaining onto nearby guardians. Script parity for the double cast: https://github.com/TrinityCore/TrinityCore/blob/3.3.5/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yogg_saron.cpp#L1168-L1172
- removes the dead 65719 condition against Sara's 25-man difficulty entry (34332): creatures always keep their normal entry regardless of difficulty (https://github.com/azerothcore/azerothcore-wotlk/blob/master/src/server/game/Entities/Creature/Creature.cpp#L509), so that row can never match.

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (claude-fable-5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/26776

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Wowhead's Yogg-Saron guide describes a single 25k Shadow Nova hit on Sara per guardian death: https://www.wowhead.com/wotlk/guide/raids/ulduar/yogg-saron-strategy. Condition values match TrinityCore's TDB 335.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Engage Yogg-Saron and spawn a Guardian of Yogg-Saron by walking onto a cloud.
2. Kill the guardian next to Sara (`.damage 2000000`).
3. Sara should take a single 25000 Shadow Nova hit in the combat log, not two.

## Known Issues and TODO List:

<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
