### PR TITLE
fix(DB/Creature): Override Taunka'le Evacuee templates for ones that are supposed to be alive

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1786135552317150800.sql
+++ b/data/sql/updates/pending_db_world/rev_1786135552317150800.sql
@@ -1,0 +1,18 @@
+-- Override the Templates
+DELETE FROM `creature_addon` WHERE (`guid` IN (100354, 100355, 100356, 100357, 100358, 100359, 100456, 100459));
+INSERT INTO `creature_addon` (`guid`, `path_id`, `mount`, `bytes1`, `bytes2`, `emote`, `visibilityDistanceType`, `auras`) VALUES
+(100354, 0, 0, 1, 1, 0, 0, ''),
+(100355, 0, 0, 1, 1, 0, 0, ''),
+(100356, 0, 0, 1, 1, 0, 0, ''),
+(100357, 0, 0, 1, 1, 0, 0, ''),
+(100358, 0, 0, 1, 1, 0, 0, ''),
+(100359, 0, 0, 1, 1, 0, 0, ''),
+(100456, 0, 0, 0, 1, 0, 0, ''),
+(100459, 0, 0, 0, 1, 0, 0, '');
+
+-- The previous flags came from the auras, not inherent to the template
+UPDATE `creature_template` SET `unit_flags` = 32768, `dynamicflags` = 0 WHERE (`entry` IN (26159, 26160));
+
+-- Spell is already cast on Quest Accepted, no need to double it
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 26158;
+DELETE FROM `smart_scripts` WHERE (`entryorguid` = 26158) AND (`source_type` = 0);

--- a/data/sql/updates/pending_db_world/rev_1786135552317150800.sql
+++ b/data/sql/updates/pending_db_world/rev_1786135552317150800.sql
@@ -14,5 +14,5 @@ INSERT INTO `creature_addon` (`guid`, `path_id`, `mount`, `bytes1`, `bytes2`, `e
 UPDATE `creature_template` SET `unit_flags` = 32768, `dynamicflags` = 0 WHERE (`entry` IN (26159, 26160));
 
 -- Spell is already cast on Quest Accepted, no need to double it
-UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 26158;
+UPDATE `creature_template` SET `AIName` = '' WHERE `entry` = 26158;
 DELETE FROM `smart_scripts` WHERE (`entryorguid` = 26158) AND (`source_type` = 0);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [X] Database (SAI, creatures, etc).

Also removes the SAI for the questgiver since they already cast on the player via quest_template_addon

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [ ] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used:
- [ ] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/22662

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [X] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Still works end-to-end

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
