### PR TITLE
fix(Scripts/Ulduar): Sara casting P1 spells with no delay

### DIFF
--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
@@ -274,9 +274,6 @@ enum Misc
     DATA_YOGG_SARON_HEALTH              = 5,
 };
 
-// Cast time of 63147, 63134 and 63138; the P1 spell timer runs cast start to cast start
-constexpr Milliseconds SARA_P1_SPELL_CAST_TIME = 4s;
-
 struct LocationsXY
 {
     float x, y, z;
@@ -912,8 +909,8 @@ struct boss_yoggsaron_sara : public ScriptedAI
                     }
 
                     me->CastCustomSpell(spell, SPELLVALUE_MAX_TARGETS, 1, nullptr, false);
-                    // Sniffed: steady ~4.9s start-to-start, the cast plus a ~1s gap
-                    events.Repeat(SARA_P1_SPELL_CAST_TIME + 900ms);
+                    // Sniffed: steady ~4.9s start-to-start, the 4s cast plus a ~1s gap
+                    events.Repeat(4900ms);
                     break;
                 }
             case EVENT_SARA_P2_START:

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
@@ -264,9 +264,6 @@ enum Misc
 
     CRITERIA_NOT_GETTING_OLDER          = 21001,
 
-    // Cast time of 63147, 63134 and 63138; the P1 spell timer runs cast start to cast start
-    SARA_P1_SPELL_CAST_TIME_MS          = 4000,
-
     // YOGG-SARON (laugh)
     YS_P3_LUNATIC_GAZE                  = 15757,
 
@@ -277,6 +274,7 @@ enum Misc
     DATA_YOGG_SARON_HEALTH              = 5,
 };
 
+// Cast time of 63147, 63134 and 63138; the P1 spell timer runs cast start to cast start
 constexpr Milliseconds SARA_P1_SPELL_CAST_TIME = 4s;
 
 struct LocationsXY
@@ -914,7 +912,8 @@ struct boss_yoggsaron_sara : public ScriptedAI
                     }
 
                     me->CastCustomSpell(spell, SPELLVALUE_MAX_TARGETS, 1, nullptr, false);
-                    events.Repeat(SARA_P1_SPELL_CAST_TIME + (me->GetMap()->Is25ManRaid() ? 2s : 4s));
+                    // Sniffed: steady ~4.9s start-to-start, the cast plus a ~1s gap
+                    events.Repeat(SARA_P1_SPELL_CAST_TIME + 900ms);
                     break;
                 }
             case EVENT_SARA_P2_START:

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
@@ -264,6 +264,9 @@ enum Misc
 
     CRITERIA_NOT_GETTING_OLDER          = 21001,
 
+    // Cast time of 63147, 63134 and 63138; the P1 spell timer runs cast start to cast start
+    SARA_P1_SPELL_CAST_TIME_MS          = 4000,
+
     // YOGG-SARON (laugh)
     YS_P3_LUNATIC_GAZE                  = 15757,
 
@@ -273,6 +276,8 @@ enum Misc
     DATA_GET_DRIVE_ME_CRAZY             = 4,
     DATA_YOGG_SARON_HEALTH              = 5,
 };
+
+constexpr Milliseconds SARA_P1_SPELL_CAST_TIME = 4s;
 
 struct LocationsXY
 {
@@ -909,7 +914,7 @@ struct boss_yoggsaron_sara : public ScriptedAI
                     }
 
                     me->CastCustomSpell(spell, SPELLVALUE_MAX_TARGETS, 1, nullptr, false);
-                    events.Repeat(me->GetMap()->Is25ManRaid() ? randtime(0ms, 3s) : randtime(4s, 6s));
+                    events.Repeat(SARA_P1_SPELL_CAST_TIME + (me->GetMap()->Is25ManRaid() ? 2s : 4s));
                     break;
                 }
             case EVENT_SARA_P2_START:


### PR DESCRIPTION
Fixes the timer for Sara's phase 1 spells in the Yogg-Saron encounter.

All three spells Sara casts during phase 1 have a **4 second cast time**:

- Sara's Anger (63147)
- Sara's Blessing (63134)
- Sara's Fervor (63138)

`EVENT_SARA_P1_SPELLS` schedules the target selectors (63744/63745/63747), which are instant and only pick the target before casting the real spell. This means the event timer effectively runs from cast start to cast start, so it has to cover the cast itself plus the intended gap between casts.

The previous values did not:

- 25man used `randtime(0ms, 3s)`, always shorter than the 4s cast, so a cast could never complete before the next one started.
- 10man used `randtime(4s, 6s)`, whose lower bound of 4s left no gap at all.

The timer is now `cast time + gap`: 2s in 25man, matching the reference video, and 4s in 10man, keeping the original design of 10man being the slower of the two (this value is not sniff based).

<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Opus5
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/27027

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
