### PR TITLE
fix(DB/Pools): drop memberless legacy pool templates, restore empty-pool error

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1786068891.sql
+++ b/data/sql/updates/pending_db_world/rev_1786068891.sql
@@ -1,0 +1,14 @@
+-- Remove pool_template rows that have no members in pool_creature,
+-- pool_gameobject, pool_quest or pool_pool. They date back to the original
+-- DB import, spawn nothing and are referenced by nothing.
+-- Pool 4508 ('Minerals - Rolands Doom - Duskwood') additionally sat as the
+-- only pool_pool child of 11650 ('Solid Chests, Azshara', 2 of 10 active):
+-- whenever the mother rolled it, a chest slot was consumed spawning nothing.
+DELETE FROM `pool_pool` WHERE `pool_id` = 4508;
+DELETE FROM `pool_template` WHERE `entry` IN
+(896, 2021, 2024, 2025, 2027, 2028, 2030, 3122, 3123, 3124, 3125, 3126, 3127,
+3128, 3129, 3154, 3161, 3210, 3310, 3410, 3413, 3418, 3444, 3463, 3477, 3479,
+3481, 3491, 3609, 3991, 4001, 4333, 4334, 4337, 4486, 4489, 4490, 4495, 4498,
+4507, 4508, 4630, 4644, 4653, 4671, 4763, 4769, 4934, 4991, 5122, 5679, 5680,
+5681, 5682, 5683, 5684, 5685, 5686, 5687, 5688, 5689, 5690, 9900, 9901, 9902,
+9904, 9905, 9906, 9907, 9908, 11212, 11642, 11676, 11677);

--- a/src/server/game/Pools/PoolMgr.cpp
+++ b/src/server/game/Pools/PoolMgr.cpp
@@ -972,11 +972,10 @@ void PoolMgr::LoadFromDB()
         }
     }
 
-    // Warn only: empty pools are inert leftovers, unlike the member errors above
     for (auto const& [poolId, templateData] : mPoolTemplate)
     {
         if (IsEmpty(poolId))
-            LOG_WARN("sql.sql", "Pool Id {} is empty (has no creatures, no gameobjects, no quests and no valid child pools). The pool will not be spawned.", poolId);
+            LOG_ERROR("sql.sql", "Pool Id {} is empty (has no creatures, no gameobjects, no quests and no valid child pools). The pool will not be spawned.", poolId);
     }
 
     // The initialize method will spawn all pools not in an event and not in another pool, this is why there is 2 left joins with 2 null checks


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Follow-up to #27001, which made the pool loader report empty pools at startup and downgraded the message to a warning because the world DB carries 74 memberless `pool_template` rows.

- Deletes the 74 rows. They have no members in `pool_creature`, `pool_gameobject`, `pool_quest` and no `pool_pool` links (verified against base + all updates), and date back to the original DB import: Wintergrasp mineral master pools, "General ICC 10man" pools (5679-5690, present since the first commit), Borean Tundra ore mothers (9900-9908), and old per-zone "Spawn Point N" rows.
- One of them was an actual bug, not just dead weight: pool 4508 ("Minerals - Rolands Doom - Duskwood") was the only `pool_pool` child of mother 11650 ("Solid Chests, Azshara", 2 of 10 active). Whenever the mother rolled it, one of the two chest slots spawned nothing. The child link is removed with it.
- With the data clean, the empty-pool startup message returns to error level, mirroring TrinityCore (which outright asserts on this condition), so future memberless pools fail the CI startup check instead of rotting silently.

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Fable 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Follow-up to #27001 (see the CI startup errors discussion there).

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Validated by tracing every id through `data/sql/base/db_world/` and `data/sql/updates/db_world/` for members and references.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Apply the SQL, start the worldserver: no "Pool Id X is empty" messages and an empty Errors.log.
2. `.pool info 11650` in-game: Azshara solid chests still roll 2 of 10 spawn points, with no phantom sub-pool entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

