### PR TITLE
fix(Core/Build): the unit tests now build on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,16 +146,19 @@ endif()
 CU_RUN_HOOK("AFTER_SRC_LOAD")
 
 if (BUILD_TESTING AND BUILD_APPLICATION_WORLDSERVER)
-    # we use these flags to get code coverage
-    set(UNIT_TEST_CXX_FLAGS "-fprofile-arcs -ftest-coverage -fno-inline")
+    # we use these flags to get code coverage. gcov only, and they land in the global
+    # CMAKE_CXX_FLAGS, so MSVC would get them on every target of the build
+    if ( CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang" )
+        set(UNIT_TEST_CXX_FLAGS "-fprofile-arcs -ftest-coverage -fno-inline")
 
-    # enable additional flags for GCC.
-    if ( CMAKE_CXX_COMPILER_ID MATCHES GNU )
-        set(UNIT_TEST_CXX_FLAGS "${UNIT_TEST_CXX_FLAGS} -fno-inline-small-functions -fno-default-inline")
+        # enable additional flags for GCC.
+        if ( CMAKE_CXX_COMPILER_ID MATCHES GNU )
+            set(UNIT_TEST_CXX_FLAGS "${UNIT_TEST_CXX_FLAGS} -fno-inline-small-functions -fno-default-inline")
+        endif()
+
+        message("Unit tests code coverage: enabling ${UNIT_TEST_CXX_FLAGS}")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${UNIT_TEST_CXX_FLAGS}")
     endif()
-
-    message("Unit tests code coverage: enabling ${UNIT_TEST_CXX_FLAGS}")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${UNIT_TEST_CXX_FLAGS}")
 
     include(src/cmake/googletest.cmake)
     fetch_googletest(

--- a/src/cmake/googletest.cmake
+++ b/src/cmake/googletest.cmake
@@ -24,6 +24,10 @@ macro(fetch_googletest _download_module_path _download_root)
             ${_download_root}
     )
 
+    # on MSVC googletest defaults to the static CRT while the core uses the dynamic one,
+    # and the two don't link together (LNK2038)
+    set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+
     # adds the targers: gtest, gtest_main, gmock, gmock_main
     add_subdirectory(
             ${_download_root}/googletest-src

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -25,6 +25,9 @@ add_executable(
 
 target_link_libraries(
         unit_tests
+        PRIVATE
+        acore-core-interface
+        PUBLIC
         game
         gtest_main
         gmock_main
@@ -48,7 +51,7 @@ endif()
 
 # Link modules library to tests so module code is available
 if(TARGET modules)
-    target_link_libraries(unit_tests modules)
+    target_link_libraries(unit_tests PUBLIC modules)
 endif()
 
 add_test(

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -26,7 +26,7 @@ add_executable(
 target_link_libraries(
         unit_tests
         PRIVATE
-        acore-core-interface
+        acore-default-interface
         PUBLIC
         game
         gtest_main


### PR DESCRIPTION
## Changes Proposed:

The unit tests do not compile with MSVC. `BUILD_TESTING` defaults to `0` and the Windows workflow builds through `./acore.sh compiler build`, so CI never turns them on and the breakage goes unnoticed. Three separate things stop the build:

- `src/test/CMakeLists.txt` was the only target in the tree not linking `acore-core-interface`, which is where `/utf-8` lives. Without it `fmt` stops the build on its own Unicode `static_assert`. The other targets all link it (`src/common/CMakeLists.txt:67`, `src/server/game/CMakeLists.txt:52`, `src/server/database/CMakeLists.txt:52`, `src/server/apps/CMakeLists.txt:128`), so this just follows them. The `modules` call below it had to move to the keyword form as well, since CMake refuses to mix both signatures on one target.
- The gcov coverage flags were set unconditionally and appended to the global `CMAKE_CXX_FLAGS`, so `cl.exe` received `-fprofile-arcs -ftest-coverage -fno-inline` on **every** target of the build, worldserver included. The `MATCHES GNU` guard right below only covered the two extra flags. The whole block now sits inside a `GNU|Clang` check.
- googletest defaults to the static CRT on MSVC while the core uses the dynamic one, which fails at link time with `LNK2038`. `gtest_force_shared_crt` is googletest's own option for exactly this.

Nothing changes for gcc or clang: the coverage flags are still set for them, and the other two edits are inert outside MSVC.

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Opus 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- None

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Nothing to test in-game here, it is a build change, so the boxes above stay unchecked. What was done instead:

Built on Windows with Visual Studio 2026, `RelWithDebInfo`, `-DBUILD_TESTING=ON`, static scripts and modules. On master the build stops at the first of the three errors; with this branch it finishes clean and the binary runs:

```
[==========] 11394 tests from 83 test suites ran. (456 ms total)
[  PASSED  ] 5908 tests.
[  SKIPPED ] 5486 tests.
```

worldserver and authserver were rebuilt from the same tree afterwards, to confirm the coverage-flag change does not affect them. Both build and start.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

Configure on Windows with `-DBUILD_TESTING=ON` and build the `unit_tests` target. On current master it fails with the `fmt` Unicode `static_assert`; with this branch it builds and the binary runs.

`unit_tests.exe` needs the MySQL and OpenSSL DLLs on `PATH`, otherwise it exits with `0xC0000135` and no message.

## Known Issues and TODO List:

Only the three build errors are addressed. The Windows CI still does not enable `BUILD_TESTING`, so it will not catch a regression of this on its own.

<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs

When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
