### PR TITLE
fix(Core/Realms): the authserver now starts after a worldserver was stopped while loading

### DIFF
--- a/src/server/apps/authserver/Main.cpp
+++ b/src/server/apps/authserver/Main.cpp
@@ -132,7 +132,9 @@ int main(int argc, char** argv)
 
     // Mark every realm offline on startup; each worldserver clears this flag for its own realm once it is ready.
     // This prevents realms from appearing online in the realm list when no worldserver is actually running.
-    LoginDatabase.DirectExecute("UPDATE realmlist SET flag = flag | {}", REALM_FLAG_OFFLINE);
+    // The loading flag goes with it: no worldserver is up at this point, so one left behind by a worldserver
+    // that died while loading only serves to make flag 3, which the realm list query excludes.
+    LoginDatabase.DirectExecute("UPDATE realmlist SET flag = (flag & ~{}) | {}", REALM_FLAG_VERSION_MISMATCH, REALM_FLAG_OFFLINE);
 
     std::shared_ptr<Acore::Asio::IoContext> ioContext = std::make_shared<Acore::Asio::IoContext>();
 

--- a/src/server/apps/authserver/Main.cpp
+++ b/src/server/apps/authserver/Main.cpp
@@ -134,7 +134,8 @@ int main(int argc, char** argv)
     // This prevents realms from appearing online in the realm list when no worldserver is actually running.
     // The loading flag goes with it: no worldserver is up at this point, so one left behind by a worldserver
     // that died while loading only serves to make flag 3, which the realm list query excludes.
-    LoginDatabase.DirectExecute("UPDATE realmlist SET flag = (flag & ~{}) | {}", REALM_FLAG_VERSION_MISMATCH, REALM_FLAG_OFFLINE);
+    LoginDatabase.DirectExecute("UPDATE realmlist SET flag = (flag & ~{}) | {}",
+        REALM_FLAG_VERSION_MISMATCH, REALM_FLAG_OFFLINE);
 
     std::shared_ptr<Acore::Asio::IoContext> ioContext = std::make_shared<Acore::Asio::IoContext>();
 

--- a/src/server/apps/worldserver/Main.cpp
+++ b/src/server/apps/worldserver/Main.cpp
@@ -416,7 +416,8 @@ int main(int argc, char** argv)
     // set server offline, dropping the loading flag with it: ORing offline onto a realm that never
     // finished loading leaves flag 3, which the realm list query excludes
     if (!sConfigMgr->GetOption<bool>("Network.UseSocketActivation", false))
-        LoginDatabase.DirectExecute("UPDATE realmlist SET flag = (flag & ~{}) | {} WHERE id = '{}'", REALM_FLAG_VERSION_MISMATCH, REALM_FLAG_OFFLINE, realm.Id.Realm);
+        LoginDatabase.DirectExecute("UPDATE realmlist SET flag = (flag & ~{}) | {} WHERE id = '{}'",
+            REALM_FLAG_VERSION_MISMATCH, REALM_FLAG_OFFLINE, realm.Id.Realm);
 
     LOG_INFO("server.worldserver", "Halting process...");
 

--- a/src/server/apps/worldserver/Main.cpp
+++ b/src/server/apps/worldserver/Main.cpp
@@ -413,9 +413,10 @@ int main(int argc, char** argv)
 
     sScriptMgr->OnShutdown();
 
-    // set server offline
+    // set server offline, dropping the loading flag with it: ORing offline onto a realm that never
+    // finished loading leaves flag 3, which the realm list query excludes
     if (!sConfigMgr->GetOption<bool>("Network.UseSocketActivation", false))
-        LoginDatabase.DirectExecute("UPDATE realmlist SET flag = flag | {} WHERE id = '{}'", REALM_FLAG_OFFLINE, realm.Id.Realm);
+        LoginDatabase.DirectExecute("UPDATE realmlist SET flag = (flag & ~{}) | {} WHERE id = '{}'", REALM_FLAG_VERSION_MISMATCH, REALM_FLAG_OFFLINE, realm.Id.Realm);
 
     LOG_INFO("server.worldserver", "Halting process...");
 


