### PR TITLE
fix(Scripts/BoreanTundra): Rewrite Nerub'ar Victims and 'Taken by the Scourge'

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1785881720771385700.sql
+++ b/data/sql/updates/pending_db_world/rev_1785881720771385700.sql
@@ -12,6 +12,7 @@ INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Lan
 DELETE FROM `creature_text` WHERE (`CreatureID` = 25414);
 INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `TextRange`, `comment`) VALUES
 (25414, 0, 0, 'My axe is yours, hero! Together we will destroy these insects!', 12, 1, 100, 5, 0, 0, 24614, 0, 'Warsong Hold Warrior - Released'),
+(25414, 0, 1, 'We will battle together to rid this quarry of the Scourge!', 12, 1, 100, 5, 0, 0, 24623, 0, 'Warsong Hold Warrior - Released'),
 (25414, 1, 0, 'I must return to Warsong Hold. Battle hard, hero!', 12, 1, 100, 0, 0, 0, 24615, 0, 'Warsong Hold Warrior - Dismissed'),
 (25414, 1, 1, 'I must return to Warsong Hold, hero. May you swim in the blood of our enemies and feast upon their sorrow!', 12, 1, 100, 0, 0, 0, 24616, 0, 'Warsong Hold Warrior - Dismissed'),
 (25414, 1, 2, 'Farewell, friend. I must return to Warsong Hold.', 12, 1, 100, 0, 0, 0, 24617, 0, 'Warsong Hold Warrior - Dismissed'),
