### PR TITLE
fix(Scripts/Ulduar): drive the Crusher Tentacle interrupt with its proc aura

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1786206334121809900.sql
+++ b/data/sql/updates/pending_db_world/rev_1786206334121809900.sql
@@ -1,0 +1,4 @@
+-- Crusher Tentacle: bind the sniffed Diminsh Power proc aura (64148)
+DELETE FROM `spell_script_names` WHERE `spell_id` = 64148;
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(64148, 'spell_yogg_saron_diminish_power_aura');

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
@@ -23,6 +23,7 @@
 #include "Player.h"
 #include "ScriptedCreature.h"
 #include "ScriptedEscortAI.h"
+#include "Spell.h"
 #include "SpellAuras.h"
 #include "SpellMgr.h"
 #include "SpellScript.h"
@@ -2274,11 +2275,14 @@ class spell_yogg_saron_diminish_power_aura : public AuraScript
     PrepareAuraScript(spell_yogg_saron_diminish_power_aura);
 
     // Serverside proc (no triggered spell in DBC): taken melee hits and melee
-    // abilities break the Diminish Power channel
+    // abilities break the Diminish Power channel. Sniffed: only the active
+    // channel breaks, the initial 1.5s cast is not interruptible by damage
     void HandleProc(AuraEffect const* /*aurEff*/, ProcEventInfo& /*eventInfo*/)
     {
         PreventDefaultAction();
-        GetTarget()->InterruptNonMeleeSpells(false);
+        if (Spell* spell = GetTarget()->GetCurrentSpell(CURRENT_CHANNELED_SPELL))
+            if (spell->getState() == SPELL_STATE_CASTING)
+                GetTarget()->InterruptSpell(CURRENT_CHANNELED_SPELL);
     }
 
     void Register() override

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
@@ -102,6 +102,7 @@ enum YoggSpells
     // CRUSHER TENTACLE
     SPELL_CRUSH                         = 64146,
     SPELL_DIMINISH_POWER                = 64145,
+    SPELL_DIMINISH_POWER_PROC           = 64148,
     SPELL_FOCUSED_ANGER                 = 57688,
 
     // CONSTRICTOR TENTACLE
@@ -1579,6 +1580,7 @@ struct boss_yoggsaron_crusher_tentacle : public ScriptedAI
         me->SetCombatMovement(false);
         me->CastSpell(me, SPELL_CRUSH, true);
         me->CastSpell(me, SPELL_FOCUSED_ANGER, true);
+        me->CastSpell(me, SPELL_DIMINISH_POWER_PROC, true);
         me->CastSpell(me, SPELL_DIMINISH_POWER, false);
     }
 
@@ -1594,7 +1596,6 @@ struct boss_yoggsaron_crusher_tentacle : public ScriptedAI
             DoResetThreatList();
             me->AddThreat(who, 100000);
             AttackStart(who);
-            me->InterruptNonMeleeSpells(false);
         }
     }
 
@@ -2264,6 +2265,25 @@ class spell_yogg_saron_malady_of_the_mind_aura : public AuraScript
     {
         OnEffectApply += AuraEffectApplyFn(spell_yogg_saron_malady_of_the_mind_aura::OnApply, EFFECT_1, SPELL_AURA_MOD_FEAR, AURA_EFFECT_HANDLE_REAL);
         OnEffectRemove += AuraEffectRemoveFn(spell_yogg_saron_malady_of_the_mind_aura::OnRemove, EFFECT_1, SPELL_AURA_MOD_FEAR, AURA_EFFECT_HANDLE_REAL);
+    }
+};
+
+// 64148 - Diminsh Power
+class spell_yogg_saron_diminish_power_aura : public AuraScript
+{
+    PrepareAuraScript(spell_yogg_saron_diminish_power_aura);
+
+    // Serverside proc (no triggered spell in DBC): taken melee hits and melee
+    // abilities break the Diminish Power channel
+    void HandleProc(AuraEffect const* /*aurEff*/, ProcEventInfo& /*eventInfo*/)
+    {
+        PreventDefaultAction();
+        GetTarget()->InterruptNonMeleeSpells(false);
+    }
+
+    void Register() override
+    {
+        OnEffectProc += AuraEffectProcFn(spell_yogg_saron_diminish_power_aura::HandleProc, EFFECT_0, SPELL_AURA_PROC_TRIGGER_SPELL);
     }
 };
 
@@ -3009,6 +3029,7 @@ void AddSC_boss_yoggsaron()
 
     // SPELLS
     RegisterSpellScript(spell_yogg_saron_malady_of_the_mind_aura);
+    RegisterSpellScript(spell_yogg_saron_diminish_power_aura);
     RegisterSpellAndAuraScriptPair(spell_yogg_saron_brain_link, spell_yogg_saron_brain_link_aura);
     RegisterSpellScript(spell_yogg_saron_shadow_beacon_aura);
     RegisterSpellScript(spell_yogg_saron_destabilization_matrix);


### PR DESCRIPTION
## Changes Proposed:
The Crusher Tentacle's Diminish Power interrupt was script-side and only reacted to white melee hits (`damagetype == DIRECT_DAMAGE`), so damaging abilities like a feral druid's Swipe never broke the channel.

A sniff shows how retail actually implements this: every Crusher Tentacle self-casts aura 64148 ("Diminsh Power", sic) at spawn. It's a real 3.3.5 client spell: Apply Aura: Proc Trigger Spell with a null trigger spell, 100% proc chance, and proc mask 0x28 (taken melee auto-attacks + taken melee-class abilities). The serverside effect of the proc is breaking the Diminish Power channel.

This PR casts 64148 on the tentacle at spawn and implements the proc in an aura script that interrupts the channel, removing the old `DamageTaken` interrupt (the threat snap on white hits stays). Interrupt eligibility now comes from the DBC proc mask, so:

- melee auto-attacks and melee-class abilities (Swipe, Sinister Strike, etc.) break the channel
- caster spells, ranged attacks and DoT ticks correctly do not
- only the active channel breaks: the initial 1.5s cast (and recasts after a break) complete even under attack, matching the sniff, where the proc aura is present from spawn yet a recast finishes while the tentacle is being hit

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Fable 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/27029
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/27032

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [x] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

The 64148 aura is present on every Crusher Tentacle create block in a sniff of the encounter, and its proc data (mask 0x28, 100% chance, no trigger spell) comes from Spell.dbc. The linked issue's period video shows Swipe breaking the channel in the original game.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Bring Yogg-Saron to phase 2 and find a Crusher Tentacle channeling Diminish Power.
2. Hit it with a melee ability (e.g. Swipe in bear form): the channel breaks and the raid-wide debuff fades.
3. Hit it with only a caster spell or a DoT: the channel keeps going.
4. White melee hits still break the channel like before.
5. Attack it during the initial 1.5s cast of Diminish Power (cast bar, not channel): the cast completes anyway.

## Known Issues and TODO List:

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