### PR DESCRIPTION
## Changes Proposed:

A realm can get stuck in a state where the authserver refuses to boot, and the only way out is editing the database by hand.

A worldserver sets `REALM_FLAG_VERSION_MISMATCH` on its realm while it loads and clears it once it is ready (`src/server/apps/worldserver/Main.cpp:286` and `:375`). Stop it before that point, or have it die there, and the flag stays behind. The next thing to mark the realm offline ORs `REALM_FLAG_OFFLINE` onto it, so the realm ends up at flag 3, and the realm list query drops exactly that: `SELECT ... FROM realmlist WHERE flag <> 3`.

The authserver then finds no realms at all and exits:

```
No valid realms specified. Possible reasons:
- the realmlist table of the auth database is empty
- every realm has flag 3 (REALM_FLAG_VERSION_MISMATCH | REALM_FLAG_OFFLINE), which the realm list query excludes
- no realm address could be resolved, see the resolver errors logged above
```

It does that on every start from then on, so a single interrupted worldserver load leaves the login server down until someone runs the `UPDATE` the error message suggests.

This clears the loading flag in both places that mark a realm offline: the worldserver on shutdown, and the authserver on startup, where by definition no worldserver is mid-load. A realm that is merely down ends up at flag 2, stays in the list, and shows as offline, which is what it is.

Found through CI, and it is also the second symptom recorded in #26984: the dashboard workflow stops the worldserver in its own test step and then cannot start the authserver in the next one. PM2 is configured with `RESTART_POLICY: always`, so it restarts the exiting process forever and the step burns its full 30 minute budget instead of failing. Example: [job 92198506214](https://github.com/azerothcore/azerothcore-wotlk/actions/runs/30972110887/job/92198506214), where the authserver log repeats that error dozens of times.

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Opus 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- None

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Code inspection: the three places that touch these flags are `worldserver/Main.cpp:286` (loading), `:375` (ready) and `:418` (shutdown), plus `authserver/Main.cpp:135` (startup). Only the last two needed changing, and neither can be reached while a worldserver is mid-load.

The realm list query is `LOGIN_SEL_REALMLIST` in `src/server/database/Database/Implementation/LoginDatabase.cpp:51`, and the guard that exits is `authserver/Main.cpp:148`.

Nothing else reads `REALM_FLAG_VERSION_MISMATCH` from the table. `AuthSession.cpp:768` sets it per connection when the client build differs, which is unrelated to the stored flag.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Built both binaries and ran them against the same database, starting each from `flag = 1`, which is what a worldserver killed while loading leaves behind:

| authserver | flag before | result | flag after |
| :-- | :-- | :-- | :-- |
| master | 1 | exits, code 1, `No valid realms specified.` | **3** |
| this PR | 1 | starts and stays up, listening | **2** |

Same machine, same database, same starting point. The only difference between the two binaries is this change.

Worth pointing out from that run: the current code makes the situation worse when it fails. It goes in at flag 1 and leaves 3 behind, so the second attempt starts from a worse place than the first, and there is no way back without editing the table. That is exactly why CI burns its full 30 minutes rather than settling.

The C++ codestyle script passes.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

Either of these reaches the same state:

1. Start the worldserver and stop it while it is still loading, before it reports being ready. Then start the authserver.
2. Or set it directly with `UPDATE realmlist SET flag = 3 WHERE id = 1;` and start the authserver.

Before this change the authserver prints `No valid realms specified` and exits, every time. After it, the authserver starts, the realm is listed as offline, and it comes online normally once a worldserver finishes loading.

Worth checking as well that a normal run is unaffected: start authserver and worldserver the usual way, confirm the realm shows online in the client, then stop the worldserver and confirm it goes offline rather than disappearing.

## Known Issues and TODO List:

- The CI step that surfaced this hangs for 30 minutes rather than failing, because PM2 is set to restart the service forever. That is worth addressing separately: a service that exits immediately should fail its step with the error in view.

<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs

When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
