### PR TITLE
docs(Agents): add script, SQL and config conventions

### DIFF
--- a/.agents/docs/cpp-guidelines.md
+++ b/.agents/docs/cpp-guidelines.md
@@ -21,7 +21,7 @@ Hard rules (also enforced by CI with `-Werror`, plus `cppcheck`):
 - **Logging**: `LOG_INFO("category.sub", "msg with {}", arg)` (also `LOG_WARN`/`ERROR`/`DEBUG`/`TRACE`). Categories are hierarchical, dot-separated (`server.loading`, `entities.player`, `sql.dev`). No `printf`-style, no `sLog->`, no `TC_LOG_*`. Macro in `src/common/Logging/Log.h`.
 - **Random**: use helpers in `src/common/Utilities/Random.h` — `urand`, `irand`, `frand`, `rand32`, `rand_chance`, `roll_chance_f`, `roll_chance_i`. Not `std::rand` or `<random>`.
 - **Strings**: `Acore::StringFormat(fmt, args...)` (`{}` placeholders) — `src/common/Utilities/StringFormat.h`.
-- **Config**: `sConfigMgr->GetOption<T>("Name", default)`.
+- **Config**: `sConfigMgr->GetOption<T>("Name", default)` — read once at startup/reload and cache the value; never call it in hot paths or per-call gating checks.
 - **Namespace**: project-wide `Acore::` (no `Trinity::` remnants — rename when porting from upstream forks).
 - **Long-lived references**: don't store a raw `Player*` / `Creature*` / `Unit*` past the current call/tick — the object can be removed (logout, despawn, instance unload) and the pointer dangles. Store the `ObjectGuid` and resolve at use time via `ObjectAccessor::FindPlayer(guid)`, `Map::GetCreature(guid)`, etc.
 - **DB queries**: use `PreparedStatement` (via `WorldDatabase` / `CharacterDatabase` / `LoginDatabase` and the prepared-statement enums), not raw query strings. Non-blocking reads go async: `_queryProcessor.AddCallback(db.AsyncQuery(stmt).WithPreparedCallback(...))` (or `WithCallback`). Multi-statement writes wrap in `SQLTransaction` + `Execute` / `AppendPreparedStatement`.

