### PR TITLE
fix(Scripts/Ulduar): add General Vezax saronite barrier fade emote and move vapors emote to Vezax

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1786191934910886700.sql
+++ b/data/sql/updates/pending_db_world/rev_1786191934910886700.sql
@@ -1,0 +1,6 @@
+--
+DELETE FROM `creature_text` WHERE `CreatureID` = 33271 AND `GroupID` IN (9, 10);
+DELETE FROM `creature_text` WHERE `CreatureID` = 33488;
+INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `TextRange`, `comment`) VALUES
+(33271, 9, 0, 'The saronite barrier protecting General Vezax shimmers and fades away!', 41, 0, 100, 0, 0, 0, 33647, 0, 'General Vezax - EMOTE_BARRIER_FADE'),
+(33271, 10, 0, 'A cloud of saronite vapors coalesces nearby!', 41, 0, 100, 0, 0, 0, 33587, 0, 'General Vezax - EMOTE_VAPORS');

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_general_vezax.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_general_vezax.cpp
@@ -99,11 +99,8 @@ enum VezaxText
     SAY_EMOTE_ANIMUS                     = 6,
     SAY_EMOTE_BARRIER                    = 7,
     SAY_EMOTE_SURGE_OF_DARKNESS          = 8,
-};
-
-enum VaporsText
-{
-    SAY_EMOTE_VAPORS    = 0,
+    SAY_EMOTE_BARRIER_FADE               = 9,
+    SAY_EMOTE_VAPORS                     = 10,
 };
 
 struct boss_vezax : public BossAI
@@ -156,6 +153,7 @@ struct boss_vezax : public BossAI
                 hardmodeAvailable = false;
                 break;
             case 2:
+                Talk(SAY_EMOTE_BARRIER_FADE);
                 me->RemoveAura(SPELL_SARONITE_BARRIER);
                 me->SetLootMode(3);
                 break;
@@ -266,6 +264,7 @@ struct boss_vezax : public BossAI
             case EVENT_SPELL_SUMMON_SARONITE_VAPORS:
                 {
                     vaporsCount++;
+                    Talk(SAY_EMOTE_VAPORS);
                     me->CastSpell(me, SPELL_SUMMON_SARONITE_VAPORS, false);
 
                     if (vaporsCount < 6 || !hardmodeAvailable)
@@ -351,11 +350,6 @@ struct npc_ulduar_saronite_vapors : public NullCreatureAI
         if (_instance)
             if (Creature* vezax = _instance->GetCreature(BOSS_VEZAX))
                 vezax->AI()->DoAction(1);
-    }
-
-    void IsSummonedBy(WorldObject* /*summoner*/) override
-    {
-        Talk(SAY_EMOTE_VAPORS);
     }
 };
 

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_general_vezax.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_general_vezax.cpp
@@ -264,8 +264,8 @@ struct boss_vezax : public BossAI
             case EVENT_SPELL_SUMMON_SARONITE_VAPORS:
                 {
                     vaporsCount++;
-                    Talk(SAY_EMOTE_VAPORS);
                     me->CastSpell(me, SPELL_SUMMON_SARONITE_VAPORS, false);
+                    Talk(SAY_EMOTE_VAPORS);
 
                     if (vaporsCount < 6 || !hardmodeAvailable)
                         events.Repeat(30s);


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Two emote fixes for the General Vezax encounter, based on a fresh sniff of the fight (full hard mode kill):

1. **Missing barrier fade emote.** When the Saronite Animus dies and the Saronite Barrier drops, Vezax should send the raid emote "The saronite barrier protecting General Vezax shimmers and fades away!". The broadcast text for it (33647) exists in 3.3.5 client data directly next to the already-used "A saronite barrier appears around General Vezax!" (33646), but was never wired up, neither here nor on TC. Added as text group 9 and triggered in `DoAction(2)` alongside the aura removal.

2. **Saronite Vapors emote sender.** The "A cloud of saronite vapors coalesces nearby!" emote is sent by General Vezax himself (sender GUID confirmed in the sniff, creature entry 33271), not by the summoned Saronite Vapors NPC. Moved the text from creature 33488 to Vezax (group 10) and the `Talk` from the vapor's `IsSummonedBy` to the boss's summon event. Visually identical for players, but matches the sniffed sender and keeps all encounter texts on the boss.

Sniff timeline for reference: 6 vapor emotes at 30s intervals, each ~200ms after Vezax casts Summon Saronite Vapors (63081); barrier fade emote sent by Vezax immediately on Animus death, right before the barrier aura removal.

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Fable 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- None

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [x] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Retail sniff (12.0.7.68974) of a complete hard mode kill. Retail is weak evidence for 3.3.5 on its own, but both emotes use wotlk-era broadcast texts (33647 and 33587 in 3.3.5 client data), and the sniff confirms the sender GUID for both.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Engage General Vezax in Ulduar and let all 6 Saronite Vapors spawn without killing any (hard mode). Each spawn should produce the "A cloud of saronite vapors coalesces nearby!" raid emote, now sent by General Vezax.
2. Wait for the Saronite Animus to form and the Saronite Barrier to appear.
3. Kill the Saronite Animus. Vezax should emote "The saronite barrier protecting General Vezax shimmers and fades away!" and the barrier aura should drop.

## Known Issues and TODO List:

- [ ]
- [ ]

<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
