### PR TITLE
fix(apps/installer): let DEBIAN_FRONTEND survive sudo on Ubuntu

### DIFF
--- a/apps/installer/includes/os_configs/ubuntu.sh
+++ b/apps/installer/includes/os_configs/ubuntu.sh
@@ -29,17 +29,17 @@ esac
 $SUDO apt update
 
 # shared deps
-DEBIAN_FRONTEND="noninteractive" $SUDO \
+$SUDO DEBIAN_FRONTEND="noninteractive" \
 apt-get -y install ccache clang cmake curl make unzip jq screen tmux \
   libreadline-dev libbz2-dev git gcc g++ libssl-dev \
   libncurses-dev libboost-all-dev gdb gdbserver expect
 
 # version-specific deps
 if [[ "$UBUNTU_VERSION" == "26.04" ]]; then
-  DEBIAN_FRONTEND="noninteractive" $SUDO \
+  $SUDO DEBIAN_FRONTEND="noninteractive" \
   apt-get -y install libgoogle-perftools-dev default-libmysqlclient-dev
 else
-  DEBIAN_FRONTEND="noninteractive" $SUDO \
+  $SUDO DEBIAN_FRONTEND="noninteractive" \
   apt-get -y install google-perftools libmysqlclient-dev libncurses5-dev libncursesw5-dev
 fi
 
@@ -53,10 +53,10 @@ if [[ $DOCKER != 1 && $SKIP_MYSQL_INSTALL != 1 ]]; then
     wget https://dev.mysql.com/get/mysql-apt-config_0.8.35-1_all.deb -P "$VAR_PATH"
     # resolve expired key issue
     sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A8D3785C
-    DEBIAN_FRONTEND="noninteractive" $SUDO dpkg -i "$VAR_PATH/mysql-apt-config_0.8.35-1_all.deb"
+    $SUDO DEBIAN_FRONTEND="noninteractive" dpkg -i "$VAR_PATH/mysql-apt-config_0.8.35-1_all.deb"
     $SUDO apt-get update
   fi
-  DEBIAN_FRONTEND="noninteractive" $SUDO apt-get install -y mysql-server
+  $SUDO DEBIAN_FRONTEND="noninteractive" apt-get install -y mysql-server
 fi
 
 


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

None of the above: this touches the Ubuntu installer script.

`ubuntu.sh` sets `DEBIAN_FRONTEND="noninteractive"` before `$SUDO`. With sudo's default `env_reset` the variable never reaches `apt-get` or `dpkg`, so every `install-deps` run as a non-root user stays interactive. It only worked when the script ran as root, where `$SUDO` is empty. The MySQL steps are where this actually bites, since that is what prompts through debconf.

Setting it after `$SUDO` works in both cases: sudo accepts a `VAR=value` assignment before the command, and with `$SUDO` empty it is a plain command prefix. `debian.sh` already uses this form.

Spotted by Copilot while reviewing #26940. Kept separate from that PR since it changes behaviour on all Ubuntu versions, not just 26.04. Both touch the same block, so whichever lands second needs a trivial rebase.

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Claude Opus 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:

- None

## SOURCE:

The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Not applicable. See `sudo(8)` on `env_reset`, and the existing pattern in `apps/installer/includes/os_configs/debian.sh`.

## Tests Performed:

This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

`bash -n` passes. Not run end to end on a fresh Ubuntu machine.

## How to Test the Changes:

- [x] This pull request requires further testing. Provide steps to test your changes.

1. On an Ubuntu machine, as a non-root user with sudo rights, run `./acore.sh install-deps`
2. The MySQL installation should not stop on a debconf prompt

## Known Issues and TODO List:

- [ ] None

## How to Test AzerothCore PRs

When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
