### PR TITLE
feat(Core/Pools): store pool spawn state per map, enable pooling in instances

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1785973401.sql
+++ b/data/sql/updates/pending_db_world/rev_1785973401.sql
@@ -1,0 +1,4 @@
+-- Omgorn the Lost (8201): the 'Eastmoon Ruins' and 'Southmoon Ruins' spawns of
+-- pool 366 were placed on map 0 while both subzones are in Tanaris (map 1),
+-- leaving the pool split across two maps.
+UPDATE `creature` SET `map` = 1 WHERE `guid` IN (152280, 152281);

--- a/data/sql/updates/pending_db_world/rev_1786067993.sql
+++ b/data/sql/updates/pending_db_world/rev_1786067993.sql
@@ -1,0 +1,10 @@
+-- Takk's Nest and Ravasaur Matriarch's Nest gameobject pools (map 1) reused
+-- pool ids 7001/7002, which belong to the Webbed Crusader creature pools
+-- (map 571). Pools are bound to a single map now, so the nests get own pools.
+DELETE FROM `pool_template` WHERE `entry` IN (201213, 201214);
+INSERT INTO `pool_template` (`entry`, `max_limit`, `description`) VALUES
+(201213, 1, 'Takk''s Nest'),
+(201214, 1, 'Ravasaur Matriarch''s Nest');
+
+UPDATE `pool_gameobject` SET `pool_entry` = 201213 WHERE `guid` IN (14990, 14991, 14992, 14993);
+UPDATE `pool_gameobject` SET `pool_entry` = 201214 WHERE `guid` IN (14994, 14995, 14996, 14997, 14998);

--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -2117,7 +2117,7 @@ void Creature::Respawn(bool force)
 
                 uint32 poolid = m_spawnId ? sPoolMgr->IsPartOfAPool<Creature>(m_spawnId) : 0;
                 if (poolid)
-                    sPoolMgr->UpdatePool<Creature>(poolid, m_spawnId);
+                    sPoolMgr->UpdatePool<Creature>(GetMap()->GetPoolData(), poolid, m_spawnId);
 
                 //Re-initialize reactstate that could be altered by movementgenerators
                 InitializeReactState();

--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -666,7 +666,7 @@ void GameObject::Update(uint32 diff)
                         // respawn timer
                         uint32 poolid = m_spawnId ? sPoolMgr->IsPartOfAPool<GameObject>(m_spawnId) : 0;
                         if (poolid)
-                            sPoolMgr->UpdatePool<GameObject>(poolid, m_spawnId);
+                            sPoolMgr->UpdatePool<GameObject>(GetMap()->GetPoolData(), poolid, m_spawnId);
                         else
                             GetMap()->AddToMap(this);
                     }
@@ -967,7 +967,7 @@ void GameObject::DespawnOrUnsummon(Milliseconds delay /*= 0ms*/, Seconds forceRe
             // GameObject::Update() will update the pool when the object is ready to respawn.
             if (poolid && !m_respawnTime)
             {
-                sPoolMgr->UpdatePool<GameObject>(poolid, m_spawnId);
+                sPoolMgr->UpdatePool<GameObject>(GetMap()->GetPoolData(), poolid, m_spawnId);
             }
         }
     }
@@ -991,7 +991,7 @@ void GameObject::Delete()
 
     uint32 poolid = m_spawnId ? sPoolMgr->IsPartOfAPool<GameObject>(m_spawnId) : 0;
     if (poolid)
-        sPoolMgr->UpdatePool<GameObject>(poolid, m_spawnId);
+        sPoolMgr->UpdatePool<GameObject>(GetMap()->GetPoolData(), poolid, m_spawnId);
     else
         AddObjectToRemoveList();
 }

--- a/src/server/game/Entities/Transport/Transport.cpp
+++ b/src/server/game/Entities/Transport/Transport.cpp
@@ -509,12 +509,27 @@ void MotionTransport::LoadStaticPassengers()
             // Creatures on transport
             guidEnd = cellItr->second.creatures.end();
             for (CellGuidSet::const_iterator guidItr = cellItr->second.creatures.begin(); guidItr != guidEnd; ++guidItr)
-                CreateNPCPassenger(*guidItr, sObjectMgr->GetCreatureData(*guidItr));
+            {
+                CreatureData const* data = sObjectMgr->GetCreatureData(*guidItr);
+
+                // Pooled spawns are in the grid data but managed by the pool system, never as static passengers
+                if (data && data->poolId)
+                    continue;
+
+                CreateNPCPassenger(*guidItr, data);
+            }
 
             // GameObjects on transport
             guidEnd = cellItr->second.gameobjects.end();
             for (CellGuidSet::const_iterator guidItr = cellItr->second.gameobjects.begin(); guidItr != guidEnd; ++guidItr)
-                CreateGOPassenger(*guidItr, sObjectMgr->GetGameObjectData(*guidItr));
+            {
+                GameObjectData const* data = sObjectMgr->GetGameObjectData(*guidItr);
+
+                if (data && data->poolId)
+                    continue;
+
+                CreateGOPassenger(*guidItr, data);
+            }
         }
     }
 }

--- a/src/server/game/Events/GameEventMgr.cpp
+++ b/src/server/game/Events/GameEventMgr.cpp
@@ -1501,7 +1501,7 @@ void GameEventMgr::GameEventSpawn(int16 eventId)
     }
 
     for (IdList::iterator itr = _gameEventPoolIds[internal_event_id].begin(); itr != _gameEventPoolIds[internal_event_id].end(); ++itr)
-        sPoolMgr->SpawnPool(*itr);
+        sPoolMgr->SpawnEventPool(*itr);
 }
 
 void GameEventMgr::GameEventUnspawn(int16 eventId)
@@ -1576,7 +1576,7 @@ void GameEventMgr::GameEventUnspawn(int16 eventId)
 
     for (IdList::iterator itr = _gameEventPoolIds[internal_event_id].begin(); itr != _gameEventPoolIds[internal_event_id].end(); ++itr)
     {
-        sPoolMgr->DespawnPool(*itr);
+        sPoolMgr->DespawnEventPool(*itr);
     }
 }
 

--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -2382,7 +2382,7 @@ void ObjectMgr::LoadCreatures()
         data.spawnMask          = fields[14].Get<uint8>();
         data.phaseMask          = fields[15].Get<uint32>();
         int16 gameEvent         = fields[16].Get<int16>();
-        uint32 PoolId           = fields[17].Get<uint32>();
+        data.poolId             = fields[17].Get<uint32>();
         data.npcflag            = fields[18].Get<uint32>();
         data.unit_flags         = fields[19].Get<uint32>();
         data.dynamicflags       = fields[20].Get<uint32>();
@@ -2490,8 +2490,9 @@ void ObjectMgr::LoadCreatures()
             WorldDatabase.Execute(stmt);
         }
 
-        // Add to grid if not managed by the game event or pool system
-        if (gameEvent == 0 && PoolId == 0)
+        // Add to grid if not managed by the game event. Pooled spawns are in
+        // the grid data too; the grid loader filters them by pool state.
+        if (gameEvent == 0)
             AddCreatureToGrid(spawnId, &data);
 
         ++count;
@@ -3035,7 +3036,7 @@ void ObjectMgr::LoadGameobjects()
 
         data.phaseMask      = fields[15].Get<uint32>();
         int16 gameEvent     = fields[16].Get<int16>();
-        uint32 PoolId        = fields[17].Get<uint32>();
+        data.poolId         = fields[17].Get<uint32>();
 
         if (data.rotation.x < -1.0f || data.rotation.x > 1.0f)
         {
@@ -3094,7 +3095,7 @@ void ObjectMgr::LoadGameobjects()
             WorldDatabase.Execute(stmt);
         }
 
-        if (gameEvent == 0 && PoolId == 0)                      // if not this is to be managed by GameEvent System or Pool system
+        if (gameEvent == 0)                      // if not this is to be managed by GameEvent System
             AddGameobjectToGrid(guid, &data);
     } while (result->NextRow());
 

--- a/src/server/game/Grids/GridObjectLoader.cpp
+++ b/src/server/game/Grids/GridObjectLoader.cpp
@@ -23,6 +23,7 @@
 #include "GameObject.h"
 #include "GridNotifiers.h"
 #include "ObjectMgr.h"
+#include "PoolMgr.h"
 #include "Transport.h"
 #include "Vehicle.h"
 
@@ -43,6 +44,10 @@ void GridObjectLoader::LoadCreatures(CellGuidSet const& guid_set, Map* map)
         // Skip spawns whose spawn group is not active on this map
         CreatureData const* cData = sObjectMgr->GetCreatureData(guid);
         if (cData && !map->IsSpawnGroupActive(cData->spawnGroupId))
+            continue;
+
+        // Skip pool members this map's pool state has not rolled as spawned
+        if (cData && cData->poolId && !map->GetPoolData().IsSpawnedObject<Creature>(guid))
             continue;
 
         Creature* obj = new Creature();
@@ -78,6 +83,10 @@ void GridObjectLoader::LoadGameObjects(CellGuidSet const& guid_set, Map* map)
 
         // Skip spawns whose spawn group is not active on this map
         if (data && !map->IsSpawnGroupActive(data->spawnGroupId))
+            continue;
+
+        // Skip pool members this map's pool state has not rolled as spawned
+        if (data && data->poolId && !map->GetPoolData().IsSpawnedObject<GameObject>(guid))
             continue;
 
         if (data && sObjectMgr->IsGameObjectStaticTransport(data->id))

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -81,6 +81,8 @@ Map::Map(uint32 id, uint32 InstanceId, uint8 SpawnMode, Map* _parent) :
 
     _weatherUpdateTimer.SetInterval(1 * IN_MILLISECONDS);
     _corpseUpdateTimer.SetInterval(20 * MINUTE * IN_MILLISECONDS);
+
+    _poolData = sPoolMgr->InitPoolsForMap(this);
 }
 
 // Hook called after map is created AND after added to map list