@@ -46,20 +47,20 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 25414;
 DELETE FROM `smart_scripts` WHERE (`source_type` = 0 AND `entryorguid` = 25414);
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
-(25414, 0, 0, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 45517, 0, 0, 0, 0, 0, 21, 40, 0, 0, 0, 0, 0, 0, 0, 'Warsong Hold Warrior - On Just Summoned - Cast \'Commanding Shout\''),
+(25414, 0, 0, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 45517, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Warsong Hold Warrior - On Just Summoned - Cast \'Commanding Shout\''),
 (25414, 0, 1, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Warsong Hold Warrior - On Just Summoned - Say Line 0'),
 (25414, 0, 2, 0, 0, 0, 100, 0, 0, 0, 8400, 17000, 0, 0, 11, 15284, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Warsong Hold Warrior - In Combat - Cast \'Cleave\''),
 (25414, 0, 3, 0, 1, 0, 100, 1, 90000, 90000, 0, 0, 0, 0, 80, 2541400, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Warsong Hold Warrior - Out of Combat - Run Script (No Repeat)'),
-(25414, 0, 4, 0, 34, 0, 100, 0, 8, 1, 0, 0, 0, 0, 41, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Warsong Hold Warrior - On Reached Point 1 - Despawn Instant'),
-(25414, 0, 5, 0, 6, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 45522, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Warsong Hold Warrior - On Just Died - Cast \'Dispel Freed Soldier Debuff\''),
-(25414, 0, 6, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 0, 8, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Warsong Hold Warrior - On Just Summoned - Set Reactstate Defensive');
+(25414, 0, 4, 0, 6, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 45522, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Warsong Hold Warrior - On Just Died - Cast \'Dispel Freed Soldier Debuff\''),
+(25414, 0, 5, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 0, 8, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Warsong Hold Warrior - On Just Summoned - Set Reactstate Defensive');
 
 DELETE FROM `smart_scripts` WHERE (`source_type` = 9 AND `entryorguid` = 2541400);
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
 (2541400, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Warsong Hold Warrior - Actionlist - Set Reactstate Passive'),
 (2541400, 9, 1, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Warsong Hold Warrior - Actionlist - Say Line 1'),
-(2541400, 9, 2, 0, 0, 0, 100, 0, 3200, 3200, 0, 0, 0, 0, 69, 1, 0, 0, 0, 0, 0, 202, 30, 0, 1, 0, 0, 0, 0, 0, 'Warsong Hold Warrior - Actionlist - Move To Random Point'),
-(2541400, 9, 3, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 45522, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Warsong Hold Warrior - Actionlist - Cast \'Dispel Freed Soldier Debuff\'');
+(2541400, 9, 2, 0, 0, 0, 100, 0, 3200, 3200, 0, 0, 0, 0, 69, 0, 0, 1, 0, 0, 0, 202, 30, 0, 1, 0, 0, 0, 0, 0, 'Warsong Hold Warrior - Actionlist - Move To Random Point'),
+(2541400, 9, 3, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 45522, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Warsong Hold Warrior - Actionlist - Cast \'Dispel Freed Soldier Debuff\''),
+(2541400, 9, 4, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 41, 3000, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Warsong Hold Warrior - Actionlist - Despawn Self');
 
 UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 25421;
 DELETE FROM `smart_scripts` WHERE (`source_type` = 0 AND `entryorguid` = 25421);
@@ -67,9 +68,8 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 (25421, 0, 0, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Warsong Hold Shaman - On Just Summoned - Say Line'),
 (25421, 0, 1, 0, 0, 0, 100, 0, 0, 0, 12000, 16000, 0, 0, 11, 15499, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Warsong Hold Shaman - In Combat - Cast \'Frost Shock\''),
 (25421, 0, 2, 0, 1, 0, 100, 1, 90000, 90000, 0, 0, 0, 0, 80, 2542100, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Warsong Hold Shaman - Out of Combat - Run Script (No Repeat)'),
-(25421, 0, 3, 0, 34, 0, 100, 0, 8, 1, 0, 0, 0, 0, 41, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Warsong Hold Shaman - On Reached Point 1 - Despawn Instant'),
-(25421, 0, 4, 0, 6, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 45522, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Warsong Hold Shaman - On Just Died - Cast \'Dispel Freed Soldier Debuff\''),
-(25421, 0, 5, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 0, 8, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Warsong Hold Shaman - On Just Summoned - Set Reactstate Defensive');
+(25421, 0, 3, 0, 6, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 45522, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Warsong Hold Shaman - On Just Died - Cast \'Dispel Freed Soldier Debuff\''),
+(25421, 0, 4, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 0, 8, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Warsong Hold Shaman - On Just Summoned - Set Reactstate Defensive');
 
 DELETE FROM `smart_scripts` WHERE (`source_type` = 9 AND `entryorguid` = 2542100);
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
@@ -77,17 +77,22 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 (2542100, 9, 1, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Warsong Hold Shaman - Actionlist - Say Line 1'),
 (2542100, 9, 2, 0, 0, 0, 100, 0, 3000, 3000, 0, 0, 0, 0, 11, 45528, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Warsong Hold Shaman - Actionlist - Cast \'Ghost Wolf\''),
 (2542100, 9, 3, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 45522, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Warsong Hold Shaman - Actionlist - Cast \'Dispel Freed Soldier Debuff\''),
-(2542100, 9, 4, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 69, 1, 0, 0, 0, 0, 0, 202, 30, 0, 1, 0, 0, 0, 0, 0, 'Warsong Hold Shaman - Actionlist - Move To Random Point');
+(2542100, 9, 4, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 69, 0, 0, 1, 0, 0, 0, 202, 30, 0, 1, 0, 0, 0, 0, 0, 'Warsong Hold Shaman - Actionlist - Move To Random Point'),
+(2542100, 9, 5, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 41, 3000, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Warsong Hold Shaman - Actionlist - Despawn Self');
 
 UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 25270;
 DELETE FROM `smart_scripts` WHERE (`source_type` = 0 AND `entryorguid` = 25270);
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
-(25270, 0, 0, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 0, 80, 2527000, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Warsong Peon - On Just Summoned - Run Script'),
-(25270, 0, 1, 0, 34, 0, 100, 0, 8, 1, 0, 0, 0, 0, 41, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Warsong Peon - On Reached Point 1 - Despawn Instant');
+(25270, 0, 0, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 0, 80, 2527000, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Warsong Peon - On Just Summoned - Run Script');
 
 DELETE FROM `smart_scripts` WHERE (`source_type` = 9 AND `entryorguid` = 2527000);
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
 (2527000, 9, 0, 0, 0, 0, 100, 0, 1200, 1200, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Warsong Peon - Actionlist - Say Line 0'),
-(2527000, 9, 1, 0, 0, 0, 100, 0, 2000, 2000, 0, 0, 0, 0, 69, 1, 0, 0, 0, 0, 0, 202, 30, 0, 1, 0, 0, 0, 0, 0, 'Warsong Peon - Actionlist - Move To Random Point');
+(2527000, 9, 1, 0, 0, 0, 100, 0, 2000, 2000, 0, 0, 0, 0, 69, 1, 0, 1, 0, 0, 0, 202, 30, 0, 1, 0, 0, 0, 0, 0, 'Warsong Peon - Actionlist - Move To Random Point'),
+(2527000, 9, 2, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 41, 1600, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Warsong Peon - Actionlist - Despawn Self');
 
 UPDATE `creature_text` SET `Emote` = 5 WHERE (`CreatureID` = 25270);
+
+-- Wow. Never needed to change a class before.
+UPDATE `creature_template` SET `unit_class` = 2 WHERE (`entry` = 25421);
+UPDATE `creature_template` SET `unit_class` = 2 WHERE (`entry` = 25420);

--- a/data/sql/updates/pending_db_world/rev_1785881720771385700.sql
+++ b/data/sql/updates/pending_db_world/rev_1785881720771385700.sql
@@ -1,0 +1,93 @@
+--
+DELETE FROM `spell_script_names` WHERE `spell_id` = 45522;
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES (45522, 'spell_dispel_freed_soldier_debuff');
+
+DELETE FROM `creature_text` WHERE (`CreatureID` = 25421);
+INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `TextRange`, `comment`) VALUES
+(25421, 0, 0, 'Rescued! You have my thanks and my aid, friend.', 12, 1, 100, 5, 0, 0, 24622, 0, 'Warsong Hold Shaman - Released'),
+(25421, 0, 1, 'We will battle together to rid this quarry of the Scourge!', 12, 1, 100, 5, 0, 0, 24623, 0, 'Warsong Hold Shaman - Released'),
+(25421, 1, 0, 'Ancestors be with you, hero. Farewell!', 12, 1, 100, 0, 0, 0, 24621, 0, 'Warsong Hold Shaman - Dismissed'),
+(25421, 1, 1, 'Spirits watch over you, friend. I must make my return to Warsong Hold.', 12, 1, 100, 0, 0, 0, 24620, 0, 'Warsong Hold Shaman - Dismissed');
+
+DELETE FROM `creature_text` WHERE (`CreatureID` = 25414);
+INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `TextRange`, `comment`) VALUES
+(25414, 0, 0, 'My axe is yours, hero! Together we will destroy these insects!', 12, 1, 100, 5, 0, 0, 24614, 0, 'Warsong Hold Warrior - Released'),
+(25414, 1, 0, 'I must return to Warsong Hold. Battle hard, hero!', 12, 1, 100, 0, 0, 0, 24615, 0, 'Warsong Hold Warrior - Dismissed'),
+(25414, 1, 1, 'I must return to Warsong Hold, hero. May you swim in the blood of our enemies and feast upon their sorrow!', 12, 1, 100, 0, 0, 0, 24616, 0, 'Warsong Hold Warrior - Dismissed'),
+(25414, 1, 2, 'Farewell, friend. I must return to Warsong Hold.', 12, 1, 100, 0, 0, 0, 24617, 0, 'Warsong Hold Warrior - Dismissed'),
+(25414, 1, 3, 'Until we meet again, hero. Duty calls!', 12, 1, 100, 0, 0, 0, 24618, 0, 'Warsong Hold Warrior - Dismissed');
+
+DELETE FROM `creature_text` WHERE (`CreatureID` = 25420);
+INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `TextRange`, `comment`) VALUES
+(25420, 0, 0, 'By the fury of the Sunwell, I am released!', 12, 1, 100, 5, 0, 0, 24624, 0, 'Warsong Hold Mage - Released'),
+(25420, 0, 1, 'Vengeance shall be mine! For Quel\'thalas! For the sin\'dorei!', 12, 1, 100, 5, 0, 0, 24625, 0, 'Warsong Hold Mage - Released'),
+(25420, 1, 0, 'Farewell, friend. I must return to Warsong Hold.', 12, 1, 100, 0, 0, 0, 24617, 0, 'Warsong Hold Mage - Dismissed'),
+(25420, 1, 1, 'Until we meet again, hero. Duty calls!', 12, 1, 100, 0, 0, 0, 24618, 0, 'Warsong Hold Mage - Dismissed');
+
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 25420;
+DELETE FROM `smart_scripts` WHERE (`source_type` = 0 AND `entryorguid` = 25420);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(25420, 0, 0, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 45525, 0, 0, 0, 0, 0, 21, 40, 0, 0, 0, 0, 0, 0, 0, 'Warsong Hold Mage - On Just Summoned - Cast \'Arcane Intellect\''),
+(25420, 0, 1, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Warsong Hold Mage - On Just Summoned - Say Line'),
+(25420, 0, 2, 0, 0, 0, 100, 0, 0, 0, 3400, 4800, 0, 0, 11, 14034, 64, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Warsong Hold Mage - In Combat - Cast \'Fireball\''),
+(25420, 0, 3, 0, 1, 0, 100, 1, 90000, 90000, 0, 0, 0, 0, 80, 2542000, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Warsong Hold Mage - Out of Combat - Run Script (No Repeat)'),
+(25420, 0, 4, 0, 6, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 45522, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Warsong Hold Mage - On Just Died - Cast \'Dispel Freed Soldier Debuff\''),
+(25420, 0, 5, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 0, 8, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Warsong Hold Mage - On Just Summoned - Set Reactstate Defensive');
+
+DELETE FROM `smart_scripts` WHERE (`source_type` = 9 AND `entryorguid` = 2542000);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(2542000, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Warsong Hold Mage - Actionlist - Set Reactstate Passive'),
+(2542000, 9, 1, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Warsong Hold Mage - Actionlist - Say Line 1'),
+(2542000, 9, 2, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 103, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Warsong Hold Mage - Actionlist - Set Rooted On'),
+(2542000, 9, 3, 0, 0, 0, 100, 0, 3400, 3400, 0, 0, 0, 0, 11, 45522, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Warsong Hold Mage - Actionlist - Cast \'Dispel Freed Soldier Debuff\''),
+(2542000, 9, 4, 0, 0, 0, 100, 0, 200, 200, 0, 0, 0, 0, 11, 41232, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Warsong Hold Mage - Actionlist - Cast \'Teleport Visual Only\''),
+(2542000, 9, 5, 0, 0, 0, 100, 0, 1600, 1600, 0, 0, 0, 0, 41, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Warsong Hold Mage - Actionlist - Despawn Instant');
+
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 25414;
+DELETE FROM `smart_scripts` WHERE (`source_type` = 0 AND `entryorguid` = 25414);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(25414, 0, 0, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 45517, 0, 0, 0, 0, 0, 21, 40, 0, 0, 0, 0, 0, 0, 0, 'Warsong Hold Warrior - On Just Summoned - Cast \'Commanding Shout\''),
+(25414, 0, 1, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Warsong Hold Warrior - On Just Summoned - Say Line 0'),
+(25414, 0, 2, 0, 0, 0, 100, 0, 0, 0, 8400, 17000, 0, 0, 11, 15284, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Warsong Hold Warrior - In Combat - Cast \'Cleave\''),
+(25414, 0, 3, 0, 1, 0, 100, 1, 90000, 90000, 0, 0, 0, 0, 80, 2541400, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Warsong Hold Warrior - Out of Combat - Run Script (No Repeat)'),
+(25414, 0, 4, 0, 34, 0, 100, 0, 8, 1, 0, 0, 0, 0, 41, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Warsong Hold Warrior - On Reached Point 1 - Despawn Instant'),
+(25414, 0, 5, 0, 6, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 45522, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Warsong Hold Warrior - On Just Died - Cast \'Dispel Freed Soldier Debuff\''),
+(25414, 0, 6, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 0, 8, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Warsong Hold Warrior - On Just Summoned - Set Reactstate Defensive');
+
+DELETE FROM `smart_scripts` WHERE (`source_type` = 9 AND `entryorguid` = 2541400);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(2541400, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Warsong Hold Warrior - Actionlist - Set Reactstate Passive'),
+(2541400, 9, 1, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Warsong Hold Warrior - Actionlist - Say Line 1'),
+(2541400, 9, 2, 0, 0, 0, 100, 0, 3200, 3200, 0, 0, 0, 0, 69, 1, 0, 0, 0, 0, 0, 202, 30, 0, 1, 0, 0, 0, 0, 0, 'Warsong Hold Warrior - Actionlist - Move To Random Point'),
+(2541400, 9, 3, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 45522, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Warsong Hold Warrior - Actionlist - Cast \'Dispel Freed Soldier Debuff\'');
+
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 25421;
+DELETE FROM `smart_scripts` WHERE (`source_type` = 0 AND `entryorguid` = 25421);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(25421, 0, 0, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Warsong Hold Shaman - On Just Summoned - Say Line'),
+(25421, 0, 1, 0, 0, 0, 100, 0, 0, 0, 12000, 16000, 0, 0, 11, 15499, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Warsong Hold Shaman - In Combat - Cast \'Frost Shock\''),
+(25421, 0, 2, 0, 1, 0, 100, 1, 90000, 90000, 0, 0, 0, 0, 80, 2542100, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Warsong Hold Shaman - Out of Combat - Run Script (No Repeat)'),
+(25421, 0, 3, 0, 34, 0, 100, 0, 8, 1, 0, 0, 0, 0, 41, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Warsong Hold Shaman - On Reached Point 1 - Despawn Instant'),
+(25421, 0, 4, 0, 6, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 45522, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Warsong Hold Shaman - On Just Died - Cast \'Dispel Freed Soldier Debuff\''),
+(25421, 0, 5, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 0, 8, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Warsong Hold Shaman - On Just Summoned - Set Reactstate Defensive');
+
+DELETE FROM `smart_scripts` WHERE (`source_type` = 9 AND `entryorguid` = 2542100);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(2542100, 9, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Warsong Hold Shaman - Actionlist - Set Reactstate Passive'),
+(2542100, 9, 1, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Warsong Hold Shaman - Actionlist - Say Line 1'),
+(2542100, 9, 2, 0, 0, 0, 100, 0, 3000, 3000, 0, 0, 0, 0, 11, 45528, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Warsong Hold Shaman - Actionlist - Cast \'Ghost Wolf\''),
+(2542100, 9, 3, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 11, 45522, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Warsong Hold Shaman - Actionlist - Cast \'Dispel Freed Soldier Debuff\''),
+(2542100, 9, 4, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 69, 1, 0, 0, 0, 0, 0, 202, 30, 0, 1, 0, 0, 0, 0, 0, 'Warsong Hold Shaman - Actionlist - Move To Random Point');
+
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 25270;
+DELETE FROM `smart_scripts` WHERE (`source_type` = 0 AND `entryorguid` = 25270);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(25270, 0, 0, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 0, 80, 2527000, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Warsong Peon - On Just Summoned - Run Script'),
+(25270, 0, 1, 0, 34, 0, 100, 0, 8, 1, 0, 0, 0, 0, 41, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Warsong Peon - On Reached Point 1 - Despawn Instant');
+
+DELETE FROM `smart_scripts` WHERE (`source_type` = 9 AND `entryorguid` = 2527000);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(2527000, 9, 0, 0, 0, 0, 100, 0, 1200, 1200, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Warsong Peon - Actionlist - Say Line 0'),
+(2527000, 9, 1, 0, 0, 0, 100, 0, 2000, 2000, 0, 0, 0, 0, 69, 1, 0, 0, 0, 0, 0, 202, 30, 0, 1, 0, 0, 0, 0, 0, 'Warsong Peon - Actionlist - Move To Random Point');
+
+UPDATE `creature_text` SET `Emote` = 5 WHERE (`CreatureID` = 25270);

--- a/src/server/scripts/Northrend/zone_borean_tundra.cpp
+++ b/src/server/scripts/Northrend/zone_borean_tundra.cpp
@@ -253,51 +253,74 @@ enum Nerubar
     SPELL_FREED_WARSONG_MAGE                = 45526,
     SPELL_FREED_WARSONG_SHAMAN              = 45527,
     SPELL_FREED_WARSONG_WARRIOR             = 45514,
-    SPELL_FREED_WARSONG_PEON                = 45532
+    SPELL_FREED_WARSONG_PEON                = 45532,
+    SPELL_FREED_SOLDIER_DEBUFF              = 45523,
+
+    MAX_FREED_SOLDIERS                      = 3
 };
 
-const uint32 nerubarVictims[3] =
+// A cocoon holds exactly one random captive. If that captive cannot be freed
+// then nothing comes out of it at all.
+uint32 const nerubarCaptiveSpells[4] =
 {
-    SPELL_FREED_WARSONG_MAGE, SPELL_FREED_WARSONG_SHAMAN, SPELL_FREED_WARSONG_WARRIOR
+    SPELL_FREED_WARSONG_PEON, SPELL_FREED_WARSONG_WARRIOR, SPELL_FREED_WARSONG_MAGE, SPELL_FREED_WARSONG_SHAMAN
 };
 
-class npc_nerubar_victim : public CreatureScript
+struct npc_nerubar_victim : public NullCreatureAI
 {
-public:
-    npc_nerubar_victim() : CreatureScript("npc_nerubar_victim") { }
+    npc_nerubar_victim(Creature* creature) : NullCreatureAI(creature) { }
 
-    struct npc_nerubar_victimAI : public NullCreatureAI
+    void JustDied(Unit* killer) override
     {
-        npc_nerubar_victimAI(Creature* creature) : NullCreatureAI(creature) { }
+        if (!killer)
+            return;
 
-        void JustDied(Unit* killer) override
+        Player* player = killer->GetCharmerOrOwnerPlayerOrPlayerItself();
+        if (!player)
+            return;
+
+        uint32 captiveSpell = nerubarCaptiveSpells[urand(0, 3)];
+
+        if (captiveSpell == SPELL_FREED_WARSONG_PEON)
         {
-            if (!killer || !killer->IsPlayer())
-            {
+            // peons are only freed while their rescue is still being asked for
+            if (player->GetQuestStatus(QUEST_TAKEN_BY_THE_SCOURGE) != QUEST_STATUS_INCOMPLETE)
                 return;
-            }
 
-            Player* player = killer->ToPlayer();
-
-            if (player->GetQuestStatus(QUEST_TAKEN_BY_THE_SCOURGE) == QUEST_STATUS_INCOMPLETE)
-            {
-                uint8 uiRand = urand(0, 99);
-                if (uiRand < 40)
-                {
-                    player->CastSpell(me, SPELL_FREED_WARSONG_PEON, true);
-                    player->KilledMonsterCredit(NPC_WARSONG_PEON);
-                }
-                else if (uiRand < 80)
-                {
-                    player->CastSpell(me, nerubarVictims[urand(0, 2)], true);
-                }
-            }
+            player->CastSpell(me, captiveSpell, true);
+            player->KilledMonsterCredit(NPC_WARSONG_PEON);
+            return;
         }
-    };
 
-    CreatureAI* GetAI(Creature* creature) const override
+        // freeing a soldier stacks a hidden debuff on the player, one stack per soldier,
+        // and no further ones are freed while it is full
+        if (Aura const* freedSoldiers = player->GetAura(SPELL_FREED_SOLDIER_DEBUFF))
+            if (freedSoldiers->GetStackAmount() >= MAX_FREED_SOLDIERS)
+                return;
+
+        player->CastSpell(me, captiveSpell, true);
+    }
+};
+
+// 45522 - Dispel Freed Soldier Debuff
+class spell_dispel_freed_soldier_debuff : public SpellScript
+{
+    PrepareSpellScript(spell_dispel_freed_soldier_debuff);
+
+    bool Validate(SpellInfo const* /*spellInfo*/) override
     {
-        return new npc_nerubar_victimAI(creature);
+        return ValidateSpellInfo({ SPELL_FREED_SOLDIER_DEBUFF });
+    }
+
+    void HandleScriptEffect(SpellEffIndex /* effIndex */)
+    {
+        // cast by a freed soldier on its summoner when it leaves, giving the slot back
+        GetHitUnit()->RemoveAuraFromStack(SPELL_FREED_SOLDIER_DEBUFF);
+    }
+
+    void Register() override
+    {
+        OnEffectHitTarget += SpellEffectFn(spell_dispel_freed_soldier_debuff::HandleScriptEffect, EFFECT_0, SPELL_EFFECT_SCRIPT_EFFECT);
     }
 };
 
@@ -1338,7 +1361,8 @@ void AddSC_borean_tundra()
     RegisterSpellScript(spell_q11919_q11940_drake_hunt_aura);
     new npc_sinkhole_kill_credit();
     new npc_khunok_the_behemoth();
-    new npc_nerubar_victim();
+    RegisterCreatureAI(npc_nerubar_victim);
+    RegisterSpellScript(spell_dispel_freed_soldier_debuff);
     new npc_lurgglbr();
     RegisterSpellScript(spell_arcane_chains_character_force_cast);
     new npc_imprisoned_beryl_sorcerer();

--- a/src/server/scripts/Northrend/zone_borean_tundra.cpp
+++ b/src/server/scripts/Northrend/zone_borean_tundra.cpp
@@ -259,8 +259,6 @@ enum Nerubar
     MAX_FREED_SOLDIERS                      = 3
 };
 
-// A cocoon holds exactly one random captive. If that captive cannot be freed
-// then nothing comes out of it at all.
 uint32 const nerubarCaptiveSpells[4] =
 {
     SPELL_FREED_WARSONG_PEON, SPELL_FREED_WARSONG_WARRIOR, SPELL_FREED_WARSONG_MAGE, SPELL_FREED_WARSONG_SHAMAN
@@ -283,7 +281,6 @@ struct npc_nerubar_victim : public NullCreatureAI
 
         if (captiveSpell == SPELL_FREED_WARSONG_PEON)
         {
-            // peons are only freed while their rescue is still being asked for
             if (player->GetQuestStatus(QUEST_TAKEN_BY_THE_SCOURGE) != QUEST_STATUS_INCOMPLETE)
                 return;
 
@@ -292,8 +289,7 @@ struct npc_nerubar_victim : public NullCreatureAI
             return;
         }
 
-        // freeing a soldier stacks a hidden debuff on the player, one stack per soldier,
-        // and no further ones are freed while it is full
+        // freeing a soldier stacks a hidden debuff on the player, one stack per soldier
         if (Aura const* freedSoldiers = player->GetAura(SPELL_FREED_SOLDIER_DEBUFF))
             if (freedSoldiers->GetStackAmount() >= MAX_FREED_SOLDIERS)
                 return;
@@ -314,7 +310,7 @@ class spell_dispel_freed_soldier_debuff : public SpellScript
 
     void HandleScriptEffect(SpellEffIndex /* effIndex */)
     {
-        // cast by a freed soldier on its summoner when it leaves, giving the slot back
+        // cast by a freed soldier on its summoner when it leaves
         GetHitUnit()->RemoveAuraFromStack(SPELL_FREED_SOLDIER_DEBUFF);
     }
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [X] Scripts (bosses, spell scripts, creature scripts).
-  [X] Database (SAI, creatures, etc).

Only 3 guardians at any time
Give guardians spells. And this one took a while to figure out, but they were all set as class warrior for some reason. So corrected that as well.
Handling follows Retail to the best as we could figure out. The summon spells adds an invisible stack on the player, up to 3. This is the counter that is checked to know if summoning is possible.
When they are dismissed, they cast ID - 45522 Dispel Freed Soldier Debuff, a script effect, that we made take away a single stack.
Guardians stay for 90s and are dismissed, following a simple RP scene (Ghost Wolf or Teleport for Shamans and Mages)
Also added lines

If you have a full party (3 guardians) or are not on the quest, there is no summon. That also follows retail.

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [X] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Opus for the scripts and troubleshooting
- [ ] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/22625

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [X] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

68974

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [X] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. .tele warsonghold
2. .quest add 11611
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
