### PR TITLE
fix(Scripts/Warrior): Sweeping Strikes no longer crashes the server on Execute

### DIFF
--- a/src/server/scripts/Spells/spell_warrior.cpp
+++ b/src/server/scripts/Spells/spell_warrior.cpp
@@ -633,7 +633,7 @@ class spell_warr_sweeping_strikes : public AuraScript
 
     bool Load() override
     {
-        _procTarget = nullptr;
+        _procTargetGUID.Clear();
         return true;
     }
 
@@ -664,20 +664,34 @@ class spell_warr_sweeping_strikes : public AuraScript
             }
         }
 
-        _procTarget = actor->SelectNearbyNoTotemTarget(eventInfo.GetProcTarget());
-        return _procTarget != nullptr;
+        Unit* procTarget = actor->SelectNearbyNoTotemTarget(eventInfo.GetProcTarget());
+        if (procTarget)
+        {
+            _procTargetGUID = procTarget->GetGUID();
+        }
+
+        return procTarget != nullptr;
     }
 
     void HandleProc(AuraEffect const* aurEff, ProcEventInfo& eventInfo)
     {
         PreventDefaultAction();
+
+        // resolved rather than cached: the target picked in CheckProc can be gone by now,
+        // same crash spell_rog_blade_flurry already carries a note about
+        Unit* procTarget = ObjectAccessor::GetUnit(*GetTarget(), _procTargetGUID);
+        if (!procTarget)
+        {
+            return;
+        }
+
         if (DamageInfo* damageInfo = eventInfo.GetDamageInfo())
         {
             SpellInfo const* spellInfo = damageInfo->GetSpellInfo();
-            if (spellInfo && spellInfo->Id == SPELL_WARRIOR_EXECUTE && !_procTarget->HasAuraState(AURA_STATE_HEALTHLESS_20_PERCENT))
+            if (spellInfo && spellInfo->Id == SPELL_WARRIOR_EXECUTE && !procTarget->HasAuraState(AURA_STATE_HEALTHLESS_20_PERCENT))
             {
                 // If triggered by Execute (while target is not under 20% hp) deals normalized weapon damage
-                GetTarget()->CastSpell(_procTarget, SPELL_WARRIOR_SWEEPING_STRIKES_EXTRA_ATTACK_2, aurEff);
+                GetTarget()->CastSpell(procTarget, SPELL_WARRIOR_SWEEPING_STRIKES_EXTRA_ATTACK_2, aurEff);
             }
             else
             {
@@ -687,7 +701,7 @@ class spell_warr_sweeping_strikes : public AuraScript
                 }
 
                 int32 damage = damageInfo->GetUnmitigatedDamage();
-                GetTarget()->CastCustomSpell(_procTarget, SPELL_WARRIOR_SWEEPING_STRIKES_EXTRA_ATTACK_1, &damage, 0, 0, true, nullptr, aurEff);
+                GetTarget()->CastCustomSpell(procTarget, SPELL_WARRIOR_SWEEPING_STRIKES_EXTRA_ATTACK_1, &damage, 0, 0, true, nullptr, aurEff);
             }
         }
     }
@@ -699,7 +713,7 @@ class spell_warr_sweeping_strikes : public AuraScript
     }
 
 private:
-    Unit* _procTarget = nullptr;
+    ObjectGuid _procTargetGUID;
 };
 
 // 50720 - Vigilance

--- a/src/server/scripts/Spells/spell_warrior.cpp
+++ b/src/server/scripts/Spells/spell_warrior.cpp
@@ -688,7 +688,8 @@ class spell_warr_sweeping_strikes : public AuraScript
         if (DamageInfo* damageInfo = eventInfo.GetDamageInfo())
         {
             SpellInfo const* spellInfo = damageInfo->GetSpellInfo();
-            if (spellInfo && spellInfo->Id == SPELL_WARRIOR_EXECUTE && !procTarget->HasAuraState(AURA_STATE_HEALTHLESS_20_PERCENT))
+            if (spellInfo && spellInfo->Id == SPELL_WARRIOR_EXECUTE
+                && !procTarget->HasAuraState(AURA_STATE_HEALTHLESS_20_PERCENT))
             {
                 // If triggered by Execute (while target is not under 20% hp) deals normalized weapon damage
                 GetTarget()->CastSpell(procTarget, SPELL_WARRIOR_SWEEPING_STRIKES_EXTRA_ATTACK_2, aurEff);
@@ -701,7 +702,8 @@ class spell_warr_sweeping_strikes : public AuraScript
                 }
 
                 int32 damage = damageInfo->GetUnmitigatedDamage();
-                GetTarget()->CastCustomSpell(procTarget, SPELL_WARRIOR_SWEEPING_STRIKES_EXTRA_ATTACK_1, &damage, 0, 0, true, nullptr, aurEff);
+                GetTarget()->CastCustomSpell(procTarget, SPELL_WARRIOR_SWEEPING_STRIKES_EXTRA_ATTACK_1,
+                    &damage, 0, 0, true, nullptr, aurEff);
             }
         }
     }