@@ -2780,18 +2782,12 @@ void Map::ProcessRespawns()
 
 void Map::ProcessCreatureRespawn(ObjectGuid::LowType spawnId)
 {
-    // Pool members in non-instanced maps are handled entirely by PoolMgr.
-    // In instanced maps the pool system operates globally and Spawn1Object is
-    // a no-op for instanceable maps, so fall through to the normal per-instance
-    // respawn logic instead.
-    if (!Instanceable())
+    // Pool members are handled entirely by the pool system on this map's pool data
+    if (uint32 poolId = sPoolMgr->IsPartOfAPool<Creature>(spawnId))
     {
-        if (uint32 poolId = sPoolMgr->IsPartOfAPool<Creature>(spawnId))
-        {
-            sPoolMgr->UpdatePool<Creature>(poolId, spawnId);
-            RemoveCreatureRespawnTime(spawnId);
-            return;
-        }
+        sPoolMgr->UpdatePool<Creature>(GetPoolData(), poolId, spawnId);
+        RemoveCreatureRespawnTime(spawnId);
+        return;
     }
 
     CreatureData const* data = sObjectMgr->GetCreatureData(spawnId);
@@ -2866,16 +2862,12 @@ void Map::ProcessCreatureRespawn(ObjectGuid::LowType spawnId)
 
 void Map::ProcessGameObjectRespawn(ObjectGuid::LowType spawnId)
 {
-    // Same rationale as ProcessCreatureRespawn: pool management via PoolMgr is
-    // only meaningful for non-instanced maps where Spawn1Object actually spawns.
-    if (!Instanceable())
+    // Pool members are handled entirely by the pool system on this map's pool data
+    if (uint32 poolId = sPoolMgr->IsPartOfAPool<GameObject>(spawnId))
     {
-        if (uint32 poolId = sPoolMgr->IsPartOfAPool<GameObject>(spawnId))
-        {
-            sPoolMgr->UpdatePool<GameObject>(poolId, spawnId);
-            RemoveGORespawnTime(spawnId);
-            return;
-        }
+        sPoolMgr->UpdatePool<GameObject>(GetPoolData(), poolId, spawnId);
+        RemoveGORespawnTime(spawnId);
+        return;
     }
 
     GameObjectData const* data = sObjectMgr->GetGameObjectData(spawnId);

--- a/src/server/game/Maps/Map.h
+++ b/src/server/game/Maps/Map.h
@@ -68,6 +68,7 @@ class StaticTransport;
 class MotionTransport;
 class PathGenerator;
 class WorldSession;
+class SpawnedPoolData;
 
 enum WeatherState : uint32;
 
@@ -380,6 +381,9 @@ public:
         return nullptr;
     }
 
+    SpawnedPoolData& GetPoolData() { return *_poolData; }
+    [[nodiscard]] SpawnedPoolData const& GetPoolData() const { return *_poolData; }
+
     MapInstanced* ToMapInstanced() { if (Instanceable())  return reinterpret_cast<MapInstanced*>(this); else return nullptr;  }
     [[nodiscard]] MapInstanced const* ToMapInstanced() const { if (Instanceable())  return (MapInstanced const*)((MapInstanced*)this); else return nullptr;  }
 
@@ -664,6 +668,8 @@ private:
         }
     };
     std::set<RespawnEntry> _respawnQueue;
+
+    std::unique_ptr<SpawnedPoolData> _poolData;
 
     std::unordered_set<uint32> _toggledSpawnGroupIds;
     uint32 _respawnCheckTimer{0};

--- a/src/server/game/Maps/SpawnData.h
+++ b/src/server/game/Maps/SpawnData.h
@@ -76,6 +76,7 @@ struct SpawnData
     uint32 ScriptId{0};
     bool dbData{true};
     uint32 spawnGroupId{0};
+    uint32 poolId{0};
 
 protected:
     SpawnData(SpawnObjectType t) : type(t) {}

--- a/src/server/game/Pools/PoolMgr.cpp
+++ b/src/server/game/Pools/PoolMgr.cpp
@@ -305,6 +305,28 @@ void PoolGroup<Pool>::RemoveOneRelation(uint32 child_pool_id)
     }
 }
 
