### PR TITLE
fix(Core/Spells): allow paladin auras from different casters to coexist

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuras.cpp
+++ b/src/server/game/Spells/Auras/SpellAuras.cpp
@@ -529,6 +529,52 @@ void Aura::_Remove(AuraRemoveMode removeMode)
     }
 }
 
+// paladin auras of the same spell may coexist on a target (one per caster) so Aura Mastery works
+// per-caster, but only the strongest one keeps its effects. Ties favor the target's own self-cast
+// aura, then the lower caster guid, to keep the outcome deterministic across update cycles.
+static bool IsPaladinAuraDominant(Aura const* aura, Aura const* other, Unit const* target)
+{
+    auto primaryAmount = [](Aura const* a) -> int32
+    {
+        for (uint8 i = 0; i < MAX_SPELL_EFFECTS; ++i)
+            if (AuraEffect* eff = a->GetEffect(i))
+                return eff->GetAmount();
+        return 0;
+    };
+
+    int32 auraAmount = std::abs(primaryAmount(aura));
+    int32 otherAmount = std::abs(primaryAmount(other));
+    if (auraAmount != otherAmount)
+        return auraAmount > otherAmount;
+
+    bool auraSelf = aura->GetCasterGUID() == target->GetGUID();
+    bool otherSelf = other->GetCasterGUID() == target->GetGUID();
+    if (auraSelf != otherSelf)
+        return auraSelf;
+
+    return aura->GetCasterGUID() < other->GetCasterGUID();
+}
+
+// strongest paladin aura application of the same rank chain on the target, cast by someone other
+// than `casterGUID`
+static AuraApplication* GetDominantOtherSameSpellApp(Unit* target, uint32 spellId, ObjectGuid casterGUID)
+{
+    AuraApplication* best = nullptr;
+    for (uint32 rankSpell = sSpellMgr->GetFirstSpellInChain(spellId); rankSpell; rankSpell = sSpellMgr->GetNextSpellInChain(rankSpell))
+    {
+        Unit::AuraApplicationMapBoundsNonConst bounds = target->GetAppliedAuras().equal_range(rankSpell);
+        for (Unit::AuraApplicationMap::iterator it = bounds.first; it != bounds.second; ++it)
+        {
+            AuraApplication* app = it->second;
+            if (app->GetBase()->GetCasterGUID() == casterGUID)
+                continue;
+            if (!best || IsPaladinAuraDominant(app->GetBase(), best->GetBase(), target))
+                best = app;
+        }
+    }
+    return best;
+}
+
 void Aura::UpdateTargetMap(Unit* caster, bool apply)
 {
     if (IsRemoved())
@@ -561,9 +607,28 @@ void Aura::UpdateTargetMap(Unit* caster, bool apply)
                         existing->second &= ~(1 << effIndex);
                 }
 
+            // paladin auras of the same spell coexist per caster, but only the strongest one keeps
+            // its effects on the target. If a stronger duplicate from another paladin is present,
+            // strip this aura's effects and keep the application effect-free (Aura Mastery needs it
+            // applied) without removing it, which would otherwise churn every update cycle.
+            bool keepEffectless = false;
+            if (m_spellInfo->GetSpellSpecific() == SPELL_SPECIFIC_AURA)
+            {
+                if (AuraApplication* otherApp = GetDominantOtherSameSpellApp(existing->first, GetId(), GetCasterGUID()))
+                {
+                    if (!IsPaladinAuraDominant(this, otherApp->GetBase(), existing->first))
+                    {
+                        for (uint8 effIndex = 0; effIndex < MAX_SPELL_EFFECTS; ++effIndex)
+                            if (appIter->second->HasEffect(effIndex))
+                                appIter->second->_HandleEffect(effIndex, false);
+                        keepEffectless = true;
+                    }
+                }
+            }
+
             // needs readding - remove now, will be applied in next update cycle
             // (dbcs do not have auras which apply on same type of targets but have different radius, so this is not really needed)
-            if (appIter->second->GetEffectMask() != existing->second || !CanBeAppliedOn(existing->first))
+            if ((appIter->second->GetEffectMask() != existing->second && !keepEffectless) || !CanBeAppliedOn(existing->first))
                 targetsToRemove.push_back(appIter->second->GetTarget());
             // nothing todo - aura already applied
             // remove from auras to register list
