### PR TITLE
fix(Scripts/Ulduar): correct Thorim gauntlet immunity staging

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1785749167609908400.sql
+++ b/data/sql/updates/pending_db_world/rev_1785749167609908400.sql
@@ -1,0 +1,2 @@
+-- Runic Colossus and Ancient Rune Giant spawn immune to players until activated (sniff build 68887)
+UPDATE `creature_template` SET `unit_flags` = `unit_flags` | 256, `VerifiedBuild` = 68887 WHERE `entry` IN (32872, 32873);

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_thorim.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_thorim.cpp
@@ -457,11 +457,11 @@ struct boss_thorim : public BossAI
                 if (GameObject* go = GetThorimObject(DATA_THORIM_LEVER))
                     go->RemoveGameObjectFlag((GameObjectFlags)48);
 
-                // Iron Ring Guards spawn with UNIT_FLAG_IMMUNE_TO_PC until the arena event starts
+                // Iron Ring Guards and the Runic Colossus spawn with UNIT_FLAG_IMMUNE_TO_PC until the arena event starts
                 summons.DoForAllSummons([](WorldObject* obj)
                 {
                     if (Creature* c = obj->ToCreature())
-                        if (c->GetEntry() == NPC_IRON_RING_GUARD)
+                        if (c->EntryEquals(NPC_IRON_RING_GUARD, NPC_RUNIC_COLOSSUS))
                             c->RemoveUnitFlag(UNIT_FLAG_IMMUNE_TO_PC);
                 });
 
@@ -1288,6 +1288,10 @@ struct boss_thorim_runic_colossus : public ScriptedAI
                 if (Creature* cr = me->GetInstanceScript()->GetCreature(BOSS_THORIM))
                     cr->AI()->Talk(SAY_SPECIAL_2);
             }
+
+            // The Ancient Rune Giant stays immune to players until the colossus falls
+            if (Creature* giant = me->FindNearestCreature(NPC_ANCIENT_RUNE_GIANT, 200.0f))
+                giant->RemoveUnitFlag(UNIT_FLAG_IMMUNE_TO_PC);
         }
 
         void JustEngagedWith(Unit*) override

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_thorim.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_thorim.cpp
@@ -457,11 +457,11 @@ struct boss_thorim : public BossAI
                 if (GameObject* go = GetThorimObject(DATA_THORIM_LEVER))
                     go->RemoveGameObjectFlag((GameObjectFlags)48);
 
-                // Iron Ring Guard / Iron Honor Guard spawn with UNIT_FLAG_IMMUNE_TO_PC
+                // Iron Ring Guards spawn with UNIT_FLAG_IMMUNE_TO_PC until the arena event starts
                 summons.DoForAllSummons([](WorldObject* obj)
                 {
                     if (Creature* c = obj->ToCreature())
-                        if (c->GetEntry() == NPC_IRON_RING_GUARD || c->GetEntry() == NPC_IRON_HONOR_GUARD)
+                        if (c->GetEntry() == NPC_IRON_RING_GUARD)
                             c->RemoveUnitFlag(UNIT_FLAG_IMMUNE_TO_PC);
                 });
 


### PR DESCRIPTION
Follow-up to #26746, verified against a retail Thorim sniff (12.0.7.68887) and TrinityCore 3.3.5.

## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Two changes:

- Drop Iron Honor Guard (32875) from the immunity clear added in #26746. It has `unit_flags` 0 in our DB and TC's, and spawns attackable in the sniff, so that branch was a no-op based on a wrong premise.
- Stage the miniboss immunity like retail and TC: Runic Colossus (32872) and Ancient Rune Giant (32873) now spawn with `UNIT_FLAG_IMMUNE_TO_PC` (DB update, `VerifiedBuild` 68887). The colossus is freed together with the Iron Ring Guards when the arena event starts; the giant only once the colossus dies. In the sniff the colossus is cleared in the same `SMSG_UPDATE_OBJECT` batch as the ring guards at encounter start, and the giant in the same batch as the colossus death. TC does the same:
https://github.com/TrinityCore/TrinityCore/blob/3.3.5/src/server/scripts/Northrend/Ulduar/Ulduar/boss_thorim.cpp#L632-L638
https://github.com/TrinityCore/TrinityCore/blob/3.3.5/src/server/scripts/Northrend/Ulduar/Ulduar/boss_thorim.cpp#L1440-L1444

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Fable 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Follow-up to #26746 (no standalone issue)

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [x] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:
- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Apply the pending world SQL update and enter Ulduar 10, start the Thorim encounter.
2. Before killing the six pre-arena adds: Iron Ring Guards, Runic Colossus and Ancient Rune Giant must be unattackable; Iron Honor Guards attackable. The colossus must still fire Runic Smash down the hallway.
3. Kill the pre-arena adds: ring guards and colossus become attackable, the giant stays immune.
4. Kill the colossus: the giant becomes attackable.

## Known Issues and TODO List:

- [ ]
- [ ]

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.