+// Whether the member can physically exist on this map's spawn mode; members
+// failing this must not occupy a roll slot or they block the pool invisibly
+template <class T>
+bool PoolGroup<T>::IsSpawnableOnMap(uint32 /*db_guid_or_pool_id*/, Map* /*map*/)
+{
+    return true;
+}
+
+template <>
+bool PoolGroup<Creature>::IsSpawnableOnMap(uint32 db_guid, Map* map)
+{
+    CreatureData const* data = sObjectMgr->GetCreatureData(db_guid);
+    return data && (data->spawnMask & (1 << map->GetSpawnMode()));
+}
+
+template <>
+bool PoolGroup<GameObject>::IsSpawnableOnMap(uint32 db_guid, Map* map)
+{
+    GameObjectData const* data = sObjectMgr->GetGameObjectData(db_guid);
+    return data && (data->spawnMask & (1 << map->GetSpawnMode()));
+}
+
 template <class T>
 void PoolGroup<T>::SpawnObject(SpawnedPoolData& spawns, uint32 limit, uint32 triggerFrom)
 {
@@ -334,7 +356,7 @@ void PoolGroup<T>::SpawnObject(SpawnedPoolData& spawns, uint32 limit, uint32 tri
 
                 // Triggering object is marked as spawned at this time and can be also rolled (respawn case)
                 // so this need explicit check for this case
-                if (roll < 0 && (obj.guid == triggerFrom || !spawns.IsSpawnedObject<T>(obj.guid)))
+                if (roll < 0 && (obj.guid == triggerFrom || (!spawns.IsSpawnedObject<T>(obj.guid) && IsSpawnableOnMap(obj.guid, spawns.GetMap()))))
                 {
                     rolledObjects.push_back(obj);
                     break;
@@ -346,7 +368,7 @@ void PoolGroup<T>::SpawnObject(SpawnedPoolData& spawns, uint32 limit, uint32 tri
         {
             std::copy_if(EqualChanced.begin(), EqualChanced.end(), std::back_inserter(rolledObjects), [triggerFrom, &spawns](PoolObject const& object)
             {
-                 return object.guid == triggerFrom || !spawns.IsSpawnedObject<T>(object.guid);
+                 return object.guid == triggerFrom || (!spawns.IsSpawnedObject<T>(object.guid) && IsSpawnableOnMap(object.guid, spawns.GetMap()));
             });
 
             Acore::Containers::RandomResize(rolledObjects, count);
@@ -383,11 +405,6 @@ void PoolGroup<Creature>::Spawn1Object(SpawnedPoolData& spawns, PoolObject* obj)
     {
         Map* map = spawns.GetMap();
 
-        // Grid loading enforces spawnMask through the per-difficulty grid data;
-        // spawning directly into an already loaded grid has to check it itself
-        if (!(data->spawnMask & (1 << map->GetSpawnMode())))
-            return;
-
         // Spawn if necessary (loaded grids only)
         // We use spawn coords to spawn
         if (map->IsGridLoaded(data->posX, data->posY))
@@ -410,9 +427,6 @@ void PoolGroup<GameObject>::Spawn1Object(SpawnedPoolData& spawns, PoolObject* ob
     if (GameObjectData const* data = sObjectMgr->GetGameObjectData(obj->guid))
     {
         Map* map = spawns.GetMap();
-
-        if (!(data->spawnMask & (1 << map->GetSpawnMode())))
-            return;
 
         // Spawn if necessary (loaded grids only)
         // We use current coords to unspawn, not spawn coords since creature can have changed grid
@@ -1017,7 +1031,7 @@ void PoolMgr::LoadFromDB()
                 }
             } while (result->NextRow());
 
-            LOG_INFO("pool", "Pool handling system initialized, {} pools will be spawned by default in {} ms", count, GetMSTimeDiffToNow(oldMSTime));
+            LOG_INFO("server.loading", ">> Pool handling system initialized, {} pools will be spawned by default in {} ms", count, GetMSTimeDiffToNow(oldMSTime));
             LOG_INFO("server.loading", " ");
         }
     }

--- a/src/server/game/Pools/PoolMgr.cpp
+++ b/src/server/game/Pools/PoolMgr.cpp
@@ -972,10 +972,11 @@ void PoolMgr::LoadFromDB()
         }
     }
 
+    // Warn only: empty pools are inert leftovers, unlike the member errors above
     for (auto const& [poolId, templateData] : mPoolTemplate)
     {
         if (IsEmpty(poolId))
-            LOG_ERROR("sql.sql", "Pool Id {} is empty (has no creatures, no gameobjects, no quests and no valid child pools). The pool will not be spawned.", poolId);
+            LOG_WARN("sql.sql", "Pool Id {} is empty (has no creatures, no gameobjects, no quests and no valid child pools). The pool will not be spawned.", poolId);
     }
 
     // The initialize method will spawn all pools not in an event and not in another pool, this is why there is 2 left joins with 2 null checks

--- a/src/server/game/Pools/PoolMgr.cpp
+++ b/src/server/game/Pools/PoolMgr.cpp
@@ -24,73 +24,73 @@
 #include "Transport.h"
 
 ////////////////////////////////////////////////////////////
-// template class ActivePoolData
+// template class SpawnedPoolData
 
 // Method that tell amount spawned objects/subpools
-uint32 ActivePoolData::GetActiveObjectCount(uint32 pool_id) const
+uint32 SpawnedPoolData::GetSpawnedObjects(uint32 pool_id) const
 {
-    ActivePoolPools::const_iterator itr = mSpawnedPools.find(pool_id);
+    SpawnedPoolPools::const_iterator itr = mSpawnedPools.find(pool_id);
     return itr != mSpawnedPools.end() ? itr->second : 0;
 }
 
 // Method that tell if a creature is spawned currently
 template<>
-bool ActivePoolData::IsActiveObject<Creature>(uint32 db_guid) const
+bool SpawnedPoolData::IsSpawnedObject<Creature>(uint32 db_guid) const
 {
     return mSpawnedCreatures.find(db_guid) != mSpawnedCreatures.end();
 }
 
 // Method that tell if a gameobject is spawned currently
 template<>
-bool ActivePoolData::IsActiveObject<GameObject>(uint32 db_guid) const
+bool SpawnedPoolData::IsSpawnedObject<GameObject>(uint32 db_guid) const
 {
     return mSpawnedGameobjects.find(db_guid) != mSpawnedGameobjects.end();
 }
 
 // Method that tell if a pool is spawned currently
 template<>
-bool ActivePoolData::IsActiveObject<Pool>(uint32 sub_pool_id) const
+bool SpawnedPoolData::IsSpawnedObject<Pool>(uint32 sub_pool_id) const
 {
     return mSpawnedPools.find(sub_pool_id) != mSpawnedPools.end();
 }
 
 // Method that tell if a quest can be started
 template<>
-bool ActivePoolData::IsActiveObject<Quest>(uint32 quest_id) const
+bool SpawnedPoolData::IsSpawnedObject<Quest>(uint32 quest_id) const
 {
-    return mActiveQuests.find(quest_id) != mActiveQuests.end();
+    return mSpawnedQuests.find(quest_id) != mSpawnedQuests.end();
 }
 
 template<>
-void ActivePoolData::ActivateObject<Creature>(uint32 db_guid, uint32 pool_id)
+void SpawnedPoolData::AddSpawn<Creature>(uint32 db_guid, uint32 pool_id)
 {
     mSpawnedCreatures.insert(db_guid);
     ++mSpawnedPools[pool_id];
 }
 
 template<>
-void ActivePoolData::ActivateObject<GameObject>(uint32 db_guid, uint32 pool_id)
+void SpawnedPoolData::AddSpawn<GameObject>(uint32 db_guid, uint32 pool_id)
 {
     mSpawnedGameobjects.insert(db_guid);
     ++mSpawnedPools[pool_id];
 }
 
 template<>
-void ActivePoolData::ActivateObject<Pool>(uint32 sub_pool_id, uint32 pool_id)
+void SpawnedPoolData::AddSpawn<Pool>(uint32 sub_pool_id, uint32 pool_id)
 {
     mSpawnedPools[sub_pool_id] = 0;
     ++mSpawnedPools[pool_id];
 }
 
 template<>
-void ActivePoolData::ActivateObject<Quest>(uint32 quest_id, uint32 pool_id)
+void SpawnedPoolData::AddSpawn<Quest>(uint32 quest_id, uint32 pool_id)
 {
-    mActiveQuests.insert(quest_id);
+    mSpawnedQuests.insert(quest_id);
     ++mSpawnedPools[pool_id];
 }
 
 template<>
-void ActivePoolData::RemoveObject<Creature>(uint32 db_guid, uint32 pool_id)
+void SpawnedPoolData::RemoveSpawn<Creature>(uint32 db_guid, uint32 pool_id)
 {
     mSpawnedCreatures.erase(db_guid);
     uint32& val = mSpawnedPools[pool_id];
@@ -99,7 +99,7 @@ void ActivePoolData::RemoveObject<Creature>(uint32 db_guid, uint32 pool_id)
 }
 
 template<>
-void ActivePoolData::RemoveObject<GameObject>(uint32 db_guid, uint32 pool_id)
+void SpawnedPoolData::RemoveSpawn<GameObject>(uint32 db_guid, uint32 pool_id)
 {
     mSpawnedGameobjects.erase(db_guid);
     uint32& val = mSpawnedPools[pool_id];
@@ -108,7 +108,7 @@ void ActivePoolData::RemoveObject<GameObject>(uint32 db_guid, uint32 pool_id)
 }
 
 template<>
-void ActivePoolData::RemoveObject<Pool>(uint32 sub_pool_id, uint32 pool_id)
+void SpawnedPoolData::RemoveSpawn<Pool>(uint32 sub_pool_id, uint32 pool_id)
 {
     mSpawnedPools.erase(sub_pool_id);
     uint32& val = mSpawnedPools[pool_id];
@@ -117,9 +117,9 @@ void ActivePoolData::RemoveObject<Pool>(uint32 sub_pool_id, uint32 pool_id)
 }
 
 template<>
-void ActivePoolData::RemoveObject<Quest>(uint32 quest_id, uint32 pool_id)
+void SpawnedPoolData::RemoveSpawn<Quest>(uint32 quest_id, uint32 pool_id)
 {
-    mActiveQuests.erase(quest_id);
+    mSpawnedQuests.erase(quest_id);
     uint32& val = mSpawnedPools[pool_id];
     if (val > 0)
         --val;
@@ -153,21 +153,42 @@ bool PoolGroup<T>::CheckPool() const
     return true;
 }
 
+template <class T>
+bool PoolGroup<T>::IsEmptyDeepCheck() const
+{
+    return IsEmpty();
+}
+
+// A mother pool is only spawnable if at least one of its child pools has content
+template <>
+bool PoolGroup<Pool>::IsEmptyDeepCheck() const
+{
+    for (PoolObject const& explicitlyChanced : ExplicitlyChanced)
+        if (!sPoolMgr->IsEmpty(explicitlyChanced.guid))
+            return false;
+
+    for (PoolObject const& equalChanced : EqualChanced)
+        if (!sPoolMgr->IsEmpty(equalChanced.guid))
+            return false;
+
+    return true;
+}
+
 // Main method to despawn a creature or gameobject in a pool
 // If no guid is passed, the pool is just removed (event end case)
 // If guid is filled, cache will be used and no removal will occur, it just fill the cache
 template<class T>
-void PoolGroup<T>::DespawnObject(ActivePoolData& spawns, ObjectGuid::LowType guid)
+void PoolGroup<T>::DespawnObject(SpawnedPoolData& spawns, ObjectGuid::LowType guid)
 {
     for (std::size_t i = 0; i < EqualChanced.size(); ++i)
     {
         // if spawned
-        if (spawns.IsActiveObject<T>(EqualChanced[i].guid))
+        if (spawns.IsSpawnedObject<T>(EqualChanced[i].guid))
         {
             if (!guid || EqualChanced[i].guid == guid)
             {
-                Despawn1Object(EqualChanced[i].guid);
-                spawns.RemoveObject<T>(EqualChanced[i].guid, poolId);
+                Despawn1Object(spawns, EqualChanced[i].guid);
+                spawns.RemoveSpawn<T>(EqualChanced[i].guid, poolId);
             }
         }
     }
@@ -175,12 +196,12 @@ void PoolGroup<T>::DespawnObject(ActivePoolData& spawns, ObjectGuid::LowType gui
     for (std::size_t i = 0; i < ExplicitlyChanced.size(); ++i)
     {
         // spawned
-        if (spawns.IsActiveObject<T>(ExplicitlyChanced[i].guid))
+        if (spawns.IsSpawnedObject<T>(ExplicitlyChanced[i].guid))
         {
             if (!guid || ExplicitlyChanced[i].guid == guid)
             {
-                Despawn1Object(ExplicitlyChanced[i].guid);
-                spawns.RemoveObject<T>(ExplicitlyChanced[i].guid, poolId);
+                Despawn1Object(spawns, ExplicitlyChanced[i].guid);
+                spawns.RemoveSpawn<T>(ExplicitlyChanced[i].guid, poolId);
             }
         }
     }
@@ -188,58 +209,40 @@ void PoolGroup<T>::DespawnObject(ActivePoolData& spawns, ObjectGuid::LowType gui
 
 // Method that is actualy doing the removal job on one creature
 template<>
-void PoolGroup<Creature>::Despawn1Object(ObjectGuid::LowType guid)
+void PoolGroup<Creature>::Despawn1Object(SpawnedPoolData& spawns, ObjectGuid::LowType guid)
 {
-    if (CreatureData const* data = sObjectMgr->GetCreatureData(guid))
+    auto creatureBounds = spawns.GetMap()->GetCreatureBySpawnIdStore().equal_range(guid);
+    for (auto itr = creatureBounds.first; itr != creatureBounds.second;)
     {
-        sObjectMgr->RemoveCreatureFromGrid(guid, data);
-
-        Map* map = sMapMgr->CreateBaseMap(data->mapid);
-        if (!map->Instanceable())
-        {
-            auto creatureBounds = map->GetCreatureBySpawnIdStore().equal_range(guid);
-            for (auto itr = creatureBounds.first; itr != creatureBounds.second;)
-            {
-                Creature* creature = itr->second;
-                ++itr;
-                creature->AddObjectToRemoveList();
-            }
-        }
+        Creature* creature = itr->second;
+        ++itr;
+        creature->AddObjectToRemoveList();
     }
 }
 
 // Same on one gameobject
 template<>
-void PoolGroup<GameObject>::Despawn1Object(ObjectGuid::LowType guid)
+void PoolGroup<GameObject>::Despawn1Object(SpawnedPoolData& spawns, ObjectGuid::LowType guid)
 {
-    if (GameObjectData const* data = sObjectMgr->GetGameObjectData(guid))
+    auto gameobjectBounds = spawns.GetMap()->GetGameObjectBySpawnIdStore().equal_range(guid);
+    for (auto itr = gameobjectBounds.first; itr != gameobjectBounds.second;)
     {
-        sObjectMgr->RemoveGameobjectFromGrid(guid, data);
-
-        Map* map = sMapMgr->CreateBaseMap(data->mapid);
-        if (!map->Instanceable())
-        {
-            auto gameobjectBounds = map->GetGameObjectBySpawnIdStore().equal_range(guid);
-            for (auto itr = gameobjectBounds.first; itr != gameobjectBounds.second;)
-            {
-                GameObject* go = itr->second;
-                ++itr;
-                go->AddObjectToRemoveList();
-            }
-        }
+        GameObject* go = itr->second;
+        ++itr;
+        go->AddObjectToRemoveList();
     }
 }
 
 // Same on one pool
 template<>
-void PoolGroup<Pool>::Despawn1Object(uint32 child_pool_id)
+void PoolGroup<Pool>::Despawn1Object(SpawnedPoolData& spawns, uint32 child_pool_id)
 {
-    sPoolMgr->DespawnPool(child_pool_id);
+    sPoolMgr->DespawnPool(spawns, child_pool_id);
 }
 
 // Same on one quest
 template<>
-void PoolGroup<Quest>::Despawn1Object(uint32 quest_id)
+void PoolGroup<Quest>::Despawn1Object(SpawnedPoolData& /*spawns*/, uint32 quest_id)
 {
     // Creatures
     QuestRelations* questMap = sObjectMgr->GetCreatureQuestRelationMap();
@@ -303,9 +306,9 @@ void PoolGroup<Pool>::RemoveOneRelation(uint32 child_pool_id)
 }
 
 template <class T>
-void PoolGroup<T>::SpawnObject(ActivePoolData& spawns, uint32 limit, uint32 triggerFrom)
+void PoolGroup<T>::SpawnObject(SpawnedPoolData& spawns, uint32 limit, uint32 triggerFrom)
 {
-    int count = limit - spawns.GetActiveObjectCount(poolId);
+    int count = limit - spawns.GetSpawnedObjects(poolId);
 
     // If triggered from some object respawn this object is still marked as spawned
     // and also counted into m_SpawnedPoolAmount so we need increase count to be
@@ -331,7 +334,7 @@ void PoolGroup<T>::SpawnObject(ActivePoolData& spawns, uint32 limit, uint32 trig
 
                 // Triggering object is marked as spawned at this time and can be also rolled (respawn case)
                 // so this need explicit check for this case
-                if (roll < 0 && (obj.guid == triggerFrom || !spawns.IsActiveObject<T>(obj.guid)))
+                if (roll < 0 && (obj.guid == triggerFrom || !spawns.IsSpawnedObject<T>(obj.guid)))
                 {
                     rolledObjects.push_back(obj);
                     break;
@@ -343,7 +346,7 @@ void PoolGroup<T>::SpawnObject(ActivePoolData& spawns, uint32 limit, uint32 trig
         {
             std::copy_if(EqualChanced.begin(), EqualChanced.end(), std::back_inserter(rolledObjects), [triggerFrom, &spawns](PoolObject const& object)
             {
-                 return object.guid == triggerFrom || !spawns.IsActiveObject<T>(object.guid);
+                 return object.guid == triggerFrom || !spawns.IsSpawnedObject<T>(object.guid);
             });
 
             Acore::Containers::RandomResize(rolledObjects, count);
@@ -354,13 +357,13 @@ void PoolGroup<T>::SpawnObject(ActivePoolData& spawns, uint32 limit, uint32 trig
         {
             if (obj.guid == triggerFrom)
             {
-                ReSpawn1Object(&obj);
+                ReSpawn1Object(spawns, &obj);
                 triggerFrom = 0;
             }
             else
             {
-                spawns.ActivateObject<T>(obj.guid, poolId);
-                Spawn1Object(&obj);
+                spawns.AddSpawn<T>(obj.guid, poolId);
+                Spawn1Object(spawns, &obj);
             }
         }
     }
@@ -374,16 +377,20 @@ void PoolGroup<T>::SpawnObject(ActivePoolData& spawns, uint32 limit, uint32 trig
 
 // Method that is actualy doing the spawn job on 1 creature
 template <>
-void PoolGroup<Creature>::Spawn1Object(PoolObject* obj)
+void PoolGroup<Creature>::Spawn1Object(SpawnedPoolData& spawns, PoolObject* obj)
 {
     if (CreatureData const* data = sObjectMgr->GetCreatureData(obj->guid))
     {
-        sObjectMgr->AddCreatureToGrid(obj->guid, data);
+        Map* map = spawns.GetMap();
+
+        // Grid loading enforces spawnMask through the per-difficulty grid data;
+        // spawning directly into an already loaded grid has to check it itself
+        if (!(data->spawnMask & (1 << map->GetSpawnMode())))
+            return;
 
         // Spawn if necessary (loaded grids only)
-        Map* map = sMapMgr->CreateBaseMap(data->mapid);
         // We use spawn coords to spawn
-        if (!map->Instanceable() && map->IsGridLoaded(data->posX, data->posY))
+        if (map->IsGridLoaded(data->posX, data->posY))
         {
             Creature* creature = new Creature;
             //LOG_DEBUG("pool", "Spawning creature {}", guid);
@@ -398,16 +405,18 @@ void PoolGroup<Creature>::Spawn1Object(PoolObject* obj)
 
 // Same for 1 gameobject
 template <>
-void PoolGroup<GameObject>::Spawn1Object(PoolObject* obj)
+void PoolGroup<GameObject>::Spawn1Object(SpawnedPoolData& spawns, PoolObject* obj)
 {
     if (GameObjectData const* data = sObjectMgr->GetGameObjectData(obj->guid))
     {
-        sObjectMgr->AddGameobjectToGrid(obj->guid, data);
+        Map* map = spawns.GetMap();
+
+        if (!(data->spawnMask & (1 << map->GetSpawnMode())))
+            return;
+
         // Spawn if necessary (loaded grids only)
-        // this base map checked as non-instanced and then only existed
-        Map* map = sMapMgr->CreateBaseMap(data->mapid);
         // We use current coords to unspawn, not spawn coords since creature can have changed grid
-        if (!map->Instanceable() && map->IsGridLoaded(data->posX, data->posY))
+        if (map->IsGridLoaded(data->posX, data->posY))
         {
             GameObject* pGameobject = sObjectMgr->IsGameObjectStaticTransport(data->id) ? new StaticTransport() : new GameObject();
             //LOG_DEBUG("pool", "Spawning gameobject {}", guid);
@@ -427,14 +436,14 @@ void PoolGroup<GameObject>::Spawn1Object(PoolObject* obj)
 
 // Same for 1 pool
 template <>
-void PoolGroup<Pool>::Spawn1Object(PoolObject* obj)
+void PoolGroup<Pool>::Spawn1Object(SpawnedPoolData& spawns, PoolObject* obj)
 {
-    sPoolMgr->SpawnPool(obj->guid);
+    sPoolMgr->SpawnPool(spawns, obj->guid);
 }
 
 // Same for 1 quest
 template<>
-void PoolGroup<Quest>::Spawn1Object(PoolObject* obj)
+void PoolGroup<Quest>::Spawn1Object(SpawnedPoolData& /*spawns*/, PoolObject* obj)
 {
     // Creatures
     QuestRelations* questMap = sObjectMgr->GetCreatureQuestRelationMap();
@@ -456,7 +465,7 @@ void PoolGroup<Quest>::Spawn1Object(PoolObject* obj)
 }
 
 template <>
-void PoolGroup<Quest>::SpawnObject(ActivePoolData& spawns, uint32 limit, uint32 triggerFrom)
+void PoolGroup<Quest>::SpawnObject(SpawnedPoolData& spawns, uint32 limit, uint32 triggerFrom)
 {
     LOG_DEBUG("pool", "PoolGroup<Quest>: Spawning pool {}", poolId);
     // load state from db
@@ -473,22 +482,22 @@ void PoolGroup<Quest>::SpawnObject(ActivePoolData& spawns, uint32 limit, uint32 
             do
             {
                 uint32 questId = result->Fetch()[0].Get<uint32>();
-                spawns.ActivateObject<Quest>(questId, poolId);
+                spawns.AddSpawn<Quest>(questId, poolId);
                 PoolObject tempObj(questId, 0.0f);
-                Spawn1Object(&tempObj);
+                Spawn1Object(spawns, &tempObj);
                 --limit;
             } while (result->NextRow() && limit);
             return;
         }
     }
 
-    ActivePoolObjects currentQuests = spawns.GetActiveQuests();
-    ActivePoolObjects newQuests;
+    SpawnedPoolObjects currentQuests = spawns.GetSpawnedQuests();
+    SpawnedPoolObjects newQuests;
 
     // always try to select different quests
     for (PoolObjectList::iterator itr = EqualChanced.begin(); itr != EqualChanced.end(); ++itr)
     {
-        if (spawns.IsActiveObject<Quest>(itr->guid))
+        if (spawns.IsSpawnedObject<Quest>(itr->guid))
             continue;
         newQuests.insert(itr->guid);
     }
@@ -514,9 +523,9 @@ void PoolGroup<Quest>::SpawnObject(ActivePoolData& spawns, uint32 limit, uint32 
     do
     {
         uint32 questId = Acore::Containers::SelectRandomContainerElement(newQuests);
-        spawns.ActivateObject<Quest>(questId, poolId);
+        spawns.AddSpawn<Quest>(questId, poolId);
         PoolObject tempObj(questId, 0.0f);
-        Spawn1Object(&tempObj);
+        Spawn1Object(spawns, &tempObj);
         newQuests.erase(questId);
         --limit;
     } while (limit && !newQuests.empty());
@@ -528,22 +537,22 @@ void PoolGroup<Quest>::SpawnObject(ActivePoolData& spawns, uint32 limit, uint32 
 
 // Method that does the respawn job on the specified object
 template <typename T>
-void PoolGroup<T>::ReSpawn1Object(PoolObject* obj)
+void PoolGroup<T>::ReSpawn1Object(SpawnedPoolData& spawns, PoolObject* obj)
 {
-    Despawn1Object(obj->guid);
-    Spawn1Object(obj);
+    Despawn1Object(spawns, obj->guid);
+    Spawn1Object(spawns, obj);
 }
 
 // Nothing to do for a quest
 template <>
-void PoolGroup<Quest>::ReSpawn1Object(PoolObject* /*obj*/)
+void PoolGroup<Quest>::ReSpawn1Object(SpawnedPoolData& /*spawns*/, PoolObject* /*obj*/)
 {
 }
 
 ////////////////////////////////////////////////////////////
 // Methods of class PoolMgr
 
-PoolMgr::PoolMgr()
+PoolMgr::PoolMgr() : mQuestSpawnedData(nullptr)
 {
 }
 
@@ -558,6 +567,8 @@ void PoolMgr::Initialize()
     mQuestSearchMap.clear();
     mGameobjectSearchMap.clear();
     mCreatureSearchMap.clear();
+    mAutoSpawnPoolsPerMap.clear();
+    mActiveEventPools.clear();
 }
 
 void PoolMgr::LoadFromDB()
@@ -584,6 +595,7 @@ void PoolMgr::LoadFromDB()
 
             PoolTemplateData& pPoolTemplate = mPoolTemplate[pool_id];
             pPoolTemplate.MaxLimit    = fields[1].Get<uint32>();
+            pPoolTemplate.MapId       = -1;
             pPoolTemplate.Description = fields[2].Get<std::string>();
 
             ++count;
@@ -635,7 +647,17 @@ void PoolMgr::LoadFromDB()
                     LOG_ERROR("sql.sql", "`pool_creature` has an invalid chance ({}) for creature guid ({}) in pool id ({}), skipped.", chance, guid, pool_id);
                     continue;
                 }
+
                 PoolTemplateData* pPoolTemplate = &mPoolTemplate[pool_id];
+                if (pPoolTemplate->MapId == -1)
+                    pPoolTemplate->MapId = int32(data->mapid);
+
+                if (pPoolTemplate->MapId != int32(data->mapid))
+                {
+                    LOG_ERROR("sql.sql", "`pool_creature` has creature spawns on multiple different maps for creature guid ({}) in pool id ({}), skipped.", guid, pool_id);
+                    continue;
+                }
+
                 PoolObject plObject = PoolObject(guid, chance);
                 PoolGroup<Creature>& cregroup = mPoolCreatureGroups[pool_id];
                 cregroup.SetPoolId(pool_id);
@@ -706,6 +728,15 @@ void PoolMgr::LoadFromDB()
                 }
 
                 PoolTemplateData* pPoolTemplate = &mPoolTemplate[pool_id];
+                if (pPoolTemplate->MapId == -1)
+                    pPoolTemplate->MapId = int32(data->mapid);
+
+                if (pPoolTemplate->MapId != int32(data->mapid))
+                {
+                    LOG_ERROR("sql.sql", "`pool_gameobject` has gameobject spawns on multiple different maps for gameobject guid ({}) in pool id ({}), skipped.", guid, pool_id);
+                    continue;
+                }
+
                 PoolObject plObject = PoolObject(guid, chance);
                 PoolGroup<GameObject>& gogroup = mPoolGameobjectGroups[pool_id];
                 gogroup.SetPoolId(pool_id);
@@ -790,6 +821,22 @@ void PoolMgr::LoadFromDB()
                 std::set<uint32> checkedPools;
                 for (SearchMap::iterator poolItr = mPoolSearchMap.find(it.first); poolItr != mPoolSearchMap.end(); poolItr = mPoolSearchMap.find(poolItr->second))
                 {
+                    // A mother pool spawns in one map's pool data, so the whole chain must stay on that map
+                    if (mPoolTemplate[poolItr->first].MapId != -1)
+                    {
+                        if (mPoolTemplate[poolItr->second].MapId == -1)
+                            mPoolTemplate[poolItr->second].MapId = mPoolTemplate[poolItr->first].MapId;
+
+                        if (mPoolTemplate[poolItr->second].MapId != mPoolTemplate[poolItr->first].MapId)
+                        {
+                            LOG_ERROR("sql.sql", "`pool_pool` has child pools on multiple maps in pool id ({}), skipped.", poolItr->second);
+                            mPoolPoolGroups[poolItr->second].RemoveOneRelation(poolItr->first);
+                            mPoolSearchMap.erase(poolItr);
+                            --count;
+                            break;
+                        }
+                    }
+
                     checkedPools.insert(poolItr->first);
                     if (checkedPools.find(poolItr->second) != checkedPools.end())
                     {
@@ -860,6 +907,14 @@ void PoolMgr::LoadFromDB()
                     continue;
                 }
 
+                // Quest pool state is global while mother pools spawn into one map's
+                // pool data, so a quest pool can never be a mother pool's child
+                if (uint32 motherPoolId = IsPartOfAPool<Pool>(pool_id))
+                {
+                    LOG_ERROR("sql.sql", "`pool_quest` pool id ({}) is a child of mother pool ({}), quest pools cannot be part of mother pools, skipped.", pool_id, motherPoolId);
+                    continue;
+                }
+
                 if (!quest->IsDailyOrWeekly())
                 {
                     LOG_ERROR("sql.sql", "`pool_quest` has an quest ({}) which is not daily or weekly in pool id ({}), use ExclusiveGroup instead, skipped.", entry, pool_id);
@@ -903,6 +958,12 @@ void PoolMgr::LoadFromDB()
         }
     }
 
+    for (auto const& [poolId, templateData] : mPoolTemplate)
+    {
+        if (IsEmpty(poolId))
+            LOG_ERROR("sql.sql", "Pool Id {} is empty (has no creatures, no gameobjects, no quests and no valid child pools). The pool will not be spawned.", poolId);
+    }
+
     // The initialize method will spawn all pools not in an event and not in another pool, this is why there is 2 left joins with 2 null checks
     LOG_INFO("server.loading", "Starting Objects Pooling System...");
     {
@@ -926,6 +987,9 @@ void PoolMgr::LoadFromDB()
                 uint32 pool_entry = fields[0].Get<uint32>();
                 uint32 pool_pool_id = fields[1].Get<uint32>();
 
+                if (IsEmpty(pool_entry))
+                    continue;
+
                 if (!CheckPool(pool_entry))
                 {
                     if (pool_pool_id)
@@ -940,12 +1004,20 @@ void PoolMgr::LoadFromDB()
                 // Don't spawn child pools, they are spawned recursively by their parent pools
                 if (!pool_pool_id)
                 {
-                    SpawnPool(pool_entry);
+                    // Quest pools are global and not map-bound: spawn them now
+                    // (restores the previously saved state from the characters DB)
+                    if (mPoolQuestGroups.find(pool_entry) != mPoolQuestGroups.end())
+                        SpawnPool<Quest>(mQuestSpawnedData, pool_entry, 0);
+
+                    PoolTemplateData const& templateData = mPoolTemplate[pool_entry];
+                    if (templateData.MapId != -1)
+                        mAutoSpawnPoolsPerMap[uint32(templateData.MapId)].push_back(pool_entry);
+
                     count++;
                 }
             } while (result->NextRow());
 
-            LOG_INFO("pool", "Pool handling system initialized, {} pools spawned in {} ms", count, GetMSTimeDiffToNow(oldMSTime));
+            LOG_INFO("pool", "Pool handling system initialized, {} pools will be spawned by default in {} ms", count, GetMSTimeDiffToNow(oldMSTime));
             LOG_INFO("server.loading", " ");
         }
     }
@@ -1002,7 +1074,7 @@ void PoolMgr::ChangeDailyQuests()
             if (quest->IsWeekly())
                 continue;
 
-            UpdatePool<Quest>(itr->second.GetPoolId(), 1);    // anything non-zero means don't load from db
+            UpdatePool<Quest>(mQuestSpawnedData, itr->second.GetPoolId(), 1);    // anything non-zero means don't load from db
         }
     }
 
@@ -1018,7 +1090,7 @@ void PoolMgr::ChangeWeeklyQuests()
             if (quest->IsDaily())
                 continue;
 
-            UpdatePool<Quest>(itr->second.GetPoolId(), 1);
+            UpdatePool<Quest>(mQuestSpawnedData, itr->second.GetPoolId(), 1);
         }
     }
 
@@ -1034,7 +1106,7 @@ void PoolMgr::ReSpawnPoolQuests()
             PoolObject tempObj(questId, 0.0f);
             auto it = mPoolQuestGroups.find(poolId);
             if (it != mPoolQuestGroups.end())
-                it->second.Spawn1Object(&tempObj);
+                it->second.Spawn1Object(mQuestSpawnedData, &tempObj);
         }
     }
 }
@@ -1042,73 +1114,92 @@ void PoolMgr::ReSpawnPoolQuests()
 // Call to spawn a pool, if cache if true the method will spawn only if cached entry is different
 // If it's same, the creature is respawned only (added back to map)
 template<>
-void PoolMgr::SpawnPool<Creature>(uint32 pool_id, uint32 db_guid)
+void PoolMgr::SpawnPool<Creature>(SpawnedPoolData& spawnedPoolData, uint32 pool_id, uint32 db_guid)
 {
     auto it = mPoolCreatureGroups.find(pool_id);
     if (it != mPoolCreatureGroups.end() && !it->second.IsEmpty())
-        it->second.SpawnObject(mSpawnedData, mPoolTemplate[pool_id].MaxLimit, db_guid);
+        it->second.SpawnObject(spawnedPoolData, mPoolTemplate[pool_id].MaxLimit, db_guid);
 }
 
 // Call to spawn a pool, if cache if true the method will spawn only if cached entry is different
 // If it's same, the gameobject is respawned only (added back to map)
 template<>
-void PoolMgr::SpawnPool<GameObject>(uint32 pool_id, uint32 db_guid)
+void PoolMgr::SpawnPool<GameObject>(SpawnedPoolData& spawnedPoolData, uint32 pool_id, uint32 db_guid)
 {
     auto it = mPoolGameobjectGroups.find(pool_id);
     if (it != mPoolGameobjectGroups.end() && !it->second.IsEmpty())
-        it->second.SpawnObject(mSpawnedData, mPoolTemplate[pool_id].MaxLimit, db_guid);
+        it->second.SpawnObject(spawnedPoolData, mPoolTemplate[pool_id].MaxLimit, db_guid);
 }
 
 // Call to spawn a pool, if cache if true the method will spawn only if cached entry is different
 // If it's same, the pool is respawned only
 template<>
-void PoolMgr::SpawnPool<Pool>(uint32 pool_id, uint32 sub_pool_id)
+void PoolMgr::SpawnPool<Pool>(SpawnedPoolData& spawnedPoolData, uint32 pool_id, uint32 sub_pool_id)
 {
     auto it = mPoolPoolGroups.find(pool_id);
     if (it != mPoolPoolGroups.end() && !it->second.IsEmpty())
-        it->second.SpawnObject(mSpawnedData, mPoolTemplate[pool_id].MaxLimit, sub_pool_id);
+        it->second.SpawnObject(spawnedPoolData, mPoolTemplate[pool_id].MaxLimit, sub_pool_id);
 }
 
 // Call to spawn a pool
 template<>
-void PoolMgr::SpawnPool<Quest>(uint32 pool_id, uint32 quest_id)
+void PoolMgr::SpawnPool<Quest>(SpawnedPoolData& spawnedPoolData, uint32 pool_id, uint32 quest_id)
 {
     auto it = mPoolQuestGroups.find(pool_id);
     if (it != mPoolQuestGroups.end() && !it->second.IsEmpty())
-        it->second.SpawnObject(mSpawnedData, mPoolTemplate[pool_id].MaxLimit, quest_id);
+        it->second.SpawnObject(spawnedPoolData, mPoolTemplate[pool_id].MaxLimit, quest_id);
 }
 
-void PoolMgr::SpawnPool(uint32 pool_id)
+void PoolMgr::SpawnPool(SpawnedPoolData& spawnedPoolData, uint32 pool_id)
 {
-    SpawnPool<Pool>(pool_id, 0);
-    SpawnPool<GameObject>(pool_id, 0);
-    SpawnPool<Creature>(pool_id, 0);
-    SpawnPool<Quest>(pool_id, 0);
+    SpawnPool<Pool>(spawnedPoolData, pool_id, 0);
+    SpawnPool<GameObject>(spawnedPoolData, pool_id, 0);
+    SpawnPool<Creature>(spawnedPoolData, pool_id, 0);
 }
 
 // Call to despawn a pool, all gameobjects/creatures in this pool are removed
-void PoolMgr::DespawnPool(uint32 pool_id)
+void PoolMgr::DespawnPool(SpawnedPoolData& spawnedPoolData, uint32 pool_id)
 {
     {
         auto it = mPoolCreatureGroups.find(pool_id);
         if (it != mPoolCreatureGroups.end() && !it->second.IsEmpty())
-            it->second.DespawnObject(mSpawnedData);
+            it->second.DespawnObject(spawnedPoolData);
     }
     {
         auto it = mPoolGameobjectGroups.find(pool_id);
         if (it != mPoolGameobjectGroups.end() && !it->second.IsEmpty())
-            it->second.DespawnObject(mSpawnedData);
+            it->second.DespawnObject(spawnedPoolData);
     }
     {
         auto it = mPoolPoolGroups.find(pool_id);
         if (it != mPoolPoolGroups.end() && !it->second.IsEmpty())
-            it->second.DespawnObject(mSpawnedData);
+            it->second.DespawnObject(spawnedPoolData);
+    }
+}
+
+bool PoolMgr::IsEmpty(uint32 pool_id) const
+{
+    {
+        auto it = mPoolGameobjectGroups.find(pool_id);
+        if (it != mPoolGameobjectGroups.end() && !it->second.IsEmptyDeepCheck())
+            return false;
+    }
+    {
+        auto it = mPoolCreatureGroups.find(pool_id);
+        if (it != mPoolCreatureGroups.end() && !it->second.IsEmptyDeepCheck())
+            return false;
+    }
+    {
+        auto it = mPoolPoolGroups.find(pool_id);
+        if (it != mPoolPoolGroups.end() && !it->second.IsEmptyDeepCheck())
+            return false;
     }
     {
         auto it = mPoolQuestGroups.find(pool_id);
-        if (it != mPoolQuestGroups.end() && !it->second.IsEmpty())
-            it->second.DespawnObject(mSpawnedData);
+        if (it != mPoolQuestGroups.end() && !it->second.IsEmptyDeepCheck())
+            return false;
     }
+    return true;
 }
 
 // Method that check chance integrity of the creatures and gameobjects in this pool
@@ -1141,18 +1232,71 @@ bool PoolMgr::CheckPool(uint32 pool_id) const
 // Here we cache only the creature/gameobject whose guid is passed as parameter
 // Then the spawn pool call will use this cache to decide
 template<typename T>
-void PoolMgr::UpdatePool(uint32 pool_id, uint32 db_guid_or_pool_id)
+void PoolMgr::UpdatePool(SpawnedPoolData& spawnedPoolData, uint32 pool_id, uint32 db_guid_or_pool_id)
 {
     if (uint32 motherpoolid = IsPartOfAPool<Pool>(pool_id))
-        SpawnPool<Pool>(motherpoolid, pool_id);
+        SpawnPool<Pool>(spawnedPoolData, motherpoolid, pool_id);
     else
-        SpawnPool<T>(pool_id, db_guid_or_pool_id);
+        SpawnPool<T>(spawnedPoolData, pool_id, db_guid_or_pool_id);
 }
 
-template void PoolMgr::UpdatePool<Pool>(uint32 pool_id, uint32 db_guid_or_pool_id);
-template void PoolMgr::UpdatePool<GameObject>(uint32 pool_id, uint32 db_guid_or_pool_id);
-template void PoolMgr::UpdatePool<Creature>(uint32 pool_id, uint32 db_guid_or_pool_id);
-template void PoolMgr::UpdatePool<Quest>(uint32 pool_id, uint32 db_guid_or_pool_id);
+template void PoolMgr::UpdatePool<Pool>(SpawnedPoolData& spawnedPoolData, uint32 pool_id, uint32 db_guid_or_pool_id);
+template void PoolMgr::UpdatePool<GameObject>(SpawnedPoolData& spawnedPoolData, uint32 pool_id, uint32 db_guid_or_pool_id);
+template void PoolMgr::UpdatePool<Creature>(SpawnedPoolData& spawnedPoolData, uint32 pool_id, uint32 db_guid_or_pool_id);
+template void PoolMgr::UpdatePool<Quest>(SpawnedPoolData& spawnedPoolData, uint32 pool_id, uint32 db_guid_or_pool_id);
+
+void PoolMgr::SpawnEventPool(uint32 pool_id)
+{
+    PoolTemplateData const* poolTemplate = GetPoolTemplate(pool_id);
+    if (!poolTemplate || poolTemplate->MapId == -1)
+        return;
+
+    // Remembered while the event runs so maps created later spawn it on creation
+    mActiveEventPools.insert(pool_id);
+
+    sMapMgr->DoForAllMapsWithMapId(uint32(poolTemplate->MapId), [pool_id](Map* map)
+    {
+        sPoolMgr->SpawnPool(map->GetPoolData(), pool_id);
+    });
+}
+
+void PoolMgr::DespawnEventPool(uint32 pool_id)
+{
+    mActiveEventPools.erase(pool_id);
+
+    PoolTemplateData const* poolTemplate = GetPoolTemplate(pool_id);
+    if (!poolTemplate || poolTemplate->MapId == -1)
+        return;
+
+    sMapMgr->DoForAllMapsWithMapId(uint32(poolTemplate->MapId), [pool_id](Map* map)
+    {
+        sPoolMgr->DespawnPool(map->GetPoolData(), pool_id);
+    });
+}
+
+std::unique_ptr<SpawnedPoolData> PoolMgr::InitPoolsForMap(Map* map)
+{
+    std::unique_ptr<SpawnedPoolData> spawnedPoolData = std::make_unique<SpawnedPoolData>(map);
+
+    // The MapInstanced container never holds spawns itself, only its child instances do
+    if (map->Instanceable() && !map->GetInstanceId())
+        return spawnedPoolData;
+
+    if (std::vector<uint32> const* poolIds = Acore::Containers::MapGetValuePtr(mAutoSpawnPoolsPerMap, map->GetId()))
+    {
+        for (uint32 poolId : *poolIds)
+            SpawnPool(*spawnedPoolData, poolId);
+    }
+
+    for (uint32 poolId : mActiveEventPools)
+    {
+        PoolTemplateData const* poolTemplate = GetPoolTemplate(poolId);
+        if (poolTemplate && poolTemplate->MapId == int32(map->GetId()))
+            SpawnPool(*spawnedPoolData, poolId);
+    }
+
+    return spawnedPoolData;
+}
 
 PoolTemplateData const* PoolMgr::GetPoolTemplate(uint32 poolId) const
 {

--- a/src/server/game/Pools/PoolMgr.h
+++ b/src/server/game/Pools/PoolMgr.h
@@ -110,6 +110,8 @@ public:
     std::vector<PoolObject> const& GetExplicitlyChanced() const { return ExplicitlyChanced; }
     std::vector<PoolObject> const& GetEqualChanced() const { return EqualChanced; }
 private:
+    static bool IsSpawnableOnMap(uint32 db_guid_or_pool_id, Map* map);
+
     uint32 poolId;
     PoolObjectList ExplicitlyChanced;
     PoolObjectList EqualChanced;
@@ -203,6 +205,8 @@ private:
     SearchMap mQuestSearchMap;
 
     std::unordered_map<uint32, std::vector<uint32>> mAutoSpawnPoolsPerMap;
+
+    // World thread only: mutated on game event start/stop, read on map creation
     std::unordered_set<uint32> mActiveEventPools;
 
     // active state of quest pools; per-map state lives on each Map's SpawnedPoolData

--- a/src/server/game/Pools/PoolMgr.h
+++ b/src/server/game/Pools/PoolMgr.h
@@ -22,10 +22,15 @@
 #include "Define.h"
 #include "GameObject.h"
 #include "QuestDef.h"
+#include <memory>
+#include <type_traits>
+
+class Map;
 
 struct PoolTemplateData
 {
     uint32      MaxLimit;
+    int32       MapId;
     std::string Description;
 };
 
@@ -40,29 +45,40 @@ class Pool                                                  // for Pool of Pool 
 {
 };
 
-typedef std::unordered_set<uint32> ActivePoolObjects;
-typedef std::map<uint32, uint32> ActivePoolPools;
+typedef std::unordered_set<uint32> SpawnedPoolObjects;
+typedef std::map<uint32, uint32> SpawnedPoolPools;
 
-class ActivePoolData
+class SpawnedPoolData
 {
 public:
+    // owner is nullptr only for PoolMgr's global quest pool state
+    explicit SpawnedPoolData(Map* owner) : mOwner(owner) { }
+
+    SpawnedPoolData(SpawnedPoolData const&) = delete;
+    SpawnedPoolData(SpawnedPoolData&&) = delete;
+    SpawnedPoolData& operator=(SpawnedPoolData const&) = delete;
+    SpawnedPoolData& operator=(SpawnedPoolData&&) = delete;
+
+    Map* GetMap() const { return mOwner; }
+
     template<typename T>
-    bool IsActiveObject(uint32 db_guid_or_pool_id) const;
+    bool IsSpawnedObject(uint32 db_guid_or_pool_id) const;
 
-    uint32 GetActiveObjectCount(uint32 pool_id) const;
-
-    template<typename T>
-    void ActivateObject(uint32 db_guid_or_pool_id, uint32 pool_id);
+    uint32 GetSpawnedObjects(uint32 pool_id) const;
 
     template<typename T>
-    void RemoveObject(uint32 db_guid_or_pool_id, uint32 pool_id);
+    void AddSpawn(uint32 db_guid_or_pool_id, uint32 pool_id);
 
-    ActivePoolObjects GetActiveQuests() const { return mActiveQuests; } // a copy of the set
+    template<typename T>
+    void RemoveSpawn(uint32 db_guid_or_pool_id, uint32 pool_id);
+
+    SpawnedPoolObjects GetSpawnedQuests() const { return mSpawnedQuests; } // a copy of the set
 private:
-    ActivePoolObjects mSpawnedCreatures;
-    ActivePoolObjects mSpawnedGameobjects;
-    ActivePoolObjects mActiveQuests;
-    ActivePoolPools   mSpawnedPools;
+    Map* mOwner;
+    SpawnedPoolObjects mSpawnedCreatures;
+    SpawnedPoolObjects mSpawnedGameobjects;
+    SpawnedPoolObjects mSpawnedQuests;
+    SpawnedPoolPools   mSpawnedPools;
 };
 
 template <class T>
@@ -74,14 +90,15 @@ public:
     void SetPoolId(uint32 pool_id) { poolId = pool_id; }
     ~PoolGroup() {};
     bool IsEmpty() const { return ExplicitlyChanced.empty() && EqualChanced.empty(); }
+    bool IsEmptyDeepCheck() const;
     void AddEntry(PoolObject& poolitem, uint32 maxentries);
     bool CheckPool() const;
-    void DespawnObject(ActivePoolData& spawns, ObjectGuid::LowType guid = 0);
-    void Despawn1Object(ObjectGuid::LowType guid);
-    void SpawnObject(ActivePoolData& spawns, uint32 limit, uint32 triggerFrom);
+    void DespawnObject(SpawnedPoolData& spawns, ObjectGuid::LowType guid = 0);
+    void Despawn1Object(SpawnedPoolData& spawns, ObjectGuid::LowType guid);
+    void SpawnObject(SpawnedPoolData& spawns, uint32 limit, uint32 triggerFrom);
 
-    void Spawn1Object(PoolObject* obj);
-    void ReSpawn1Object(PoolObject* obj);
+    void Spawn1Object(SpawnedPoolData& spawns, PoolObject* obj);
+    void ReSpawn1Object(SpawnedPoolData& spawns, PoolObject* obj);
     void RemoveOneRelation(uint32 child_pool_id);
     uint32 GetFirstEqualChancedObjectId()
     {
@@ -120,16 +137,31 @@ public:
     template<typename T>
     uint32 IsPartOfAPool(uint32 db_guid_or_pool_id) const;
 
+    // Quest pool state is global: quests are realm-wide, not tied to a map.
+    // Creature/GameObject/Pool spawn state lives on the owning Map's SpawnedPoolData.
     template<typename T>
-    bool IsSpawnedObject(uint32 db_guid_or_pool_id) const { return mSpawnedData.IsActiveObject<T>(db_guid_or_pool_id); }
+    bool IsSpawnedObject(uint32 quest_id) const
+    {
+        static_assert(std::is_same_v<T, Quest>, "only quest pool state is global; query the owning Map's SpawnedPoolData instead");
+        return mQuestSpawnedData.IsSpawnedObject<Quest>(quest_id);
+    }
 
+    bool IsEmpty(uint32 pool_id) const;
     bool CheckPool(uint32 pool_id) const;
 
-    void SpawnPool(uint32 pool_id);
-    void DespawnPool(uint32 pool_id);
+    void SpawnPool(SpawnedPoolData& spawnedPoolData, uint32 pool_id);
+    void DespawnPool(SpawnedPoolData& spawnedPoolData, uint32 pool_id);
 
     template<typename T>
-    void UpdatePool(uint32 pool_id, uint32 db_guid_or_pool_id);
+    void UpdatePool(SpawnedPoolData& spawnedPoolData, uint32 pool_id, uint32 db_guid_or_pool_id);
+
+    // Game-event pools are spawned on all live maps of the pool's map id and
+    // remembered while active, so maps created mid-event (lazily created
+    // continents, new instances) spawn them on creation too.
+    void SpawnEventPool(uint32 pool_id);
+    void DespawnEventPool(uint32 pool_id);
+
+    std::unique_ptr<SpawnedPoolData> InitPoolsForMap(Map* map);
 
     void ChangeDailyQuests();
     void ChangeWeeklyQuests();
@@ -143,14 +175,14 @@ public:
     PoolGroup<Creature> const* GetPoolCreatureGroup(uint32 poolId) const;
     PoolGroup<GameObject> const* GetPoolGameObjectGroup(uint32 poolId) const;
     PoolGroup<Pool> const* GetPoolPoolGroup(uint32 poolId) const;
-    ActivePoolData const& GetSpawnedData() const { return mSpawnedData; }
+    SpawnedPoolData const& GetQuestSpawnedData() const { return mQuestSpawnedData; }
     uint32 GetCreaturePoolId(uint32 guid) const;
     uint32 GetGameObjectPoolId(uint32 guid) const;
 
     friend class PoolQuestReloadFixTest;
 private:
     template<typename T>
-    void SpawnPool(uint32 pool_id, uint32 db_guid_or_pool_id);
+    void SpawnPool(SpawnedPoolData& spawnedPoolData, uint32 pool_id, uint32 db_guid_or_pool_id);
 
     typedef std::unordered_map<uint32, PoolTemplateData>      PoolTemplateDataMap;
     typedef std::unordered_map<uint32, PoolGroup<Creature>>   PoolGroupCreatureMap;
@@ -170,11 +202,19 @@ private:
     SearchMap mPoolSearchMap;
     SearchMap mQuestSearchMap;
 
-    // dynamic data
-    ActivePoolData mSpawnedData;
+    std::unordered_map<uint32, std::vector<uint32>> mAutoSpawnPoolsPerMap;
+    std::unordered_set<uint32> mActiveEventPools;
+
+    // active state of quest pools; per-map state lives on each Map's SpawnedPoolData
+    SpawnedPoolData mQuestSpawnedData;
 };
 
 #define sPoolMgr PoolMgr::instance()
+
+template<> void PoolMgr::SpawnPool<Pool>(SpawnedPoolData& spawnedPoolData, uint32 pool_id, uint32 sub_pool_id);
+template<> void PoolMgr::SpawnPool<Creature>(SpawnedPoolData& spawnedPoolData, uint32 pool_id, uint32 db_guid);
+template<> void PoolMgr::SpawnPool<GameObject>(SpawnedPoolData& spawnedPoolData, uint32 pool_id, uint32 db_guid);
+template<> void PoolMgr::SpawnPool<Quest>(SpawnedPoolData& spawnedPoolData, uint32 pool_id, uint32 quest_id);
 
 // Method that tell if the creature is part of a pool and return the pool id if yes
 template<>

--- a/src/server/scripts/Commands/cs_gobject.cpp
+++ b/src/server/scripts/Commands/cs_gobject.cpp
@@ -313,7 +313,7 @@ public:
             mapId =   fields[6].Get<uint16>();
             phase =   fields[7].Get<uint32>();
             poolId =  sPoolMgr->IsPartOfAPool<GameObject>(guidLow);
-            if (!poolId || sPoolMgr->IsSpawnedObject<GameObject>(guidLow))
+            if (!poolId || handler->GetSession()->GetPlayer()->GetMap()->GetPoolData().IsSpawnedObject<GameObject>(guidLow))
                 found = true;
         } while (result->NextRow() && !found);
 

--- a/src/server/scripts/Commands/cs_pool.cpp
+++ b/src/server/scripts/Commands/cs_pool.cpp
@@ -54,9 +54,28 @@ private:
         return active ? "ACTIVE" : "inactive";
     }
 
+    // Spawn state lives on the pool's map: prefer the invoker's map, else the
+    // loaded base map. Returns nullptr when no matching map is loaded (state
+    // then displays as inactive).
+    static SpawnedPoolData const* GetPoolSpawns(ChatHandler* handler, PoolTemplateData const* tpl)
+    {
+        if (tpl->MapId == -1)
+            return nullptr;
+
+        if (Player* player = handler->GetPlayer())
+            if (player->GetMap()->GetId() == uint32(tpl->MapId))
+                return &player->GetMap()->GetPoolData();
+
+        if (Map* map = sMapMgr->FindMap(uint32(tpl->MapId), 0))
+            if (!map->Instanceable())
+                return &map->GetPoolData();
+
+        return nullptr;
+    }
+
     static void ListPoolMembers(ChatHandler* handler, char const* typeName,
         std::vector<PoolObject> const& explicitly,
-        std::vector<PoolObject> const& equal, bool isCreature)
+        std::vector<PoolObject> const& equal, bool isCreature, SpawnedPoolData const* spawns)
     {
         if (explicitly.empty() && equal.empty())
             return;
@@ -66,9 +85,9 @@ private:
 
         auto printMember = [&](PoolObject const& obj)
         {
-            bool spawned = isCreature
-                ? sPoolMgr->IsSpawnedObject<Creature>(obj.guid)
-                : sPoolMgr->IsSpawnedObject<GameObject>(obj.guid);
+            bool spawned = spawns && (isCreature
+                ? spawns->IsSpawnedObject<Creature>(obj.guid)
+                : spawns->IsSpawnedObject<GameObject>(obj.guid));
 
             std::string name = "Unknown";
             uint32 entry = 0;
@@ -122,7 +141,12 @@ private:
             return false;
         }
 
-        uint32 activeCount = sPoolMgr->GetSpawnedData().GetActiveObjectCount(poolId);
+        SpawnedPoolData const* spawns = GetPoolSpawns(handler, tpl);
+
+        uint32 activeCount = sPoolMgr->GetQuestSpawnedData().GetSpawnedObjects(poolId);
+        if (spawns)
+            activeCount += spawns->GetSpawnedObjects(poolId);
+
         handler->PSendSysMessage(LANG_POOL_INFO_HEADER, poolId,
             tpl->Description.empty() ? "(none)" : tpl->Description,
             tpl->MaxLimit, activeCount);
@@ -137,7 +161,7 @@ private:
         {
             if (!creGroup->IsEmpty())
                 ListPoolMembers(handler, "Creatures",
-                    creGroup->GetExplicitlyChanced(), creGroup->GetEqualChanced(), true);
+                    creGroup->GetExplicitlyChanced(), creGroup->GetEqualChanced(), true, spawns);
         }
 
         // GameObject members
@@ -145,7 +169,7 @@ private:
         {
             if (!goGroup->IsEmpty())
                 ListPoolMembers(handler, "GameObjects",
-                    goGroup->GetExplicitlyChanced(), goGroup->GetEqualChanced(), false);
+                    goGroup->GetExplicitlyChanced(), goGroup->GetEqualChanced(), false, spawns);
         }
 
         // Sub-pool members
@@ -160,7 +184,7 @@ private:
 
                 auto printSubPool = [&](PoolObject const& obj)
                 {
-                    bool active = sPoolMgr->GetSpawnedData().IsActiveObject<Pool>(obj.guid);
+                    bool active = spawns && spawns->IsSpawnedObject<Pool>(obj.guid);
                     PoolTemplateData const* subTpl = sPoolMgr->GetPoolTemplate(obj.guid);
                     std::string desc = subTpl ? subTpl->Description : "Unknown";
 
@@ -192,7 +216,7 @@ private:
             uint32 poolId = sPoolMgr->GetCreaturePoolId(spawnId);
             if (poolId)
             {
-                bool spawned = sPoolMgr->IsSpawnedObject<Creature>(spawnId);
+                bool spawned = target->GetMap()->GetPoolData().IsSpawnedObject<Creature>(spawnId);
                 handler->PSendSysMessage(LANG_POOL_LOOKUP_IN_POOL,
                     target->GetName(), spawnId, poolId, StatusTag(spawned));
                 handler->PSendSysMessage(LANG_POOL_LOOKUP_USE_INFO, poolId);
@@ -212,7 +236,7 @@ private:
             uint32 poolId = sPoolMgr->GetGameObjectPoolId(spawnId);
             if (poolId)
             {
-                bool spawned = sPoolMgr->IsSpawnedObject<GameObject>(spawnId);
+                bool spawned = goTarget->GetMap()->GetPoolData().IsSpawnedObject<GameObject>(spawnId);
                 handler->PSendSysMessage(LANG_POOL_LOOKUP_IN_POOL,
                     goTarget->GetName(), spawnId, poolId, StatusTag(spawned));
                 handler->PSendSysMessage(LANG_POOL_LOOKUP_USE_INFO, poolId);

--- a/src/test/server/game/Pools/PoolQuestReloadTest.cpp
+++ b/src/test/server/game/Pools/PoolQuestReloadTest.cpp
@@ -86,7 +86,8 @@ protected:
     {
         PoolGroup<Quest> poolGroup;
         PoolObject obj(questId, 0.0f);
-        poolGroup.Spawn1Object(&obj);
+        SpawnedPoolData spawns(nullptr);
+        poolGroup.Spawn1Object(spawns, &obj);
     }
 
     /// Simulate what LoadQuestRelationsHelper does on reload:
@@ -230,7 +231,7 @@ protected:
         sPoolMgr->mQuestSearchMap[TEST_QUEST_ID] = TEST_POOL_ID;
 
         // Mark the quest as active/spawned
-        sPoolMgr->mSpawnedData.ActivateObject<Quest>(TEST_QUEST_ID, TEST_POOL_ID);
+        sPoolMgr->mQuestSpawnedData.AddSpawn<Quest>(TEST_QUEST_ID, TEST_POOL_ID);
 
         // Set up pool-side mapping: quest -> creature
         sPoolMgr->mQuestCreatureRelation.insert(
@@ -243,7 +244,7 @@ protected:
         sPoolMgr->mPoolTemplate.erase(TEST_POOL_ID);
         sPoolMgr->mPoolQuestGroups.erase(TEST_POOL_ID);
         sPoolMgr->mQuestSearchMap.erase(TEST_QUEST_ID);
-        sPoolMgr->mSpawnedData.RemoveObject<Quest>(TEST_QUEST_ID, TEST_POOL_ID);
+        sPoolMgr->mQuestSpawnedData.RemoveSpawn<Quest>(TEST_QUEST_ID, TEST_POOL_ID);
 
         auto range = sPoolMgr->mQuestCreatureRelation.equal_range(TEST_QUEST_ID);
         sPoolMgr->mQuestCreatureRelation.erase(range.first, range.second);
@@ -270,7 +271,8 @@ TEST_F(PoolQuestReloadFixTest, ReSpawnPoolQuestsRestoresQuestAfterReload)
     // 1. Spawn the quest onto the NPC (simulates normal startup)
     PoolGroup<Quest> poolGroup;
     PoolObject obj(TEST_QUEST_ID, 0.0f);
-    poolGroup.Spawn1Object(&obj);
+    SpawnedPoolData spawns(nullptr);
+    poolGroup.Spawn1Object(spawns, &obj);
 
     auto count = [&]() {
         uint32 n = 0;


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Port of TrinityCore commit https://github.com/TrinityCore/TrinityCore/commit/94d829c84fb184990e26178551d10ecdca049efd (Core/Pools: Implemented pooling for instances), adapted to AzerothCore.

### The problem

`PoolMgr` keeps all spawned-object state (`ActivePoolData`, a set of `unordered_set`s) in one global structure, but pool updates run on map update worker threads: the creature/gameobject respawn paths and `Map::ProcessRespawns` all call `sPoolMgr->UpdatePool` from their own map's thread. Two maps rolling pool respawns in the same tick mutate the same hash containers without synchronization, corrupt them, and crash:

```
#4  ActivePoolData::IsActiveObject<Creature> (PoolMgr.cpp:40)
#5  PoolGroup<Creature>::DespawnObject (PoolMgr.cpp:165)
#6  PoolMgr::DespawnPool (PoolMgr.cpp:1095)
...
#11 Map::ProcessCreatureRespawn (Map.cpp:2791)
#13 Map::Update
#15 MapUpdater::WorkerThread
```

Pool spawning also mutated the global grid guid store (`ObjectMgr::Add/RemoveCreatureFromGrid`) from map threads, a second cross-thread race.

### The fix (TC parity)

- Mutable spawn state moves into `SpawnedPoolData`, owned by each `Map` and created with it (`PoolMgr::InitPoolsForMap`). Every map thread only touches its own map's state, so no locking is needed anywhere.
- `pool_template.MapId` is computed at load time from member spawns and propagated through `pool_pool` chains; pools spanning several maps are rejected with a DB error. Unlike TC, no new DB column is needed.
- Pooled spawns are now part of the regular grid data; the grid loader skips members the owning map's pool state has not rolled as spawned. The global grid data is no longer mutated at runtime by pools.
- Pooling now works in instanced maps, each instance rolling its own state. The DB already ships pool data on instance maps (BRD, Dire Maul, Sunken Temple, ZG, AQ, several TBC dungeons and more) that AC silently ignored until now.

### AC-specific adaptations

- Quest pools stay inside `PoolMgr` with a single global state, since quests are realm-wide and AC has not split quest pooling out (TC master did that separately in QuestPoolMgr). Quest pools are rejected as `pool_pool` children at load; the DB has none. Splitting the bookkeeping also fixes pools 358/359 (Argent Tournament dailies), whose ids collide with old creature pool members: both shared one `max_limit` counter, so the daily quests could never activate.
- Deviation from TC: game-event pools are remembered while their event is active, so maps created mid-event (lazily created continents when grid preloading is off, fresh instances) spawn them on creation. TC only spawns event pools on maps that already exist when the event starts.
- Direct pool spawns into already-loaded grids check `spawnMask`, matching what per-difficulty grid data enforces on grid load.
- DB fix included: pool 366 (Omgorn the Lost) had its Eastmoon/Southmoon Ruins spawns on map 0 while both subzones are in Tanaris (map 1), which the new single-map validation would reject.

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Fable 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #6658
- Fixes https://github.com/chromiecraft/chromiecraft/issues/5882 (pooled mining/herb nodes in Auchindoun instances never spawn)
- No issue filed for the crash itself; observed on a live server (backtrace above).

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Upstream source: https://github.com/TrinityCore/TrinityCore/commit/94d829c84fb184990e26178551d10ecdca049efd

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Continents: `.pool info <id>` on a known pool (e.g. TLPD pool chain), kill a pooled rare and verify the pool rerolls on respawn. Run activity on two continents at once to exercise concurrent map updates (previously crashed).
2. Instances: enter Dire Maul or BRD repeatedly and verify pooled rares/chests now spawn, with different rolls per instance.
3. Game events: start/stop Darkmoon Faire (`.event start 9` / `.event stop 9`) and verify its pooled objects spawn/despawn; also start the event before entering a continent that is not loaded yet (grid preloading off) and verify the spawns appear once the map is created.
4. Daily quest pools: pass a daily reset (or `.quest reset daily`-equivalent flow) and verify pooled dailies (Dalaran cooking/fishing/jewelcrafting) rotate and persist across restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

