### PR TITLE
fix(CI): build the Dashboard CI ubuntu-26.04 leg with gcc-15

### DIFF
--- a/.github/workflows/dashboard-ci.yml
+++ b/.github/workflows/dashboard-ci.yml
@@ -75,8 +75,20 @@ jobs:
       matrix:
         include:
           - os: ubuntu-24.04
+            compiler:
+              CC: clang-18
+              CXX: clang++-18
+          # gcc rather than clang here: the default clang on 26.04 is 21, which
+          # cannot parse the libstdc++ 16 headers it picks up and dies in
+          # <shared_mutex> and <numeric> before reaching any of our code
           - os: ubuntu-26.04
+            compiler:
+              CC: gcc-15
+              CXX: g++-15
     runs-on: ${{ matrix.os }}
+    env:
+      CC: ${{ matrix.compiler.CC }}
+      CXX: ${{ matrix.compiler.CXX }}
     if: github.repository == 'azerothcore/azerothcore-wotlk' && !github.event.pull_request.draft
     steps:
       - name: Checkout repository
@@ -149,9 +161,9 @@ jobs:
       # recent on any ref the run can reach, which is its own and the base
       # branch, and is how a first run inherits master's. Both must use
       # matrix.os to stay in the key's namespace.
-      # The runner.os entries below reach the linux-build action's caches, but
-      # only on the 24.04 leg: on 26.04 this workflow detects clang-21 while
-      # linux-build is passed clang-20, so nothing there lines up.
+      # The runner.os entries below reach the linux-build action's caches, which
+      # now line up on both legs: clang-18 on 24.04 and gcc-15 on 26.04 are both
+      # compilers the core-build workflows already run.
       - name: Restore ccache
         id: restore_ccache
         uses: actions/cache/restore@v4


### PR DESCRIPTION
## Changes Proposed:

`Dashboard CI` is the only build workflow that does not pin a compiler. On ubuntu-26.04 that means it picks up whatever `clang` resolves to, which is clang 21, and clang 21 cannot parse the libstdc++ 16 headers it selects. It dies in `<shared_mutex>` and `<numeric>` before reaching any AzerothCore code:

```
/usr/lib/gcc/x86_64-linux-gnu/16/../../../../include/c++/16/shared_mutex:528:33: fatal error: no member named '__to_timeout_timespec' in namespace 'std::chrono'
```

```
/usr/lib/gcc/x86_64-linux-gnu/16/../../../../include/c++/16/numeric:302:21: fatal error: no template named '__is_any_random_access_iter'; did you mean '__is_random_access_iter'?
```

Every pull request that actually recompiles the core goes red on it, and since the matrix uses `fail-fast: true`, the ubuntu-24.04 leg is cancelled along with it and shows red too. Neither has anything to do with the code under review.

This pins both legs the way `core-build-pch.yml` and `core-build-nopch.yml` already do: clang-18 on 24.04 and gcc-15 on 26.04, two compilers those workflows run today. As a side effect the `runner.os` ccache restore-keys now line up with the ones the `linux-build` action writes on both legs, where before they only matched on 24.04.

Part of #26984, which also records a second and unrelated symptom on that workflow.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Opus 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- None

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Code inspection: `libstdc++-16-dev` is already installed on that runner by #26940, and the failing runs confirm it (`Setting up libstdc++-16-dev:amd64 (16-20260322-1ubuntu1)`), so this is not the missing-package problem that fixed. It is clang 21 being unable to consume that header set at all.

The reason this is not already visible on master is ccache: the ubuntu-26.04 legs of `Dashboard CI`, `pch-build` and `nopch-build` all finish in under 5 minutes there against roughly 45 for a real build, so nothing is compiled and the compiler is never asked to parse those headers. The same applies to the clang-21 legs of the core-build workflows, which are left untouched here since they are a separate call on whether to keep clang coverage on 26.04 or move it to a toolchain clang can handle.

`Detect compiler` already reads `${CC:-}` before falling back to `command -v clang`, so pinning through the job env is enough for both the build and the ccache key to follow.

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Not run locally: this only takes effect on the GitHub runners, so the workflow run on this pull request is the test. What should be visible is the `Build and Integration Test (ubuntu-26.04)` job compiling and going green instead of stopping in `Run complete installation (deps, compile, database, client-data)`.

Evidence for the diagnosis comes from the failing runs on #26735 ([job 92198476550](https://github.com/azerothcore/azerothcore-wotlk/actions/runs/30972100383/job/92198476550)) and #26820 ([job 92198492917](https://github.com/azerothcore/azerothcore-wotlk/actions/runs/30972106279/job/92198492917)), and from the job durations on the latest master run of each build workflow.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

Watch this pull request's own `Dashboard CI` run:

1. `Build and Integration Test (ubuntu-26.04)` should get through `Run complete installation (deps, compile, database, client-data)` rather than failing in it after roughly two minutes.
2. The `Echo cache key` step should print `gcc-15_g++-15` for that leg instead of `clang-21_clang++-21`.
3. `Build and Integration Test (ubuntu-24.04)` should stay green on `clang-18`.

Note that a green run here is not on its own proof, since a warm ccache can hide a compile break on this workflow. A leg that compiles for real takes tens of minutes, not a handful.

## Known Issues and TODO List:

- None

<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs

When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
