### PR TITLE
fix(DB/Quest): Venomhide dailies now keep coming until the mount quest is handed in

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1785903104675032100.sql
+++ b/data/sql/updates/pending_db_world/rev_1785903104675032100.sql
@@ -1,0 +1,13 @@
+-- The dailies were gated on the mount quest being incomplete, but that status runs off a cached
+-- counter that can disagree with the bags, and then the last tooth can never be obtained. Carrying
+-- the hatchling lasts exactly as long as the quest and cannot drift.
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 19 AND `SourceGroup` = 0 AND `SourceEntry` IN (13889, 13903, 13904, 13905, 13914, 13915, 13916, 13917);
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(19, 0, 13889, 0, 0, 2, 0, 46362, 1, 0, 0, 0, 0, '', 'Show quest \'Hungry, Hungry Hatchling\' only while carrying the Venomhide Hatchling'),
+(19, 0, 13915, 0, 0, 2, 0, 46362, 1, 0, 0, 0, 0, '', 'Show quest \'Hungry, Hungry Hatchling\' only while carrying the Venomhide Hatchling'),
+(19, 0, 13903, 0, 0, 2, 0, 46362, 1, 0, 0, 0, 0, '', 'Show quest \'Gorishi Grub\' only while carrying the Venomhide Hatchling'),
+(19, 0, 13917, 0, 0, 2, 0, 46362, 1, 0, 0, 0, 0, '', 'Show quest \'Gorishi Grub\' only while carrying the Venomhide Hatchling'),
+(19, 0, 13904, 0, 0, 2, 0, 46362, 1, 0, 0, 0, 0, '', 'Show quest \'Poached, Scrambled, Or Raw?\' only while carrying the Venomhide Hatchling'),
+(19, 0, 13916, 0, 0, 2, 0, 46362, 1, 0, 0, 0, 0, '', 'Show quest \'Poached, Scrambled, Or Raw?\' only while carrying the Venomhide Hatchling'),
+(19, 0, 13905, 0, 0, 2, 0, 46362, 1, 0, 0, 0, 0, '', 'Show quest \'Searing Roc Feathers\' only while carrying the Venomhide Hatchling'),
+(19, 0, 13914, 0, 0, 2, 0, 46362, 1, 0, 0, 0, 0, '', 'Show quest \'Searing Roc Feathers\' only while carrying the Venomhide Hatchling');


### PR DESCRIPTION
## Changes Proposed:

The Venomhide Ravasaur mount chain can dead-end. The player ends up short of the 20 Venomhide Baby Teeth, Mor'vek shows the gold question mark but refuses the turn-in, and the hatchling stops handing out its daily, which is the only place teeth come from. Nothing the player can do in game gets them out of it.

The eight hatchling dailies were gated on `They Grow Up So Fast` being incomplete. That quest counts its items with a cached counter rather than reading the bags, and the counter can end up ahead of what the player is actually carrying, at which point the quest reads complete, the turn-in is refused because it re-counts the real bags, and the dailies disappear because the quest is no longer incomplete. Both doors shut at once.

This gates the dailies on carrying the Venomhide Hatchling instead. It covers exactly the same window, since the item is granted when the quest is accepted, destroyed if it is abandoned and consumed by the turn-in, and it cannot drift out of step the way the objective counter can. It is also one condition per quest instead of the two the quest status would need.

Also reported on ChromieCraft: https://github.com/chromiecraft/chromiecraft/issues/8755

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Opus 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #26964

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Code inspection: Why the quest status is not a safe thing to gate on here:

