### PR TITLE
fix(Scripts/Ulduar): credit Singed to the player instead of the campfire

### DIFF
--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_hodir.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_hodir.cpp
@@ -1484,13 +1484,14 @@ class spell_hodir_toasty_fire_aura : public AuraScript
                 target->ToPlayer()->UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_BE_SPELL_TARGET2, SPELL_MAGE_TOASTY_FIRE_AURA, 0, GetCaster());
     }
 
-    void HandleProc(AuraEffect const* /*aurEff*/, ProcEventInfo& eventInfo)
+    void HandleProc(AuraEffect const* aurEff, ProcEventInfo& eventInfo)
     {
-        // Default proc handling tags Singed with the campfire as original caster, so
-        // every new campfire starts a separate stack on Hodir. Cast as the player instead.
+        // The default handler would credit the campfire (the aura caster) as original caster,
+        // freezing the shared Singed stack's duration once it despawns. Credit the player instead.
         PreventDefaultAction();
+        Unit* player = GetTarget();
         if (Unit* target = eventInfo.GetProcTarget())
-            GetTarget()->CastSpell(target, SPELL_SINGED, true);
+            player->CastSpell(target, SPELL_SINGED, true, nullptr, aurEff, player->GetGUID());
     }
 
     void Register() override

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_hodir.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_hodir.cpp
@@ -1472,6 +1472,11 @@ class spell_hodir_toasty_fire_aura : public AuraScript
 {
     PrepareAuraScript(spell_hodir_toasty_fire_aura);
 
+    bool Validate(SpellInfo const* /*spellInfo*/) override
+    {
+        return ValidateSpellInfo({ SPELL_SINGED });
+    }
+
     void HandleAfterEffectApply(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
     {
         if (Unit* target = GetTarget())
@@ -1479,9 +1484,19 @@ class spell_hodir_toasty_fire_aura : public AuraScript
                 target->ToPlayer()->UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_BE_SPELL_TARGET2, SPELL_MAGE_TOASTY_FIRE_AURA, 0, GetCaster());
     }
 
+    void HandleProc(AuraEffect const* /*aurEff*/, ProcEventInfo& eventInfo)
+    {
+        // Default proc handling tags Singed with the campfire as original caster, so
+        // every new campfire starts a separate stack on Hodir. Cast as the player instead.
+        PreventDefaultAction();
+        if (Unit* target = eventInfo.GetProcTarget())
+            GetTarget()->CastSpell(target, SPELL_SINGED, true);
+    }
+
     void Register() override
     {
         AfterEffectApply += AuraEffectApplyFn(spell_hodir_toasty_fire_aura::HandleAfterEffectApply, EFFECT_0, SPELL_AURA_MOD_STAT, AURA_EFFECT_HANDLE_SEND_FOR_CLIENT_MASK);
+        OnEffectProc += AuraEffectProcFn(spell_hodir_toasty_fire_aura::HandleProc, EFFECT_1, SPELL_AURA_PROC_TRIGGER_SPELL);
     }
 };
 


### PR DESCRIPTION
## Changes Proposed:

Add a proc handler to the Toasty Fire aura (62821) that casts Singed (65280) from the buffed player instead of letting the campfire NPC be credited as its caster.

The bug is an interaction of three things:

- Singed carries `SPELL_ATTR0_CU_SINGLE_AURA_STACK` (`spell_custom_attr`), so all applications merge into a single aura on Hodir regardless of caster.
- The generic proc handler passes the triggering aura into `CastSpell`, and an old workaround in `Unit::CastSpell` (flagged "@todo: this is a workaround - not needed anymore, but required for some scripts") substitutes the aura's caster as original caster. The Toasty Fire aura's caster is the campfire NPC, so the merged Singed aura permanently remembers the first campfire as its caster.
- `Aura::ModStackAmount` requests a duration refresh on every application, but `Aura::RefreshDuration` starts with `if (!caster) return;`. Once that first campfire despawns (its 60s lifetime, or Flash Freeze), the refresh silently no-ops from then on: stacks keep adding while the timer stays frozen, and the whole stack drops 25s after the last refresh that happened while the original campfire was alive. Then the next proc opens a fresh aura remembering the next campfire, and the cycle repeats.

With the player as caster, the merged aura's caster stays resolvable for the whole fight, so every proc adds a stack and refreshes the duration.

## Issues Addressed:

- Closes #26959

## SOURCE:

Retail sniff (12.0.7.68887): the Singed SMSG_SPELL_GO carries the player as CasterGUID/CasterUnit (proc'd off their Auto Shot), so retail attributes Singed to the player, not the campfire. Detailed analysis in the issue comments.

## Tests Performed:

- Builds clean (Release).
- Verified in game: Singed now both stacks and refreshes its 25s timer on every proc, across campfire changeovers and after Flash Freeze.

## How to Test the Changes:

1. `.tele Hodir`, engage, free the mages, tank Hodir on a campfire and watch Singed stack.
2. Keep attacking as campfires expire and new ones are dropped: the same Singed stack must keep refreshing and growing instead of freezing its timer.
3. Let Flash Freeze destroy the fires; once new campfires are up and you attack from them, the surviving stack must refresh, not restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)