### PR TITLE
fix(Core/Vehicles): allow passengers to attack the vehicle carrying them

### DIFF
--- a/src/server/game/Entities/Player/PlayerUpdates.cpp
+++ b/src/server/game/Entities/Player/PlayerUpdates.cpp
@@ -164,9 +164,14 @@ void Player::Update(uint32 p_time)
             // default combat reach 10
             /// @todo add weapon, skill check
 
+            // A vehicle passenger can neither turn nor move, and their stored position and
+            // orientation can be stale; never fail swing range or facing against the vehicle
+            // carrying them (e.g. Yogg-Saron's Constrictor Tentacle grab).
+            bool const victimIsVehicleBase = GetVehicleBase() == victim;
+
             if (isAttackReady(BASE_ATTACK))
             {
-                if (!IsWithinMeleeRange(victim))
+                if (!victimIsVehicleBase && !IsWithinMeleeRange(victim))
                 {
                     setAttackTimer(BASE_ATTACK, 100);
                     if (m_swingErrorMsg != 1) // send single time (client auto repeat)
@@ -176,7 +181,7 @@ void Player::Update(uint32 p_time)
                     }
                 }
                 // 120 degrees of radiant range, if player is not in boundary radius
-                else if (!IsWithinBoundaryRadius(victim) && !HasInArc(2 * float(M_PI) / 3, victim))
+                else if (!victimIsVehicleBase && !IsWithinBoundaryRadius(victim) && !HasInArc(2 * float(M_PI) / 3, victim))
                 {
                     setAttackTimer(BASE_ATTACK, 100);
                     if (m_swingErrorMsg != 2) // send single time (client auto repeat)
@@ -206,9 +211,9 @@ void Player::Update(uint32 p_time)
 
             if (HasOffhandWeaponForAttack() && isAttackReady(OFF_ATTACK))
             {
-                if (!IsWithinMeleeRange(victim))
+                if (!victimIsVehicleBase && !IsWithinMeleeRange(victim))
                     setAttackTimer(OFF_ATTACK, 100);
-                else if (!IsWithinBoundaryRadius(victim) && !HasInArc(2 * float(M_PI) / 3, victim))
+                else if (!victimIsVehicleBase && !IsWithinBoundaryRadius(victim) && !HasInArc(2 * float(M_PI) / 3, victim))
                     setAttackTimer(BASE_ATTACK, 100);
                 else
                 {

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -7123,6 +7123,11 @@ SpellCastResult Spell::CheckRange(bool strict)
     {
         if (target != m_caster)
         {
+            // A vehicle passenger can neither turn nor move, and their stored position and
+            // orientation can be stale; never fail range or facing against the vehicle
+            // carrying them (e.g. Yogg-Saron's Constrictor Tentacle grab).
+            bool const targetIsVehicleBase = m_caster->GetVehicleBase() == target;
+
             // Xinef: Spells with 5yd range can hit target 9yd away?
             if (range_type == SPELL_RANGE_MELEE)
             {
@@ -7133,13 +7138,13 @@ SpellCastResult Spell::CheckRange(bool strict)
                 else
                     real_max_range -= 2 * MIN_MELEE_REACH;
 
-                if (!m_caster->IsWithinMeleeRange(target, std::max(real_max_range, 0.0f)))
+                if (!targetIsVehicleBase && !m_caster->IsWithinMeleeRange(target, std::max(real_max_range, 0.0f)))
                     return SPELL_FAILED_OUT_OF_RANGE;
             }
-            else if (!m_caster->IsWithinCombatRange(target, max_range))
+            else if (!targetIsVehicleBase && !m_caster->IsWithinCombatRange(target, max_range))
                 return SPELL_FAILED_OUT_OF_RANGE; //0x5A;
 
-            if (m_caster->IsPlayer() && (m_spellInfo->FacingCasterFlags & SPELL_FACING_FLAG_INFRONT) && !m_caster->HasInArc(static_cast<float>(M_PI), target) && !m_caster->IsWithinBoundaryRadius(target))
+            if (!targetIsVehicleBase && m_caster->IsPlayer() && (m_spellInfo->FacingCasterFlags & SPELL_FACING_FLAG_INFRONT) && !m_caster->HasInArc(static_cast<float>(M_PI), target) && !m_caster->IsWithinBoundaryRadius(target))
                 return SPELL_FAILED_UNIT_NOT_INFRONT;
         }
 


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

When a player is grabbed by a grab-type vehicle such as Yogg-Saron's Constrictor Tentacle (Squeeze), the server keeps the stale pre-boarding position and orientation reported by the client's root ack: the boarding spline is zero-length (start equals end in transport space) and finalizes instantly, then `CMSG_FORCE_MOVE_ROOT_ACK` relocates the player back to where they stood when grabbed. Since the seat has no `VEHICLE_SEAT_FLAG_ALLOW_TURNING`, the player can never change that facing again, and the tentacle can spawn up to 8 yd away from its victim (spell 64133, EffectRadiusIndex 14) with a model whose bounding radius and combat reach are 0. As a result, facing and melee range checks against the tentacle pass or fail depending purely on where the player stood and faced at the moment of the grab, which matches the inconsistent behavior described in the issue.

Fix: skip spell range, spell facing and melee swing range/facing checks when the target is the caster's own vehicle base. A seated passenger physically cannot turn or move, so these checks can only produce false negatives against the vehicle carrying them.

Notes:

- This only relaxes range/facing. Target validity is untouched, so passengers still cannot attack a friendly vehicle they ride (siege engines, mounts). The seat flag gate is also untouched: seats without `VEHICLE_SEAT_FLAG_CAN_ATTACK` (e.g. Kologarn's Stone Grip, seats 3690-3692) still block all attacks from the seat, which is retail-correct there.
- Ranged minimum range (`SPELL_FAILED_TOO_CLOSE`) is intentionally kept, so hunters still cannot Auto Shot the tentacle holding them.
- TrinityCore (3.3.5 and master) and cmangos have the same bug class; there was nothing to cherry-pick, all three cores use the same vehicle-ride grab (64131/64123) with no passenger exemption in their facing checks.

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Fable 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #26925

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Retail reference from the issue: https://youtu.be/Y2__yntqv2c?si=CJkohFWaaeJjicGY&t=579 (grabbed players freely DPS the constrictor). Mechanics verified against Spell.dbc, Vehicle.dbc and VehicleSeat.dbc (seat 3788: `CAN_ATTACK` set, `ALLOW_TURNING` not set).

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Builds without errors (Windows 11, VS 2022, Release).

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Follow the issue's reproduction steps to reach Yogg-Saron P2 and get grabbed by a Constrictor Tentacle, ideally while running away from where it erupts.
2. While grabbed, cast facing-required spells and melee abilities at the tentacle and enable auto-attack. Everything should work on every grab, regardless of your facing when grabbed.
3. Regression: since the changed checks are generic, also verify normal gameplay is unaffected (see the test checklist comment below).

## Known Issues and TODO List:

- [ ] Cone and positional requirements (e.g. Cone of Cold's arc, Backstab's behind-target check) still evaluate the stale position/orientation while grabbed. Out of scope here; would need the passenger's server position to be pinned to the seat.

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
