### PR TITLE
fix(Scripts/Ulduar): rework Yogg-Saron Death Ray to sniffed behaviour

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1786197992848215100.sql
+++ b/data/sql/updates/pending_db_world/rev_1786197992848215100.sql
@@ -1,0 +1,12 @@
+-- Yogg-Saron Death Ray: bind the ray AI, make it a trigger like TC, let the Death Orb fly
+UPDATE `creature_template` SET `ScriptName` = 'boss_yoggsaron_death_ray', `flags_extra` = `flags_extra` | 128 WHERE `entry` = 33881;
+UPDATE `creature_template_movement` SET `Ground` = 0, `Flight` = 1 WHERE `CreatureId` = 33882;
+
+-- Sniffed: the Death Ray beam visuals anchor to the Death Orb, not to Sara
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 13 AND `SourceEntry` IN (63882, 63886) AND `ConditionTypeOrReference` = 31;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(13, 1, 63882, 0, 0, 31, 0, 3, 33882, 0, 0, 0, 0, '', 'Death Ray Warning Visual targets Death Orb'),
+(13, 1, 63886, 0, 0, 31, 0, 3, 33882, 0, 0, 0, 0, '', 'Death Ray Damage Visual targets Death Orb');
+
+-- Give the serverside Death Ray Summon stubs their summon effect (one ray each)
+UPDATE `spell_dbc` SET `Effect_1` = 28, `ImplicitTargetA_1` = 18, `EffectMiscValue_1` = 33881, `EffectMiscValueB_1` = 64 WHERE `ID` IN (63887, 63888, 63889, 63890);

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
@@ -1609,7 +1609,7 @@ struct boss_yoggsaron_death_ray : public NullCreatureAI
                 break;
             case EVENT_DEATH_RAY_ACTIVE:
                 me->CastSpell(me, SPELL_DEATH_RAY_DAMAGE, true);
-                me->CastSpell(nullptr, SPELL_DEATH_RAY_DAMAGE_VISUAL, true);
+                me->CastSpell((Unit*)nullptr, SPELL_DEATH_RAY_DAMAGE_VISUAL, true);
                 events.ScheduleEvent(EVENT_DEATH_RAY_MOVE, 0ms);
                 break;
             case EVENT_DEATH_RAY_MOVE:

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
@@ -76,6 +76,7 @@ enum YoggSpells
     SPELL_DARK_VOLLEY                   = 63038,
 
     // SARA P2
+    SPELL_RIDE_YOGG_SARON_VEHICLE       = 61791,
     SPELL_SARA_PSYCHOSIS_10             = 63795,
     SPELL_SARA_PSYCHOSIS_25             = 65301,
     SPELL_MALADY_OF_THE_MIND            = 63830,
@@ -84,11 +85,16 @@ enum YoggSpells
     SPELL_BRAIN_LINK_DAMAGE             = 63803,
     SPELL_BRAIN_LINK_OK                 = 63804,
 
+    SPELL_DEATH_RAY                     = 63891,
     SPELL_DEATH_RAY_DAMAGE_VISUAL       = 63886,
     SPELL_DEATH_RAY_ORIGIN_VISUAL       = 63893,
     SPELL_DEATH_RAY_WARNING             = 63882,
     SPELL_DEATH_RAY_DAMAGE              = 63883,
     SPELL_DEATH_RAY_DAMAGE_REAL         = 63884,
+    SPELL_DEATH_RAY_SUMMON_1            = 63887, // serverside, one per ray
+    SPELL_DEATH_RAY_SUMMON_2            = 63888,
+    SPELL_DEATH_RAY_SUMMON_3            = 63889,
+    SPELL_DEATH_RAY_SUMMON_4            = 63890,
 
     // YOGG-SARON P2
     SPELL_SHADOW_BARRIER                = 63894,
@@ -175,6 +181,10 @@ enum YoggEvents
     EVENT_YS_SUMMON_GUARDIAN            = 32,
     EVENT_YS_SHADOW_BEACON              = 33,
 
+    EVENT_DEATH_RAY_WARNING             = 35,
+    EVENT_DEATH_RAY_ACTIVE              = 36,
+    EVENT_DEATH_RAY_MOVE                = 37,
+
     EVENT_SARA_WIPE_OPEN_DOOR           = 40,
     EVENT_SARA_WIPE_RESPAWN             = 41,
 };