@@ -653,7 +718,30 @@ void Aura::UpdateTargetMap(Unit* caster, bool apply)
                                itr->first->GetName(), itr->first->IsInWorld() ? itr->first->GetMap()->GetId() : uint32(-1));
                 ABORT();
             }
-            itr->first->_CreateAuraApplication(this, itr->second);
+
+            // paladin auras of the same spell coexist per caster, but only the strongest one keeps
+            // its effects on the target; weaker duplicates are applied without effects so each
+            // paladin's Aura Mastery can still detect their own aura on the target.
+            uint8 effMask = itr->second;
+            if (m_spellInfo->GetSpellSpecific() == SPELL_SPECIFIC_AURA)
+            {
+                if (AuraApplication* otherApp = GetDominantOtherSameSpellApp(itr->first, GetId(), GetCasterGUID()))
+                {
+                    if (IsPaladinAuraDominant(this, otherApp->GetBase(), itr->first))
+                    {
+                        // this aura is stronger - strip the other aura's effects on this target
+                        for (uint8 effIndex = 0; effIndex < MAX_SPELL_EFFECTS; ++effIndex)
+                            if (otherApp->HasEffect(effIndex))
+                                otherApp->_HandleEffect(effIndex, false);
+                    }
+                    else
+                    {
+                        effMask = 0;
+                    }
+                }
+            }
+            itr->second = effMask;
+            itr->first->_CreateAuraApplication(this, effMask);
             ++itr;
         }
     }