- `CanCompleteQuest` reads the cached counter `q_status.ItemCount[]` rather than the inventory (`src/server/game/Entities/Player/PlayerQuest.cpp:325`), while `CanRewardQuest` re-counts the real bags, bank excluded, with its own comment `prevent receive reward with quest items in bank` (`src/server/game/Entities/Player/PlayerQuest.cpp:407`).
- The counter can get ahead of the bags. `AdjustQuestReqItemCount` seeds it on accept counting the bank as well (`src/server/game/Entities/Player/PlayerQuest.cpp:1832`), and moving a required item into the bank by splitting a stack (`src/server/game/Entities/Player/PlayerStorage.cpp:3623`), dropping it onto another stack (`:3823`) or swapping it with a banked item (`:3994`) does not touch the counters at all, unlike the plain move to an empty slot (`:3775`). All of this matches TrinityCore 3.3.5, so it is inherited rather than introduced here, and it is left alone in this PR.
- `CONDITION_QUESTTAKEN` only passes on `QUEST_STATUS_INCOMPLETE`, despite the enum comment reading `true while quest active` (`src/server/game/Conditions/ConditionMgr.cpp:184`). The gold question mark on Mor'vek comes from the same status via `DIALOG_STATUS_REWARD` (`src/server/game/Entities/Player/PlayerQuest.cpp:1702`), which is what the reporter saw while short of teeth.

Why the item is a safe thing to gate on: quest 13906 hands out item 46362 as its source item on accept (`GiveQuestSourceItem`, `src/server/game/Entities/Player/PlayerQuest.cpp:551`), `TakeQuestSourceItem` destroys it on abandon since the item does not start the quest (`:1447`), and it is listed as `RequiredItemId1`, so the turn-in consumes it. Its lifetime is the quest's lifetime, with no cached state in between.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Tested on 3.3.5a, both the failure and the normal run.

The dead end was reproduced on purpose: with quest 13906 saved as `status = 1` (complete) and fewer teeth than that in the bags, Mor'vek showed the gold question mark with the continue button greyed out and the summoned hatchling offered nothing at all. With the change the hatchling offers its daily again, the missing tooth reaches the bags and Mor'vek then accepts the quest.

The normal run was then done start to finish on a fresh character: take the chain from Mor'vek, summon the hatchling, get and hand in its daily for a tooth, complete the quest and receive `Whistle of the Venomhide Ravasaur`. After the turn-in the item is consumed, so there is no hatchling and no dailies left behind.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

Three things worth knowing before starting, all of which look like a broken fix when they are not:

- `They Grow Up So Fast` also requires **80 gold**, so without it the quest never reads complete no matter how many teeth are held.
- A daily already handed in that day cannot be taken again until the daily reset, and there is no GM command to clear that. **Use a fresh character** rather than retrying on one that already did today's daily.
- Only one daily is offered per day, picked from a pool per race: orc and blood elf get 13889, 13903, 13904, 13905, while undead, tauren and troll get 13915, 13916, 13917, 13914. `SELECT * FROM pool_quest_save WHERE pool_id IN (350, 351);` in the characters database shows which one is active.

**Normal run.** On a new Horde character:

```
.levelup 49
.go creature id 11701
.quest add 13850
.quest complete 13850
```
Hand 13850 in to Mor'vek, take `Venomhide Eggs`, then:
```
.quest complete 13887
```
Hand that in as well. You now have `They Grow Up So Fast` and the Venomhide Hatchling item.

1. Use the item to summon the hatchling. **It offers its daily.**
2. `.quest complete <the daily it offered>` and hand it in to the hatchling. One Venomhide Baby Tooth arrives and the quest log reads 1/20.
3. Fill in the rest and finish:
```
.additem 47196 19
.additem 14047 20
.additem 8170 20
.modify money 1000000
```
4. Hand `They Grow Up So Fast` in to Mor'vek. **You receive `Whistle of the Venomhide Ravasaur`.**
5. Try to summon the hatchling again. The item was consumed by the turn-in, so there is no pet and no dailies left behind.

**Dead end.** Same character, between steps 3 and 4 above:

1. Go to a bank, shift-click the stack of teeth, split **1** off and drop it in an empty bank slot.
2. The quest log now reads 19/20 while the quest itself still counts as complete, which is the state from the report: Mor'vek shows the **gold** question mark and the continue button is greyed out.
3. Summon the hatchling. Without this change it offers nothing at all and the chain is over. With it the daily is still offered, so the last tooth can be earned and the quest handed in.

## Known Issues and TODO List:

- None

<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs

When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