--- a/.agents/docs/cpp-scripts.md
+++ b/.agents/docs/cpp-scripts.md
@@ -17,6 +17,6 @@ Then declare and call `AddSC_<name>()` from the regional loader (`Spells/spells_
 - A `SpellScript`/`AuraScript` without a matching `spell_script_names` row is inert — ship the binding SQL update in the same change as the C++ registration.
 - Never add `UNIT_FLAG*` / `UNIT_FLAG2*` / `UNIT_DYNFLAG*` values without sniff or upstream evidence; the same flag used in another script is not evidence.
 - Trigger NPCs (`creature_template.flags_extra` 0x80) have no threat list — `SelectTarget` / `AddThreat` / `UpdateVictim` chains on them silently do nothing. A never-evading helper NPC left on a boss's threatened-by list also stalls the boss's evade/reset forever; make such helpers `IMMUNE_TO_NPC`.
-- A spell id missing from Wowhead only proves it is not client-side — check the world DB's `spell_dbc` table before concluding a sniffed id doesn't exist.
+- A spell id missing from Wowhead is inconclusive — check the world DB's `spell_dbc` table (server-side spells) before concluding a sniffed id doesn't exist.
 
 Custom (non-upstream) scripts go in `src/server/scripts/Custom/` (gitignored).

--- a/.agents/docs/cpp-scripts.md
+++ b/.agents/docs/cpp-scripts.md
@@ -14,5 +14,9 @@ Then declare and call `AddSC_<name>()` from the regional loader (`Spells/spells_
 **Conventions:**
 
 - Script ids (action/event/data/phase) get named enum entries — never raw literals, even when the file already uses them: add the entry and convert that literal's every call site and handler in the same change.
+- A `SpellScript`/`AuraScript` without a matching `spell_script_names` row is inert — ship the binding SQL update in the same change as the C++ registration.
+- Never add `UNIT_FLAG*` / `UNIT_FLAG2*` / `UNIT_DYNFLAG*` values without sniff or upstream evidence; the same flag used in another script is not evidence.
+- Trigger NPCs (`creature_template.flags_extra` 0x80) have no threat list — `SelectTarget` / `AddThreat` / `UpdateVictim` chains on them silently do nothing. A never-evading helper NPC left on a boss's threatened-by list also stalls the boss's evade/reset forever; make such helpers `IMMUNE_TO_NPC`.
+- A spell id missing from Wowhead only proves it is not client-side — check the world DB's `spell_dbc` table before concluding a sniffed id doesn't exist.
 
 Custom (non-upstream) scripts go in `src/server/scripts/Custom/` (gitignored).

--- a/.agents/docs/sql-guidelines.md
+++ b/.agents/docs/sql-guidelines.md
@@ -8,6 +8,11 @@
 
 Run the linter before claiming a change is done: `python apps/codestyle/codestyle-sql.py` (compares to origin/master).
 
+## Data conventions
+
+- `smart_scripts` edits always rewrite the full `entryorguid` block (`DELETE` + `INSERT` of every row) — never a partial `UPDATE`, not even for a comment-only fix.
+- `creature_immunities`: immunity sets are single-reference. Before minting a new id, check whether an existing set already matches; to extend a creature's immunities, create a superset instead of editing a shared set. Negative ids are curated — don't allocate them.
+
 ## The three databases
 
 - `acore_auth` — accounts, realm list, IP/account bans, session keys. Shared across all realms.

--- a/.agents/docs/sql-guidelines.md
+++ b/.agents/docs/sql-guidelines.md
@@ -10,8 +10,8 @@ Run the linter before claiming a change is done: `python apps/codestyle/codestyl
 
 ## Data conventions
 
-- `smart_scripts` edits always rewrite the full `entryorguid` block (`DELETE` + `INSERT` of every row) — never a partial `UPDATE`, not even for a comment-only fix.
-- `creature_immunities`: immunity sets are single-reference. Before minting a new id, check whether an existing set already matches; to extend a creature's immunities, create a superset instead of editing a shared set. Negative ids are curated — don't allocate them.
+- `smart_scripts` edits always rewrite the full block — `DELETE` + `INSERT` of every row for the `(entryorguid, source_type)` pair, with the `DELETE` matching both columns — never a partial `UPDATE`, not even for a comment-only fix.
+- `creature_immunities`: negative ids are curated shared sets — reference them via `creature_template.CreatureImmunitiesId`, never edit them or allocate new ones. Positive ids are single-creature sets — reuse an existing set only on an exact match; to extend a creature's immunities, insert a superset under a new id and point the creature's `CreatureImmunitiesId` at it.
 
 ## The three databases
 


### PR DESCRIPTION
## Changes Proposed:

Follow-up to #26962, extending the agent docs with more conventions learned from recent script and DB work:

- `.agents/docs/cpp-scripts.md`: four new bullets in the Conventions section: spell scripts need their `spell_script_names` row shipped in the same change, unit flag changes require sniff or upstream evidence, trigger NPCs (`flags_extra` 0x80) have no threat list (plus the boss evade stall caused by never-evading helpers), and `spell_dbc` should be checked before concluding a sniffed spell id does not exist.
- `.agents/docs/sql-guidelines.md`: new "Data conventions" section covering full-block DELETE+INSERT for `smart_scripts` edits and the `creature_immunities` single-reference/superset rules.
- `.agents/docs/cpp-guidelines.md`: the Config bullet now tells agents to cache config values at startup/reload instead of calling `sConfigMgr->GetOption` in hot paths.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Documentation only (`.agents/docs/`), no code or data changes.

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Fable 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- None

## SOURCE:
The changes have been validated through:
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)

Each convention comes from a lesson learned while working on merged fixes and reviews in this repo (threat rework behaviour, `creature_immunities` migration, `spell_script_names` bindings, SmartAI update workflow).

## Tests Performed:

Documentation only, nothing to test in-game.

## How to Test the Changes:

Not applicable.

## Known Issues and TODO List:

None.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
