### PR TITLE
fix(CMake): AzerothCore now compiles on Ubuntu 26.04

### DIFF
--- a/apps/compiler/includes/functions.sh
+++ b/apps/compiler/includes/functions.sh
@@ -58,6 +58,33 @@ function comp_ccacheShowStats() {
     ccache -s
 }
 
+# clang builds against the newest GCC toolchain installed on the box. When that
+# toolchain is newer than clang understands, compilation dies inside the standard
+# headers before reaching any of our code: clang 21 with GCC 16 on Ubuntu 26.04
+# fails in <shared_mutex> and <numeric>. Fall back to the newest GCC that clang can
+# actually parse. Does nothing where the default already works.
+function comp_selectGccToolchain() {
+  [[ "$($CCOMPILERCXX --version 2>/dev/null | head -1)" == *clang* ]] || return 0
+
+  local probe="#include <shared_mutex>
+#include <numeric>
+int main() { return 0; }"
+
+  echo "$probe" | "$CCOMPILERCXX" -x c++ -std=c++20 -fsyntax-only - 2>/dev/null && return 0
+
+  local dir
+  for dir in $(ls -d /usr/lib/gcc/*/[0-9]* 2>/dev/null | sort -Vr); do
+    echo "$probe" | "$CCOMPILERCXX" -x c++ -std=c++20 -fsyntax-only "--gcc-install-dir=$dir" - 2>/dev/null || continue
+
+    echo "clang cannot use the default GCC toolchain, falling back to $dir"
+    export CFLAGS="${CFLAGS:+$CFLAGS }--gcc-install-dir=$dir"
+    export CXXFLAGS="${CXXFLAGS:+$CXXFLAGS }--gcc-install-dir=$dir"
+    return 0
+  done
+
+  echo "WARNING: $CCOMPILERCXX cannot parse the standard headers of any installed GCC toolchain"
+}
+
 function comp_configure() {
   CWD=$(pwd)
 
@@ -80,6 +107,7 @@ function comp_configure() {
   fi
 
   comp_ccacheEnable
+  comp_selectGccToolchain
 
   OSOPTIONS=""
 

--- a/apps/compiler/includes/functions.sh
+++ b/apps/compiler/includes/functions.sh
@@ -58,56 +58,6 @@ function comp_ccacheShowStats() {
     ccache -s
 }
 
-# clang builds against the newest GCC toolchain on the box, and that is not always one
-# it can parse: Ubuntu 26.04 defaults to GCC 15 but drags GCC 16 in through libstdc++6,
-# and clang 21 then dies inside <shared_mutex> and <numeric>. When that happens, point it
-# at the toolchain behind the default g++, which is the pairing the distro supports.
-#
-# The probe instantiates rather than only including: these failures live in templates the
-# compiler does not look at until something actually uses them.
-function comp_selectGccToolchain() {
-  [[ "$($CCOMPILERCXX --version 2>/dev/null | head -1)" == *clang* ]] || return 0
-
-  local probe="#include <chrono>
-#include <memory>
-#include <numeric>
-#include <shared_mutex>
-#include <string>
-#include <vector>
-int main()
-{
-    std::vector<int> values{3, 1, 2};
-    std::shared_timed_mutex mutex;
-    auto text = std::make_unique<std::string>(\"probe\");
-
-    (void)std::reduce(values.begin(), values.end());
-    (void)mutex.try_lock_for(std::chrono::milliseconds(1));
-    return int(text->size() & 0u);
-}"
-
-  echo "$probe" | "$CCOMPILERCXX" -x c++ -std=c++20 -fsyntax-only - 2>/dev/null && return 0
-
-  # the default g++ first, then anything else installed, newest first
-  local candidates
-  candidates="$(dirname "$(g++ -print-libgcc-file-name 2>/dev/null)") $(ls -d /usr/lib/gcc/*/[0-9]* 2>/dev/null | sort -Vr)"
-
-  echo "$CCOMPILERCXX cannot use its default GCC toolchain, trying: $candidates"
-
-  local dir
-  for dir in $candidates; do
-    [[ -d "$dir" ]] || continue
-    echo "$probe" | "$CCOMPILERCXX" -x c++ -std=c++20 -fsyntax-only "--gcc-install-dir=$dir" - 2>/dev/null || continue
-
-    # C++ only: the C compiler is configured separately and never sees libstdc++,
-    # so it must not be handed a flag its own driver may not know
-    echo "using GCC toolchain $dir"
-    export CXXFLAGS="${CXXFLAGS:+$CXXFLAGS }--gcc-install-dir=$dir"
-    return 0
-  done
-
-  echo "WARNING: no installed GCC toolchain works with $CCOMPILERCXX"
-}
-
 function comp_configure() {
   CWD=$(pwd)
 
@@ -130,7 +80,6 @@ function comp_configure() {
   fi
 
   comp_ccacheEnable
-  comp_selectGccToolchain
 
   OSOPTIONS=""
 

--- a/apps/compiler/includes/functions.sh
+++ b/apps/compiler/includes/functions.sh
@@ -58,32 +58,54 @@ function comp_ccacheShowStats() {
     ccache -s
 }
 
-# clang builds against the newest GCC toolchain installed on the box. When that
-# toolchain is newer than clang understands, compilation dies inside the standard
-# headers before reaching any of our code: clang 21 with GCC 16 on Ubuntu 26.04
-# fails in <shared_mutex> and <numeric>. Fall back to the newest GCC that clang can
-# actually parse. Does nothing where the default already works.
+# clang builds against the newest GCC toolchain on the box, and that is not always one
+# it can parse: Ubuntu 26.04 defaults to GCC 15 but drags GCC 16 in through libstdc++6,
+# and clang 21 then dies inside <shared_mutex> and <numeric>. When that happens, point it
+# at the toolchain behind the default g++, which is the pairing the distro supports.
+#
+# The probe instantiates rather than only including: these failures live in templates the
+# compiler does not look at until something actually uses them.
 function comp_selectGccToolchain() {
   [[ "$($CCOMPILERCXX --version 2>/dev/null | head -1)" == *clang* ]] || return 0
 
-  local probe="#include <shared_mutex>
+  local probe="#include <chrono>
+#include <memory>
 #include <numeric>
-int main() { return 0; }"
+#include <shared_mutex>
+#include <string>
+#include <vector>
+int main()
+{
+    std::vector<int> values{3, 1, 2};
+    std::shared_timed_mutex mutex;
+    auto text = std::make_unique<std::string>(\"probe\");
+
+    (void)std::reduce(values.begin(), values.end());
+    (void)mutex.try_lock_for(std::chrono::milliseconds(1));
+    return int(text->size() & 0u);
+}"
 
   echo "$probe" | "$CCOMPILERCXX" -x c++ -std=c++20 -fsyntax-only - 2>/dev/null && return 0
 
+  # the default g++ first, then anything else installed, newest first
+  local candidates
+  candidates="$(dirname "$(g++ -print-libgcc-file-name 2>/dev/null)") $(ls -d /usr/lib/gcc/*/[0-9]* 2>/dev/null | sort -Vr)"
+
+  echo "$CCOMPILERCXX cannot use its default GCC toolchain, trying: $candidates"
+
   local dir
-  for dir in $(ls -d /usr/lib/gcc/*/[0-9]* 2>/dev/null | sort -Vr); do
+  for dir in $candidates; do
+    [[ -d "$dir" ]] || continue
     echo "$probe" | "$CCOMPILERCXX" -x c++ -std=c++20 -fsyntax-only "--gcc-install-dir=$dir" - 2>/dev/null || continue
 
     # C++ only: the C compiler is configured separately and never sees libstdc++,
     # so it must not be handed a flag its own driver may not know
-    echo "clang cannot use the default GCC toolchain, falling back to $dir"
+    echo "using GCC toolchain $dir"
     export CXXFLAGS="${CXXFLAGS:+$CXXFLAGS }--gcc-install-dir=$dir"
     return 0
   done
 
-  echo "WARNING: $CCOMPILERCXX cannot parse the standard headers of any installed GCC toolchain"
+  echo "WARNING: no installed GCC toolchain works with $CCOMPILERCXX"
 }
 
 function comp_configure() {

--- a/apps/compiler/includes/functions.sh
+++ b/apps/compiler/includes/functions.sh
@@ -76,8 +76,9 @@ int main() { return 0; }"
   for dir in $(ls -d /usr/lib/gcc/*/[0-9]* 2>/dev/null | sort -Vr); do
     echo "$probe" | "$CCOMPILERCXX" -x c++ -std=c++20 -fsyntax-only "--gcc-install-dir=$dir" - 2>/dev/null || continue
 
+    # C++ only: the C compiler is configured separately and never sees libstdc++,
+    # so it must not be handed a flag its own driver may not know
     echo "clang cannot use the default GCC toolchain, falling back to $dir"
-    export CFLAGS="${CFLAGS:+$CFLAGS }--gcc-install-dir=$dir"
     export CXXFLAGS="${CXXFLAGS:+$CXXFLAGS }--gcc-install-dir=$dir"
     return 0
   done

--- a/src/cmake/compiler/clang/settings.cmake
+++ b/src/cmake/compiler/clang/settings.cmake
@@ -41,6 +41,68 @@ int main()
 }
 " CLANG_HAVE_PROPER_CHARCONV)
 
+# Clang builds against the newest GCC toolchain installed on the box, and that is not always one
+# it can parse: on Ubuntu 26.04 it picks GCC 16 and dies inside <shared_mutex> and <numeric>
+# before reaching any of our code. Fall back to the newest GCC it can actually use.
+# This whole block can go once clang can consume the libstdc++ shipped next to it.
+#
+# The probe instantiates rather than only including: those failures live in templates the
+# compiler does not look at until something uses them.
+if(UNIX AND NOT APPLE)
+  set(CLANG_LIBSTDCXX_PROBE "
+#include <chrono>
+#include <memory>
+#include <numeric>
+#include <shared_mutex>
+#include <string>
+#include <vector>
+int main()
+{
+    std::vector<int> values{3, 1, 2};
+    std::shared_timed_mutex mutex;
+    auto text = std::make_unique<std::string>(\"probe\");
+
+    (void)std::reduce(values.begin(), values.end());
+    (void)mutex.try_lock_for(std::chrono::milliseconds(1));
+    return static_cast<int>(text->size() & 0u);
+}
+")
+
+  check_cxx_source_compiles("${CLANG_LIBSTDCXX_PROBE}" CLANG_DEFAULT_GCC_TOOLCHAIN_USABLE)
+
+  if(NOT CLANG_DEFAULT_GCC_TOOLCHAIN_USABLE)
+    file(GLOB CLANG_GCC_TOOLCHAINS LIST_DIRECTORIES true /usr/lib/gcc/*/*)
+    list(SORT CLANG_GCC_TOOLCHAINS COMPARE NATURAL ORDER DESCENDING)
+
+    foreach(gccToolchain IN LISTS CLANG_GCC_TOOLCHAINS)
+      if(NOT IS_DIRECTORY "${gccToolchain}")
+        continue()
+      endif()
+
+      string(MAKE_C_IDENTIFIER "CLANG_GCC_TOOLCHAIN_USABLE_${gccToolchain}" probeResult)
+
+      set(CMAKE_REQUIRED_FLAGS "--gcc-install-dir=${gccToolchain}")
+      check_cxx_source_compiles("${CLANG_LIBSTDCXX_PROBE}" ${probeResult})
+      unset(CMAKE_REQUIRED_FLAGS)
+
+      if(${probeResult})
+        message(STATUS "Clang: cannot use the default GCC toolchain, falling back to ${gccToolchain}")
+
+        target_compile_options(acore-compile-option-interface INTERFACE --gcc-install-dir=${gccToolchain})
+        target_link_options(acore-compile-option-interface INTERFACE --gcc-install-dir=${gccToolchain})
+
+        set(CLANG_GCC_TOOLCHAIN_SELECTED ON)
+        break()
+      endif()
+    endforeach()
+
+    if(NOT CLANG_GCC_TOOLCHAIN_SELECTED)
+      message(WARNING "Clang: no installed GCC toolchain can be parsed, the build will likely "
+        "fail in the standard headers")
+    endif()
+  endif()
+endif()
+
 if(WITH_WARNINGS)
   target_compile_options(acore-warning-interface
     INTERFACE


### PR DESCRIPTION
## Changes Proposed:

Ubuntu 26.04 cannot compile AzerothCore with clang. Clang builds against the newest GCC toolchain installed on the box, and on that release it picks GCC 16, whose libstdc++ headers it cannot parse. The build dies before reaching any of our code:

```
/usr/lib/gcc/x86_64-linux-gnu/16/../../../../include/c++/16/shared_mutex:528:33: fatal error: no member named '__to_timeout_timespec' in namespace 'std::chrono'
```

```
/usr/lib/gcc/x86_64-linux-gnu/16/../../../../include/c++/16/numeric:302:21: fatal error: no template named '__is_any_random_access_iter'; did you mean '__is_random_access_iter'?
```

GCC 16 ends up on the box even though 26.04 defaults to GCC 15, because Ubuntu ships a single `libstdc++6` built against 16 for both, so installing clang pulls the whole GCC 16 toolchain in. Thanks to @CheckYourFax for working that part out.

This adds a fallback to `src/cmake/compiler/clang/settings.cmake`: probe whether clang can use its default toolchain, and if it cannot, try each installed GCC newest first and pass `--gcc-install-dir` for the first one that works. A box where the default already works never sees the flag, and the whole block can go once clang can consume the libstdc++ shipped next to it.

That file is where clang-specific handling already lives, and it already carries this exact shape: a `check_cxx_source_compiles` probe for a clang bug in the standard library, with a note saying it can be removed once the minimum clang version is raised. The flag is applied through `target_compile_options` on `acore-compile-option-interface`, the same way the sanitiser blocks do it, so it does not clobber flags passed in from outside.

The probe instantiates rather than only including. Both failures live in templates the compiler does not look at until something uses them, so a bare `#include` of those two headers compiles cleanly even on a box where the real build dies. That is worth knowing before testing this by hand.

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Opus 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- None

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Code inspection: `libstdc++-16-dev` is already installed by #26940 and the failing runs confirm it (`Setting up libstdc++-16-dev:amd64 (16-20260322-1ubuntu1)`), so this is not the missing package that fixed. Dropping the package again would not help either: clang still selects the GCC 16 toolchain and then fails to link, which is what #26940 was addressing. The toolchain has to be named explicitly.

The reason master looks unaffected is ccache. The ubuntu-26.04 legs of `Dashboard CI`, `pch-build` and `nopch-build` all finish there in under 5 minutes against roughly 45 for a real build, so nothing is compiled and the headers are never parsed. Only a pull request touching core files rebuilds enough to hit it, which is why #26735 and #26820 are red on a job that has nothing to do with their changes.

An earlier revision of this PR did the same thing in `apps/compiler/includes/functions.sh`. That was the wrong place twice over: it only covered people building through the dashboard, and it reimplemented what `check_cxx_source_compiles` already does.

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

The selection logic was exercised on its own with `cmake -P` against a tree of fake toolchain directories: it walks them newest first, skips the ones the probe rejects, applies the flag for the first that passes and stops there.

The clang path itself needs a 26.04 box, so this pull request's own CI run is the real test. Note that a green run there does not prove much on its own, since a warm ccache can finish that leg in a handful of minutes without compiling anything. What to look for is `Clang: cannot use the default GCC toolchain, falling back to ...` in the configure output.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

On an Ubuntu 26.04 box with the stock clang:

1. Before this change, configuring and building fails in `<shared_mutex>` and `<numeric>` as above.
2. With it, cmake prints either nothing, if clang was already fine, or `Clang: cannot use the default GCC toolchain, falling back to /usr/lib/gcc/x86_64-linux-gnu/15`, and the build proceeds.
3. On 24.04, and anywhere else the default pairing works, the probe passes and nothing is added.

If you want to check by hand whether your box is affected, the include-only test is not enough. This is one that reaches the failing templates:

```
printf '#include <numeric>\n#include <shared_mutex>\n#include <vector>\n#include <chrono>\nint main(){std::vector<int> v{1,2,3};std::shared_timed_mutex m;(void)std::reduce(v.begin(),v.end());(void)m.try_lock_for(std::chrono::seconds(1));}\n' | clang++ -x c++ -std=c++20 -fsyntax-only -
```

## Known Issues and TODO List:

- None

<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs

When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