@@ -193,6 +203,7 @@ enum NPCsGOs
     NPC_CORRUPTOR_TENTACLE              = 33985, // 30-40 secs ?
 
     NPC_INFLUENCE_TENTACLE              = 33943,
+    NPC_DEATH_RAY                       = 33881,
     NPC_DEATH_ORB                       = 33882,
     NPC_DESCEND_INTO_MADNESS            = 34072,
     NPC_LAUGHING_SKULL                  = 33990,
@@ -394,6 +405,7 @@ struct boss_yoggsaron_sara : public ScriptedAI
     uint8 _currentIllusion;
     bool _isIllusionReversed;
     bool _isWipeRecovering = false;
+    bool _deathRayAnnounce = true;
 
     void AttackStart(Unit*) override { }
     void MoveInLineOfSight(Unit*) override { }
@@ -401,6 +413,14 @@ struct boss_yoggsaron_sara : public ScriptedAI
     void JustSummoned(Creature* summon) override
     {
         summons.Summon(summon);
+
+        // Sniffed: the yell accompanies every other Death Ray cast, starting with the first
+        if (summon->GetEntry() == NPC_DEATH_ORB)
+        {
+            if (_deathRayAnnounce)
+                Talk(SAY_SARA_DEATH_RAY);
+            _deathRayAnnounce = !_deathRayAnnounce;
+        }
     }
 
     void SpawnClouds()
@@ -420,6 +440,8 @@ struct boss_yoggsaron_sara : public ScriptedAI
         if (!_EnterEvadeMode(why))
             return;
 
+        // NearTeleportTo does not dismount creatures from vehicles
+        me->ExitVehicle();
         Position pos = me->GetHomePosition();
         me->NearTeleportTo(pos.GetPositionX(), pos.GetPositionY(), pos.GetPositionZ(), pos.GetOrientation());
 
@@ -489,6 +511,7 @@ struct boss_yoggsaron_sara : public ScriptedAI
         _summonedGuardiansCount = 0;
         _p2TalkTimer = 0;
         _secondPhase = false;
+        _deathRayAnnounce = true;
         _summonSpeed = 1.0f;
         _currentIllusion = urand(1, 3);
         _isIllusionReversed = urand(0, 1);
@@ -612,17 +635,6 @@ struct boss_yoggsaron_sara : public ScriptedAI
         }
     }
 
-    void SummonDeathOrbs()
-    {
-        for (uint8 i = 0; i < 4; ++i)
-        {
-            uint32 dist = urand(38, 48);
-            float o = rand_norm() * M_PI * 2;
-            float Zplus = (dist - 38) / 6.5f;
-            me->SummonCreature(NPC_DEATH_ORB, me->GetPositionX() + dist * cos(o), me->GetPositionY() + dist * std::sin(o), 327.2 + Zplus, 0, TEMPSUMMON_TIMED_DESPAWN, 20000);
-        }
-    }
-
     void AddPortals()
     {
         _summonSpeed -= 0.1f;
@@ -694,6 +706,7 @@ struct boss_yoggsaron_sara : public ScriptedAI
                 summons.DoAction(ACTION_YOGG_SARON_HARD_MODE, pred2);
 
             summons.DespawnEntry(NPC_DEATH_ORB);
+            summons.DespawnEntry(NPC_DEATH_RAY);
             events.SetPhase(EVENT_PHASE_THREE);
 
             me->RemoveAllAuras();
@@ -935,9 +948,9 @@ struct boss_yoggsaron_sara : public ScriptedAI
                 events.Repeat(3500ms);
                 break;
             case EVENT_SARA_P2_DEATH_RAY:
-                Talk(SAY_SARA_DEATH_RAY);
-                SummonDeathOrbs();
-                events.Repeat(20s);
+                // Sniffed: the Death Orb is summoned 3 yd above Sara's head
+                me->CastSpell(me->GetPositionX(), me->GetPositionY(), me->GetPositionZ() + 3.0f, SPELL_DEATH_RAY, false);
+                events.Repeat(22s);
                 break;
             case EVENT_SARA_P2_SUMMON_T1: // CRUSHER
                 SpawnTentacle(NPC_CRUSHER_TENTACLE);
@@ -970,26 +983,29 @@ struct boss_yoggsaron_sara : public ScriptedAI
                     break;
                 }
             case EVENT_SARA_P2_SPAWN_START_TENTACLES:
-                me->SetOrientation(M_PI);
-                me->SetDisplayId(SARA_TRANSFORM_MODEL);
+                {
+                    me->SetOrientation(M_PI);
+                    me->SetDisplayId(SARA_TRANSFORM_MODEL);
 
-                me->NearTeleportTo(me->GetPositionX(), me->GetPositionY(), 355, me->GetOrientation());
-                me->SetPosition(me->GetPositionX(), me->GetPositionY(), 355, me->GetOrientation());
+                    // Sniffed: Sara rides Yogg-Saron's vehicle for the rest of the fight
+                    if (Creature* yogg = _instance->GetCreature(BOSS_YOGGSARON))
+                        me->CastSpell(yogg, SPELL_RIDE_YOGG_SARON_VEHICLE, true);
 
-                SpawnTentacle(NPC_CRUSHER_TENTACLE);
-                me->CastCustomSpell(SPELL_CONSTRICTOR_TENTACLE, SPELLVALUE_MAX_TARGETS, 1, me, false);
-                SpawnTentacle(NPC_CORRUPTOR_TENTACLE);
-                SpawnTentacle(NPC_CORRUPTOR_TENTACLE);
+                    SpawnTentacle(NPC_CRUSHER_TENTACLE);
+                    me->CastCustomSpell(SPELL_CONSTRICTOR_TENTACLE, SPELLVALUE_MAX_TARGETS, 1, me, false);
+                    SpawnTentacle(NPC_CORRUPTOR_TENTACLE);
+                    SpawnTentacle(NPC_CORRUPTOR_TENTACLE);
 
-                events.ScheduleEvent(EVENT_SARA_P2_MALADY, 7s, 0, EVENT_PHASE_TWO);
-                events.ScheduleEvent(EVENT_SARA_P2_PSYCHOSIS, 3s, 0, EVENT_PHASE_TWO);
-                events.ScheduleEvent(EVENT_SARA_P2_DEATH_RAY, 15s, 0, EVENT_PHASE_TWO);
-                events.ScheduleEvent(EVENT_SARA_P2_SUMMON_T1, 50s, 60s, 0, EVENT_PHASE_TWO);
-                events.ScheduleEvent(EVENT_SARA_P2_SUMMON_T2, 15s, 20s, 0, EVENT_PHASE_TWO);
-                events.ScheduleEvent(EVENT_SARA_P2_SUMMON_T3, 30s + randtime(0ms, 10s), 0, EVENT_PHASE_TWO);
-                events.ScheduleEvent(EVENT_SARA_P2_BRAIN_LINK, 0ms, 0, EVENT_PHASE_TWO);
-                events.ScheduleEvent(EVENT_SARA_P2_OPEN_PORTALS, 60s, 0, EVENT_PHASE_TWO);
-                break;
+                    events.ScheduleEvent(EVENT_SARA_P2_MALADY, 7s, 0, EVENT_PHASE_TWO);
+                    events.ScheduleEvent(EVENT_SARA_P2_PSYCHOSIS, 3s, 0, EVENT_PHASE_TWO);
+                    events.ScheduleEvent(EVENT_SARA_P2_DEATH_RAY, 20s, 0, EVENT_PHASE_TWO);
+                    events.ScheduleEvent(EVENT_SARA_P2_SUMMON_T1, 50s, 60s, 0, EVENT_PHASE_TWO);
+                    events.ScheduleEvent(EVENT_SARA_P2_SUMMON_T2, 15s, 20s, 0, EVENT_PHASE_TWO);
+                    events.ScheduleEvent(EVENT_SARA_P2_SUMMON_T3, 30s + randtime(0ms, 10s), 0, EVENT_PHASE_TWO);
+                    events.ScheduleEvent(EVENT_SARA_P2_BRAIN_LINK, 0ms, 0, EVENT_PHASE_TWO);
+                    events.ScheduleEvent(EVENT_SARA_P2_OPEN_PORTALS, 60s, 0, EVENT_PHASE_TWO);
+                    break;
+                }
             case EVENT_SARA_P1_BERSERK:
                 if (me->GetInstanceScript())
                 {
@@ -1547,27 +1563,74 @@ struct boss_yoggsaron_death_orb : public NullCreatureAI
 {
     boss_yoggsaron_death_orb(Creature* creature) : NullCreatureAI(creature)
     {
-        me->CastSpell(me, SPELL_DEATH_RAY_WARNING, true);
-        _startTimer = 1;
+        me->CastSpell(me, SPELL_DEATH_RAY_ORIGIN_VISUAL, true);
     }
 
-    uint32 _startTimer;
+    void IsSummonedBy(WorldObject* /*summoner*/) override
+    {
+        // Sniffed: each ray comes from its own serverside summon spell, falls from the orb
+        // to the ground below it, and the orb winks out when their damage phase ends
+        for (uint32 spellId = SPELL_DEATH_RAY_SUMMON_1; spellId <= SPELL_DEATH_RAY_SUMMON_4; ++spellId)
+            me->CastSpell(me, spellId, true);
+
+        me->DespawnOrUnsummon(18400ms);
+    }
+
+    void JustSummoned(Creature* summon) override
+    {
+        if (InstanceScript* instance = me->GetInstanceScript())
+            if (Creature* sara = instance->GetCreature(DATA_SARA))
+                sara->AI()->JustSummoned(summon);
+    }
+};
+
+struct boss_yoggsaron_death_ray : public NullCreatureAI
+{
+    boss_yoggsaron_death_ray(Creature* creature) : NullCreatureAI(creature) { }
+
+    EventMap events;
+    uint8 _movementLegs = 0;
+
+    void IsSummonedBy(WorldObject* /*summoner*/) override
+    {
+        me->GetMotionMaster()->MoveFall(0, true);
+        events.ScheduleEvent(EVENT_DEATH_RAY_WARNING, 1200ms);
+        me->DespawnOrUnsummon(19s);
+    }
 
     void UpdateAI(uint32 diff) override
     {
-        if (_startTimer)
+        events.Update(diff);
+        switch (events.ExecuteEvent())
         {
-            _startTimer += diff;
-            if (_startTimer > 4000)
-            {
-                me->CastSpell(me, SPELL_DEATH_RAY_DAMAGE_VISUAL, true);
+            case EVENT_DEATH_RAY_WARNING:
+                me->CastSpell(me, SPELL_DEATH_RAY_WARNING, false);
+                events.ScheduleEvent(EVENT_DEATH_RAY_ACTIVE, 5s);
+                break;
+            case EVENT_DEATH_RAY_ACTIVE:
                 me->CastSpell(me, SPELL_DEATH_RAY_DAMAGE, true);
+                me->CastSpell(nullptr, SPELL_DEATH_RAY_DAMAGE_VISUAL, true);
+                events.ScheduleEvent(EVENT_DEATH_RAY_MOVE, 0ms);
+                break;
+            case EVENT_DEATH_RAY_MOVE:
+                {
+                    // Sniffed: 8 straight 9 yd legs on random cardinal axes, one every ~1.6s
+                    float x = me->GetPositionX();
+                    float y = me->GetPositionY();
+                    switch (urand(0, 3))
+                    {
+                        case 0: x += 9.0f; break;
+                        case 1: x -= 9.0f; break;
+                        case 2: y += 9.0f; break;
+                        case 3: y -= 9.0f; break;
+                    }
+                    float z = me->GetMap()->GetHeight(me->GetPhaseMask(), x, y, me->GetPositionZ() + 5.0f);
+                    me->GetMotionMaster()->MovePoint(0, x, y, z);
 
-                _startTimer = 0;
-                me->SetSpeed(MOVE_WALK, 2);
-                me->SetSpeed(MOVE_RUN, 2);
-                me->GetMotionMaster()->MoveRandom(20.0f);
-            }
+                    if (++_movementLegs < 8)
+                        events.Repeat(1625ms);
+                    break;
+                }
         }
     }
 };
@@ -2246,23 +2309,16 @@ class spell_yogg_saron_malady_of_the_mind_aura : public AuraScript
 
     bool Validate(SpellInfo const* /*spellInfo*/) override
     {
-        return ValidateSpellInfo({ SPELL_DEATH_RAY_DAMAGE_REAL, SPELL_MALADY_OF_THE_MIND_TRIGGER });
-    }
-
-    void OnApply(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
-    {
-        GetUnitOwner()->ApplySpellImmune(SPELL_DEATH_RAY_DAMAGE_REAL, IMMUNITY_ID, SPELL_DEATH_RAY_DAMAGE_REAL, true);
+        return ValidateSpellInfo({ SPELL_MALADY_OF_THE_MIND_TRIGGER });
     }
 
     void OnRemove(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
     {
-        GetUnitOwner()->ApplySpellImmune(SPELL_DEATH_RAY_DAMAGE_REAL, IMMUNITY_ID, SPELL_DEATH_RAY_DAMAGE_REAL, false);
         GetUnitOwner()->CastCustomSpell(SPELL_MALADY_OF_THE_MIND_TRIGGER, SPELLVALUE_MAX_TARGETS, 1, GetUnitOwner(), true);
     }
 
     void Register() override
     {
-        OnEffectApply += AuraEffectApplyFn(spell_yogg_saron_malady_of_the_mind_aura::OnApply, EFFECT_1, SPELL_AURA_MOD_FEAR, AURA_EFFECT_HANDLE_REAL);
         OnEffectRemove += AuraEffectRemoveFn(spell_yogg_saron_malady_of_the_mind_aura::OnRemove, EFFECT_1, SPELL_AURA_MOD_FEAR, AURA_EFFECT_HANDLE_REAL);
     }
 };
@@ -2995,6 +3051,7 @@ void AddSC_boss_yoggsaron()
     RegisterUlduarCreatureAI(boss_yoggsaron_guardian_of_ys);
     RegisterUlduarCreatureAI(boss_yoggsaron_brain);
     RegisterUlduarCreatureAI(boss_yoggsaron_death_orb);
+    RegisterUlduarCreatureAI(boss_yoggsaron_death_ray);
     RegisterUlduarCreatureAI(boss_yoggsaron_crusher_tentacle);
     RegisterUlduarCreatureAI(boss_yoggsaron_corruptor_tentacle);
     RegisterUlduarCreatureAI(boss_yoggsaron_constrictor_tentacle);


### PR DESCRIPTION
## Changes Proposed:
Rework of Yogg-Saron's Death Ray to match sniffed behaviour end to end:

- Sara now boards Yogg-Saron's vehicle at phase 2 start with the Ride Vehicle spell (61791) instead of a hardcoded teleport. The vehicle seat data places her 23.5 yd above Yogg, which is exactly what the sniff shows.
- Sara summons the Death Orb with the real summon spell (63891) at a destination 3 yd above herself, on a 20s initial / 22s repeat timer. Her yell accompanies every other cast, starting with the first of the engagement.
- The four Death Ray Summon serverside spells (63887-63890) get their summon effect filled in `spell_dbc`, and the orb casts one per ray as sniffed. The rays free-fall from the orb to the ground at the arena center. They are never scattered around the room at spawn.
- Each ray channels the 5s warning visual at the orb, then self-casts the periodic aura (63883, which ticks 63884 through DBC data) plus the damage beam visual, and wanders in 8 straight 9 yd legs on random cardinal axes, one leg every ~1.6s at 6 yd/s. Rays despawn after 19s, the orb after 18.4s, matching sniffed lifetimes.
- The `conditions` rows anchoring the warning/damage beam visuals (63882/63886) pointed at Sara (33134); they now point at the Death Orb (33882), matching both the sniff and TrinityCore.
- The Death Orb gets its flying movement back (`creature_template_movement`), the Death Ray creature is bound to its own AI and flagged as a trigger, like TrinityCore.
- The script-side `ApplySpellImmune` for Death Ray damage during Malady of the Mind was removed: the shipped conditions already exclude players with Insane, Malady of the Mind, or the Malady jump aura from 63884.

Known cosmetic deviations from the sniff: rays turn to face their movement direction (no facing control in point movement) while they keep a fixed orientation on retail, and the free-fall starts at the orb rather than slightly above it (the DBC summon target cannot encode a Z offset).

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Fable 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/27028

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [x] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Every timing, position and cast in this PR was extracted from a sniff of the encounter (9 Death Ray volleys across two pulls, all consistent), cross-checked against WotLK spell data on Wowhead and TrinityCore's implementation and DB data. TrinityCore's ray movement is a self-acknowledged TODO (`MoveConfused`), so the movement here follows the sniff instead.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Start the Yogg-Saron encounter and let Guardians bring Sara to phase 2.
2. After the transform, Sara should be riding Yogg-Saron ~23 yd above him. Every ~22s she summons a Death Orb just above herself, yelling "Tremble, mortals..." on every other cast.
3. Four Death Rays fall from the orb to the arena center, show green warning beams anchored to the orb for 5s, then wander in straight 9 yd legs for ~12s dealing damage around themselves. Orb and rays despawn ~19s after the summon.
4. Regression checks: players feared by Malady of the Mind and insane players take no Death Ray damage; the phase 3 transition despawns orb and rays; a wipe resets Sara cleanly back to her spawn.

## Known Issues and TODO List:

- [ ] Phase 2 transition RP pacing differs from retail and was left untouched (out of scope).

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
