### PR TITLE
fix(Core/ObjectAccessor): prevent shutdown crash from static destruct…

### DIFF
--- a/src/server/game/Globals/ObjectAccessor.cpp
+++ b/src/server/game/Globals/ObjectAccessor.cpp
@@ -58,18 +58,42 @@ T* HashMapHolder<T>::Find(ObjectGuid guid)
     return (itr != GetContainer().end()) ? itr->second : nullptr;
 }
 
+// Both statics are intentionally never destroyed.
+//
+// As plain function-local statics they are destroyed during exit, in reverse
+// order of construction. Other global destructors still reach into them after
+// that point, and locking a destroyed std::shared_mutex is undefined
+// behaviour. Observed as ACCESS_VIOLATION (0xC0000005) on a normal graceful
+// shutdown, via:
+//
+//     exit -> GuildMgr::~GuildMgr -> Guild::~Guild -> Guild::_DeleteBankItems
+//          -> Guild::BankTab::Delete -> Object::ClearUpdateMask
+//          -> Item::RemoveFromObjectUpdate -> Item::GetOwner
+//          -> ObjectAccessor::FindPlayer -> HashMapHolder<Player>::Find
+//
+// GuildMgr tears down guild bank items and asks each item for its owning
+// player, after the player map and its lock have already gone.
+//
+// Leaking makes them outlive every other static, so a late lookup finds an
+// empty but valid map and returns nullptr rather than crashing. The memory is
+// reclaimed by the OS at process exit, so nothing is lost.
+//
+// This makes late lookups safe; it does not prevent them. Removing them would
+// mean destroying guilds inside World::Shutdown while the player map is still
+// alive, which is a much larger change to shutdown sequencing.
+
 template<class T>
 auto HashMapHolder<T>::GetContainer() -> MapType&
 {
-    static MapType _objectMap;
-    return _objectMap;
+    static MapType* _objectMap = new MapType();
+    return *_objectMap;
 }
 
 template<class T>
 std::shared_mutex* HashMapHolder<T>::GetLock()
 {
-    static std::shared_mutex _lock;
-    return &_lock;
+    static std::shared_mutex* _lock = new std::shared_mutex();
+    return _lock;
 }
 
 HashMapHolder<Player>::MapType const& ObjectAccessor::GetPlayers()


### PR DESCRIPTION
…ion order

HashMapHolder's player container and its lock were plain function-local statics, so they were destroyed during exit in reverse order of construction.

Global destructors that run afterwards still reach into them. GuildMgr's destructor tears down guild bank items, and each item is asked for its owning player, which locks the already-destroyed shared_mutex:

    exit -> GuildMgr::~GuildMgr -> Guild::~Guild -> Guild::_DeleteBankItems
         -> Guild::BankTab::Delete -> Object::ClearUpdateMask
         -> Item::RemoveFromObjectUpdate -> Item::GetOwner
         -> ObjectAccessor::FindPlayer -> HashMapHolder<Player>::Find

Locking a destroyed std::shared_mutex is undefined behaviour; in practice it raises ACCESS_VIOLATION (0xC0000005) and the worldserver crashes on an otherwise clean shutdown, after saves have completed.

Allocate both statics on the heap and never free them, so they outlive every other static. A late lookup then finds an empty but valid map and returns nullptr instead of crashing. The memory is reclaimed by the OS at process exit, so nothing is leaked in any meaningful sense.

This makes the late lookups safe rather than preventing them. Eliminating them would require destroying guilds inside World::Shutdown while the player map is still alive, which is a much larger change to shutdown sequencing.

Refs #8085

<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used:
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Run a worldserver with at least one guild holding items in its guild bank.
2. Shut down gracefully (`server shutdown 10`, or console `exit`).
3. Check the process exit code. Affected: 3221225477 (0xC0000005). Fixed: 0.
4. Repeat several times — on an affected build the crash appears intermittently.
The crash occurs AFTER the save path completes, so no character data is lost; the
symptom is a non-zero exit code and a crash dump, which misleads service managers
and automation.

Crash stack from an affected run:

    exit
     -> GuildMgr::~GuildMgr                GuildMgr.cpp:27
       -> Guild::~Guild                    Guild.cpp:1055
         -> Guild::_DeleteBankItems        Guild.cpp:2532
           -> Guild::BankTab::Delete       Guild.cpp:435
             -> Object::ClearUpdateMask    Object.cpp:530
               -> Item::RemoveFromObjectUpdate   Item.cpp:1175
                 -> Item::GetOwner              Item.cpp:552
                   -> ObjectAccessor::FindPlayer
                     -> HashMapHolder<Player>::Find   <-- ACCESS_VIOLATION

Core revision: branched from aa0c298a652f7263d2ff1004ebb4179e83ccb268
## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