--- a/src/server/scripts/Spells/spell_warrior.cpp
+++ b/src/server/scripts/Spells/spell_warrior.cpp
@@ -641,9 +641,7 @@ class spell_warr_sweeping_strikes : public AuraScript
     {
         Unit* actor = eventInfo.GetActor();
         if (!actor)
-        {
             return false;
-        }
 
         if (SpellInfo const* spellInfo = eventInfo.GetSpellInfo())
         {
@@ -654,11 +652,12 @@ class spell_warr_sweeping_strikes : public AuraScript
                 case SPELL_WARRIOR_WHIRLWIND_OFF:
                     return false;
                 case SPELL_WARRIOR_WHIRLWIND_MAIN:
+                {
                     if (actor->HasSpellCooldown(SPELL_WARRIOR_SWEEPING_STRIKES_EXTRA_ATTACK_1))
-                    {
                         return false;
-                    }
+
                     break;
+                }
                 default:
                     break;
             }
@@ -666,9 +665,7 @@ class spell_warr_sweeping_strikes : public AuraScript
 
         Unit* procTarget = actor->SelectNearbyNoTotemTarget(eventInfo.GetProcTarget());
         if (procTarget)
-        {
             _procTargetGUID = procTarget->GetGUID();
-        }
 
         return procTarget != nullptr;
     }
@@ -677,13 +674,9 @@ class spell_warr_sweeping_strikes : public AuraScript
     {
         PreventDefaultAction();
 
-        // resolved rather than cached: the target picked in CheckProc can be gone by now,
-        // same crash spell_rog_blade_flurry already carries a note about
         Unit* procTarget = ObjectAccessor::GetUnit(*GetTarget(), _procTargetGUID);
         if (!procTarget)
-        {
             return;
-        }
 
         if (DamageInfo* damageInfo = eventInfo.GetDamageInfo())
         {
@@ -697,13 +690,11 @@ class spell_warr_sweeping_strikes : public AuraScript
             else
             {
                 if (spellInfo && spellInfo->Id == SPELL_WARRIOR_WHIRLWIND_MAIN)
-                {
                     eventInfo.GetActor()->AddSpellCooldown(SPELL_WARRIOR_SWEEPING_STRIKES_EXTRA_ATTACK_1, 0, 500);
-                }
 
-                int32 damage = damageInfo->GetUnmitigatedDamage();
+                auto damage = static_cast<int32>(damageInfo->GetUnmitigatedDamage());
                 GetTarget()->CastCustomSpell(procTarget, SPELL_WARRIOR_SWEEPING_STRIKES_EXTRA_ATTACK_1,
-                    &damage, 0, 0, true, nullptr, aurEff);
+                    &damage, nullptr, nullptr, true, nullptr, aurEff);
             }
         }
     }


### PR DESCRIPTION
## Changes Proposed:

Sweeping Strikes can take the whole worldserver down. `CheckProc` picks the secondary target and keeps it as a raw `Unit*`, then `HandleProc` dereferences it without checking, so if that target is gone by the time the proc is handled the server segfaults on `Object::HasFlag` with `this=0x0`. Reported in #26987 with a backtrace and a rate of four crashes in twelve hours on a fifty player realm, with only two warriors carrying the talent.

The fix is the one the codebase already uses for the same mechanic. Blade Flurry does exactly this, picks a nearby target on proc and swings at it, and it stores the guid and resolves it at the point of use. It even carries a note about the identical crash:

```cpp
// Xinef: no _procTarget but checkproc passed??
// Unit::CalculateAOEDamageReduction (this=0x0, damage=4118, schoolMask=1, caster=0x7ffdad089000)
Unit* procTarget = ObjectAccessor::GetUnit(*GetTarget(), _procTargetGUID);
```

Sweeping Strikes never got the same treatment, so it does the same here.

The reporter proposed a plain `if (!_procTarget) return;` instead. That covers today's crash but only half the failure: the cached pointer can end up dangling rather than null, and then the check passes and the dereference is worse to diagnose. Resolving a guid covers both, and it is what `AGENTS.md` asks for: *don't store a raw `Player*` / `Creature*` / `Unit*` past the current call/tick ... store the `ObjectGuid` and resolve at use time*.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Opus 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #26987

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Code inspection: verified against master. `CheckProc` assigns at `src/server/scripts/Spells/spell_warrior.cpp:667` and `HandleProc` dereferences at `:677`, which is the line in the reported backtrace.

Six spell scripts cache a `Unit*` selected in `CheckProc`, and only three touch it directly afterwards. `spell_rog_blade_flurry` converts to a guid immediately (`src/server/scripts/Spells/spell_rogue.cpp:133`) and resolves it in `HandleProc` (`:142`). `spell_mage.cpp:599` guards with a null check before use. `spell_warr_sweeping_strikes` was the only one dereferencing unguarded.

`spell_warr_vigilance` keeps the same pattern but hands the pointer to `CastSpell`, which null checks in `SpellCastTargets::SetUnitTarget`, so it is left alone here.

`ObjectAccessor` needs no new include: `spell_dk.cpp` calls `ObjectAccessor::GetUnit` with the same include set in this directory.

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Not reproduced locally: the crash is a race, and the reporter saw it roughly four times in twelve hours on a populated realm without being able to trigger it on demand either.

What can be checked is that the ability still behaves the same. Sweeping Strikes should keep hitting a second nearby enemy on Whirlwind, Cleave and ordinary swings, and Execute above 20 percent should still land the normalized weapon damage variant rather than the mirrored damage one, since that branch is the one that used to dereference.

The C++ codestyle script passes.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

Normal behaviour, which is what needs checking since the crash itself is a race:

1. On a warrior with Sweeping Strikes active, attack a target with at least one other enemy next to it. The second enemy should take damage alongside the main one.
2. Repeat with Whirlwind and with Cleave.
3. Cast Execute on a target above 20 percent health with a second enemy nearby. The second enemy should take normalized weapon damage.
4. Cast Execute on a target below 20 percent health. The second enemy should take the mirrored damage instead.

For the crash itself, the reporter's realm saw it around four times in twelve hours with two warriors using the talent, so a populated realm running this for a day is the real test.

## Known Issues and TODO List:

- None

<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs

When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
