### PR TITLE
fix(Scripts/Spells): implement Clear Demonic Circle, cast by General Vezax on engage

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1786192707275526400.sql
+++ b/data/sql/updates/pending_db_world/rev_1786192707275526400.sql
@@ -1,0 +1,4 @@
+--
+DELETE FROM `spell_script_names` WHERE `ScriptName` = 'spell_gen_clear_demonic_circle';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(62037, 'spell_gen_clear_demonic_circle');

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_general_vezax.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_general_vezax.cpp
@@ -41,6 +41,7 @@ enum VezaxSpellData
     SPELL_MARK_OF_THE_FACELESS_AURA             = 63276,
     SPELL_MARK_OF_THE_FACELESS_EFFECT           = 63278,
 
+    SPELL_CLEAR_DEMONIC_CIRCLE                  = 62037,
     SPELL_AURA_OF_DESPAIR_1                     = 62692,
     SPELL_AURA_OF_DESPAIR_2                     = 64848,
     SPELL_CORRUPTED_RAGE                        = 68415,
@@ -145,6 +146,7 @@ struct boss_vezax : public BossAI
 
         Talk(SAY_AGGRO);
 
+        me->CastSpell(me, SPELL_CLEAR_DEMONIC_CIRCLE, true);
         me->CastSpell(me, SPELL_AURA_OF_DESPAIR_1, true);
     }
 

--- a/src/server/scripts/Spells/spell_generic.cpp
+++ b/src/server/scripts/Spells/spell_generic.cpp
@@ -1483,6 +1483,33 @@ class spell_gen_clear_debuffs : public SpellScript
     }
 };
 
+enum ClearDemonicCircle
+{
+    SPELL_DEMONIC_CIRCLE_SUMMON = 48018
+};
+
+// 62037 - Clear Demonic Circle
+class spell_gen_clear_demonic_circle : public SpellScript
+{
+    PrepareSpellScript(spell_gen_clear_demonic_circle);
+
+    bool Validate(SpellInfo const* /*spellInfo*/) override
+    {
+        return ValidateSpellInfo({ SPELL_DEMONIC_CIRCLE_SUMMON });
+    }
+
+    void HandleScript(SpellEffIndex /*effIndex*/)
+    {
+        if (Unit* target = GetHitUnit())
+            target->RemoveAurasDueToSpell(SPELL_DEMONIC_CIRCLE_SUMMON);
+    }
+
+    void Register() override
+    {
+        OnEffectHitTarget += SpellEffectFn(spell_gen_clear_demonic_circle::HandleScript, EFFECT_0, SPELL_EFFECT_SCRIPT_EFFECT);
+    }
+};
+
 enum CreateLanceSpells
 {
     SPELL_CREATE_LANCE_ALLIANCE = 63914,
@@ -6225,6 +6252,7 @@ void AddSC_generic_spell_scripts()
     RegisterSpellScript(spell_gen_burn_brutallus);
     RegisterSpellScript(spell_gen_cannibalize);
     RegisterSpellScript(spell_gen_clear_debuffs);
+    RegisterSpellScript(spell_gen_clear_demonic_circle);
     RegisterSpellScript(spell_gen_create_lance);
     RegisterSpellScript(spell_gen_netherbloom);
     RegisterSpellScript(spell_gen_nightmare_vine);


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Implements the serverside utility spell 62037 (Clear Demonic Circle) and has General Vezax cast it on engage, matching a fresh sniff of the encounter.

At encounter start the sniff shows Vezax casting 62037 in the same packet burst as the aggro reaction, hitting the players in the instance. The spell removes warlock Demonic Circles placed before the pull, closing the classic cheese of pre-placing a circle at a safe spot and teleporting out mid-fight. Demonic Circle: Summon (48018) lasts 6 minutes in 3.3.5 and nothing else removes it on combat start.

The 3.3.5 DBC entry for 62037 already carries the full targeting: script effect, implicit targets (22, 7) with a 50000 yd radius, and `SPELL_ATTR3_ONLY_TARGET_PLAYERS`, so the core's area target selection resolves players on its own. The new `spell_gen_clear_demonic_circle` script only implements the script effect, removing 48018 from each hit player. Removing the summon aura despawns the circle gameobject and clears the teleport-enable aura (62388) through the existing `spell_warl_demonic_circle_summon` remove handler.

62037 is not player-accessible (generic family, no cost, no skill line), so binding the script has no side effects outside scripted casts.

Scope note: on retail this looks like generic encounter-framework behavior, but only the Vezax cast is backed by the sniff, so only Vezax casts it here. There is no wotlk-era sniff evidence for this spell; backporting the retail behavior is deliberate.

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Fable 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- None

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [x] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Retail sniff (12.0.7.68974) of a General Vezax kill: 62037 cast by Vezax at the exact aggro timestamp, self-targeted `SPELL_START` followed by `SPELL_GO` with source location at the boss and the raid as hit targets. Spell data verified against the 3.3.5 Spell.dbc.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. On a warlock, cast Demonic Circle: Summon (48018) anywhere in General Vezax's room in Ulduar.
2. Engage General Vezax.
3. The circle gameobject should despawn immediately on pull and Demonic Circle: Teleport should be unusable.
4. Other players' circles anywhere in the instance are cleared as well.

## Known Issues and TODO List:

- [ ]
- [ ]

<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