@@ -2070,6 +2158,11 @@ bool Aura::CanStackWith(Aura const* existingAura) const
     // spell of same spell rank chain
     if (m_spellInfo->IsRankOf(existingSpellInfo) && !(m_spellInfo->SpellFamilyName == SPELLFAMILY_HUNTER && m_spellInfo->SpellFamilyFlags[1] & 0x80000000))
     {
+        // allow any rank of a paladin aura from a different paladin to coexist on a target so Aura
+        // Mastery works per-caster; UpdateTargetMap keeps only the strongest rank's effects active
+        if (!sameCaster && m_spellInfo->GetSpellSpecific() == SPELL_SPECIFIC_AURA)
+            return true;
+
         // don't allow passive area auras to stack
         if (m_spellInfo->IsMultiSlotAura() && !IsArea())
             return true;

--- a/src/server/game/Spells/Auras/SpellAuras.h
+++ b/src/server/game/Spells/Auras/SpellAuras.h
@@ -35,6 +35,7 @@ class AuraScript;
 
 class AuraApplication
 {
+    friend class Aura; // Aura::UpdateTargetMap manages paladin aura effect suppression
     friend void Unit::_ApplyAura(AuraApplication* aurApp, uint8 effMask);
     friend void Unit::_UnapplyAura(AuraApplicationMap::iterator& i, AuraRemoveMode removeMode);
     friend void Unit::_ApplyAuraEffect(Aura* aura, uint8 effIndex);

--- a/src/test/server/game/Spells/PaladinAuraStackingTest.cpp
+++ b/src/test/server/game/Spells/PaladinAuraStackingTest.cpp
@@ -1,0 +1,107 @@
+/*
+ * This file is part of the AzerothCore Project. See AUTHORS file for Copyright information
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "IntegrationTestFixture.h"
+#include "SpellInfoTestHelper.h"
+#include "SpellAuraDefines.h"
+#include "SpellAuras.h"
+#include "SpellMgr.h"
+#include "gtest/gtest.h"
+
+/*
+ * Paladin aura stacking (SPELL_SPECIFIC_AURA).
+ *
+ * Two paladins may have the same paladin aura on the same target, but only the
+ * strongest one may provide effects. The weaker duplicates stay applied (so Aura
+ * Mastery can detect each caster's own aura via HasAura(spellId, casterGUID))
+ * without contributing effects, which would otherwise double the bonus.
+ *
+ * We drive the real aura pipeline (Unit::AddAura -> Aura::TryRefreshStackOrCreate
+ * -> Aura::UpdateTargetMap) with a non-area aura effect so no party grouping is
+ * needed. _spellSpecific is normally computed by SpellMgr::LoadSpellInfo from DBC
+ * data, which the test builder bypasses, so it is set explicitly.
+ */
+class PaladinAuraStackingTest : public IntegrationTestFixture
+{
+protected:
+    static constexpr uint32 FIRE_RES_AURA_ID  = 48947;   // Fire Resistance Aura rank 5
+    static constexpr int32  FIRE_RES_AMOUNT   = 129;     // +129 fire resistance
+
+    static std::unique_ptr<SpellInfo> MakeFireResAura()
+    {
+        std::unique_ptr<SpellInfo> info = SpellInfoBuilder()
+            .WithId(FIRE_RES_AURA_ID)
+            .WithSpellFamilyName(SPELLFAMILY_PALADIN)
+            .WithSpellFamilyFlags(0, 0, 0x20) // paladin aura family flag -> SPELL_SPECIFIC_AURA
+            .WithEffect(0, SPELL_EFFECT_APPLY_AURA, SPELL_AURA_MOD_RESISTANCE_EXCLUSIVE)
+            .WithEffectBasePoints(0, FIRE_RES_AMOUNT)
+            .WithEffectMiscValue(0, SPELL_SCHOOL_MASK_FIRE)
+            .BuildUnique();
+
+        info->_spellSpecific = SPELL_SPECIFIC_AURA;
+        return info;
+    }
+};
+
+// Two paladins apply the same Fire Resistance Aura to one target:
+//   - both auras stay applied (each caster's own aura, so Aura Mastery finds each)
+//   - only one aura effect is active (no doubled resistance)
+TEST_F(PaladinAuraStackingTest, SameRankAuraCoexistsPerCasterButSingleEffect)
+{
+    std::unique_ptr<SpellInfo> auraInfo = MakeFireResAura();
+
+    auto* paladinA = CreateTestPlayer(1, "PaladinA");
+    auto* paladinB = CreateTestPlayer(2, "PaladinB");
+    auto* target   = CreateTestPlayer(3, "Target");
+
+    Aura* auraA = paladinA->AddAura(auraInfo.get(), MAX_EFFECT_MASK, target);
+    ASSERT_NE(auraA, nullptr);
+    Aura* auraB = paladinB->AddAura(auraInfo.get(), MAX_EFFECT_MASK, target);
+    ASSERT_NE(auraB, nullptr);
+
+    // two separate aura objects, one per caster
+    EXPECT_NE(auraA, auraB);
+
+    // both auras are present on the target (per-caster)
+    EXPECT_TRUE(target->HasAura(FIRE_RES_AURA_ID, paladinA->GetGUID()));
+    EXPECT_TRUE(target->HasAura(FIRE_RES_AURA_ID, paladinB->GetGUID()));
+
+    // only the dominant aura registered an effect
+    auto const& effects = target->GetAuraEffectsByType(SPELL_AURA_MOD_RESISTANCE_EXCLUSIVE);
+    EXPECT_EQ(effects.size(), 1u);
+}
+
+// A single caster's repeated application collapses into the existing aura instead of
+// creating a duplicate application (the per-caster exclusivity that must be preserved).
+TEST_F(PaladinAuraStackingTest, SingleCasterReapplicationRefreshes)
+{
+    std::unique_ptr<SpellInfo> auraInfo = MakeFireResAura();
+
+    auto* paladinA = CreateTestPlayer(1, "PaladinA");
+    auto* target   = CreateTestPlayer(2, "Target");
+
+    Aura* first  = paladinA->AddAura(auraInfo.get(), MAX_EFFECT_MASK, target);
+    ASSERT_NE(first, nullptr);
+    Aura* second = paladinA->AddAura(auraInfo.get(), MAX_EFFECT_MASK, target);
+    ASSERT_NE(second, nullptr);
+
+    // same caster -> same aura object is refreshed, not duplicated
+    EXPECT_EQ(first, second);
+
+    auto const& effects = target->GetAuraEffectsByType(SPELL_AURA_MOD_RESISTANCE_EXCLUSIVE);
+    EXPECT_EQ(effects.size(), 1u);
+}


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [ ] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used:
- [ ] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/25765

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
