### PR TITLE
fix(Scripts/Ulduar): allow immunities to free players from Yogg-Saron's Constrictor Tentacle

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1785720451234545500.sql
+++ b/data/sql/updates/pending_db_world/rev_1785720451234545500.sql
@@ -1,0 +1,5 @@
+--
+DELETE FROM `spell_script_names` WHERE `spell_id` IN (64125, 64126) AND `ScriptName` = 'spell_yogg_saron_squeeze_aura';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(64125, 'spell_yogg_saron_squeeze_aura'),
+(64126, 'spell_yogg_saron_squeeze_aura');

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
@@ -1728,6 +1728,12 @@ struct boss_yoggsaron_constrictor_tentacle : public ScriptedAI
             me->RemoveAura(SPELL_SHATTERED_ILLUSION);
     }
 
+    void PassengerBoarded(Unit* passenger, int8 /*seatId*/, bool apply) override
+    {
+        if (!apply)
+            passenger->RemoveAurasDueToSpell(sSpellMgr->GetSpellIdForDifficulty(SPELL_SQUEEZE, passenger));
+    }
+
     void JustDied(Unit*) override
     {
         if (Unit* player = ObjectAccessor::GetUnit(*me, _playerGUID))
@@ -2836,6 +2842,26 @@ class spell_yogg_saron_constrictor_tentacle_aura : public AuraScript
     }
 };
 
+// 64125, 64126 - Squeeze
+class spell_yogg_saron_squeeze_aura : public AuraScript
+{
+    PrepareAuraScript(spell_yogg_saron_squeeze_aura);
+
+    // Immunities (Divine Shield, Ice Block, ...) purge this aura; killing the
+    // tentacle on removal is what actually frees the player from the vehicle.
+    void OnRemove(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
+    {
+        if (Unit* vehicle = GetTarget()->GetVehicleBase())
+            if (vehicle->IsAlive())
+                vehicle->KillSelf();
+    }
+
+    void Register() override
+    {
+        AfterEffectRemove += AuraEffectRemoveFn(spell_yogg_saron_squeeze_aura::OnRemove, EFFECT_0, SPELL_AURA_PERIODIC_DAMAGE, AURA_EFFECT_HANDLE_REAL);
+    }
+};
+
 // 63305 - Grim Reprisal
 class spell_yogg_saron_grim_reprisal_aura : public AuraScript
 {
@@ -2968,6 +2994,7 @@ void AddSC_boss_yoggsaron()
     RegisterSpellScript(spell_yogg_saron_in_the_maws_of_the_old_god);
     RegisterSpellScript(spell_yogg_saron_target_selectors);
     RegisterSpellScript(spell_yogg_saron_constrictor_tentacle_aura);
+    RegisterSpellScript(spell_yogg_saron_squeeze_aura);
     RegisterSpellScript(spell_yogg_saron_grim_reprisal_aura);
 
     // ACHIEVEMENTS


### PR DESCRIPTION
## Changes Proposed:
Immunity effects that purge debuffs (Divine Shield, Ice Block, Blessing of Protection) remove the Squeeze aura from a player grabbed by Yogg-Saron's Constrictor Tentacle, but nothing released the player: they stayed seated on the tentacle vehicle until it was killed externally. On retail, gaining an immunity frees the player instantly.

This ports the missing pieces from TrinityCore:
- `spell_yogg_saron_squeeze_aura` (64125/64126): when the Squeeze aura is removed, the tentacle vehicle is killed, which releases the passenger.
- `PassengerBoarded` on the Constrictor Tentacle AI: leaving the vehicle strips the difficulty-mapped Squeeze aura.
- `spell_script_names` bindings for both the 10-man (64125) and 25-man (64126) spell ids.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Claude Fable 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #26926

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Ported from TrinityCore, committed with `--author` crediting the original author (horn):
- https://github.com/TrinityCore/TrinityCore/commit/0a0698b1d41cca4ae19f84b1c62c97d2964e13a5 (original Yogg-Saron script, Squeeze aura script and PassengerBoarded hook)
- https://github.com/TrinityCore/TrinityCore/commit/5ac40cf9d159a74ebb36d06821d4f895afc974c4 (25-man spell id binding and difficulty-mapped aura removal)

Behavior reference: https://www.wowhead.com/wotlk/guide/raids/ulduar/yogg-saron-strategy ("Immunity effects such as Blessing of Protection, Divine Shield or Ice Block also free the player instantly.")

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Builds without errors (MSVC, Release). Tested in-game on Windows: grabbed by a Constrictor Tentacle in phase 2, using an immunity kills the tentacle and frees the player; killing the tentacle normally still releases the player as before.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Engage Yogg-Saron with a level 80 Mage or Paladin and bring the encounter to phase 2.
2. Get grabbed by a Constrictor Tentacle (Squeeze aura, riding the tentacle).
3. Use Ice Block, Divine Shield or Blessing of Protection.
4. The tentacle should die and release the player immediately.
5. Also verify the unchanged path: without immunities, killing the tentacle still frees the player.

## Known Issues and TODO List:

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
