### PR TITLE
fix(Scripts/Ulduar): complete the brain room Influence Tentacle sets

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1786222003126161600.sql
+++ b/data/sql/updates/pending_db_world/rev_1786222003126161600.sql
@@ -1,0 +1,28 @@
+-- Yogg-Saron brain room Influence Tentacles (sniffed positions), summoned per illusion by the brain
+DELETE FROM `creature_summon_groups` WHERE `summonerId` = 33890 AND `summonerType` = 0 AND `groupId` IN (1, 2, 3);
+INSERT INTO `creature_summon_groups` (`summonerId`, `summonerType`, `groupId`, `entry`, `position_x`, `position_y`, `position_z`, `orientation`, `summonType`, `summonTime`, `Comment`) VALUES
+(33890, 0, 1, 33943, 2069.298, -43.5317, 239.8006, 0.47124, 8, 0, 'Brain of Yogg-Saron - Chamber Illusion - Influence Tentacle'),
+(33890, 0, 1, 33943, 2069.4792, -5.6997, 239.8058, 5.42797, 8, 0, 'Brain of Yogg-Saron - Chamber Illusion - Influence Tentacle'),
+(33890, 0, 1, 33943, 2113.3298, -65.7101, 239.8058, 1.78024, 8, 0, 'Brain of Yogg-Saron - Chamber Illusion - Influence Tentacle'),
+(33890, 0, 1, 33943, 2139.8298, -50.2865, 239.8058, 2.46091, 8, 0, 'Brain of Yogg-Saron - Chamber Illusion - Influence Tentacle'),
+(33890, 0, 1, 33943, 2136.6406, -1.9965, 239.8058, 3.83972, 8, 0, 'Brain of Yogg-Saron - Chamber Illusion - Influence Tentacle'),
+(33890, 0, 1, 33943, 2116.9307, 11.375, 239.8058, 4.41568, 8, 0, 'Brain of Yogg-Saron - Chamber Illusion - Influence Tentacle'),
+(33890, 0, 1, 33943, 2146.2395, -34.4045, 239.8058, 3.01942, 8, 0, 'Brain of Yogg-Saron - Chamber Illusion - Influence Tentacle'),
+(33890, 0, 1, 33943, 2146.8801, -17.0313, 239.8058, 3.35103, 8, 0, 'Brain of Yogg-Saron - Chamber Illusion - Influence Tentacle'),
+(33890, 0, 2, 33943, 1897.3455, -106.6076, 240.1444, 4.93928, 8, 0, 'Brain of Yogg-Saron - Icecrown Illusion - Influence Tentacle'),
+(33890, 0, 2, 33943, 1902.132, -111.3594, 240.0698, 4.85202, 8, 0, 'Brain of Yogg-Saron - Icecrown Illusion - Influence Tentacle'),
+(33890, 0, 2, 33943, 1905.3264, -104.7865, 240.0523, 4.76475, 8, 0, 'Brain of Yogg-Saron - Icecrown Illusion - Influence Tentacle'),
+(33890, 0, 2, 33943, 1912.1285, -136.934, 240.073, 4.18879, 8, 0, 'Brain of Yogg-Saron - Icecrown Illusion - Influence Tentacle'),
+(33890, 0, 2, 33943, 1917.5591, -135.7448, 240.073, 4.18879, 8, 0, 'Brain of Yogg-Saron - Icecrown Illusion - Influence Tentacle'),
+(33890, 0, 2, 33943, 1919.125, -140.9566, 240.073, 3.97935, 8, 0, 'Brain of Yogg-Saron - Icecrown Illusion - Influence Tentacle'),
+(33890, 0, 2, 33943, 1948.4688, -136.2951, 240.0707, 3.4383, 8, 0, 'Brain of Yogg-Saron - Icecrown Illusion - Influence Tentacle'),
+(33890, 0, 2, 33943, 1952.9653, -130.5295, 240.1347, 3.80482, 8, 0, 'Brain of Yogg-Saron - Icecrown Illusion - Influence Tentacle'),
+(33890, 0, 2, 33943, 1956.4445, -138.4028, 240.1078, 3.36849, 8, 0, 'Brain of Yogg-Saron - Icecrown Illusion - Influence Tentacle'),
+(33890, 0, 3, 33943, 1897.3435, 64.3142, 239.7495, 0.13963, 8, 0, 'Brain of Yogg-Saron - Stormwind Illusion - Influence Tentacle'),
+(33890, 0, 3, 33943, 1903.3931, 86.6029, 239.7495, 5.61996, 8, 0, 'Brain of Yogg-Saron - Stormwind Illusion - Influence Tentacle'),
+(33890, 0, 3, 33943, 1908.993, 44.2666, 239.7495, 0.92502, 8, 0, 'Brain of Yogg-Saron - Stormwind Illusion - Influence Tentacle'),
+(33890, 0, 3, 33943, 1923.3416, 98.0123, 239.7495, 4.83456, 8, 0, 'Brain of Yogg-Saron - Stormwind Illusion - Influence Tentacle'),
+(33890, 0, 3, 33943, 1931.1404, 38.4695, 239.7495, 1.71042, 8, 0, 'Brain of Yogg-Saron - Stormwind Illusion - Influence Tentacle'),
+(33890, 0, 3, 33943, 1945.4417, 92.1795, 239.7495, 4.04916, 8, 0, 'Brain of Yogg-Saron - Stormwind Illusion - Influence Tentacle'),
+(33890, 0, 3, 33943, 1951.0402, 49.8888, 239.7495, 2.49582, 8, 0, 'Brain of Yogg-Saron - Stormwind Illusion - Influence Tentacle'),
+(33890, 0, 3, 33943, 1956.5028, 72.1946, 239.7495, 3.28122, 8, 0, 'Brain of Yogg-Saron - Stormwind Illusion - Influence Tentacle');

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
@@ -1326,6 +1326,7 @@ struct boss_yoggsaron_brain : public NullCreatureAI
     {
         me->SetDisableGravity(true);
         _tentacleCount = 0;
+        _tentacleTotal = 0;
         _activeIllusion = 0;
         _induceTimer = 0;
         _brainDamaged = false;
@@ -1334,6 +1335,7 @@ struct boss_yoggsaron_brain : public NullCreatureAI
 
     bool _brainDamaged;
     uint8 _tentacleCount;
+    uint8 _tentacleTotal;
     uint8 _activeIllusion;
     uint32 _induceTimer;
     SummonList summons;
@@ -1343,6 +1345,8 @@ struct boss_yoggsaron_brain : public NullCreatureAI
     {
         if (cr->GetEntry() == NPC_INFLUENCE_TENTACLE)
         {
+            ++_tentacleTotal;
+
             // Dragons Illusion
             if (cr->GetPositionX() > 2000.0f && cr->GetPositionX() < 2150.0f)
                 cr->UpdateEntry(urand(NPC_CONSORT_FIRST, NPC_CONSORT_LAST));
@@ -1364,13 +1368,15 @@ struct boss_yoggsaron_brain : public NullCreatureAI
 
     void PrepareChamberIllusion()
     {
-        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 2126.13f, -65.488f, 239.721f, 1.99171f);
-        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 2141.05f, -50.5146f, 239.751f, 2.72998f);
-        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 2148.83f, -23.9568f, 239.721f, 3.04807f);
-        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 2064.39f, -42.0691f, 239.719f, 0.0949586f);
-        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 2064.29f, -7.13128f, 239.756f, 5.96974f);
-        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 2117.31f, 14.897f, 239.731f, 4.32041f);
-        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 2136.7f, 2.43262f, 239.72f, 3.90023f);
+        // Sniffed positions
+        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 2069.298f, -43.5317f, 239.8006f, 0.47124f);
+        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 2069.4792f, -5.6997f, 239.8058f, 5.42797f);
+        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 2113.3298f, -65.7101f, 239.8058f, 1.78024f);
+        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 2139.8298f, -50.2865f, 239.8058f, 2.46091f);
+        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 2136.6406f, -1.9965f, 239.8058f, 3.83972f);
+        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 2116.9307f, 11.375f, 239.8058f, 4.41568f);
+        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 2146.2395f, -34.4045f, 239.8058f, 3.01942f);
+        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 2146.8801f, -17.0313f, 239.8058f, 3.35103f);
 
         // Laughing Skulls
         if (urand(0, 1))
@@ -1413,13 +1419,16 @@ struct boss_yoggsaron_brain : public NullCreatureAI
             me->SummonCreature(NPC_LAUGHING_SKULL, 1921, -158, 240, 0);
 
         // Influence
-        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 1958.29f, -128.65f, 239.99f, 3.61293f);
-        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 1957.78f, -134.368f, 239.99f, 3.35375f);
-        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 1953.04f, -137.843f, 239.99f, 3.55796f);
-        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 1900.31f, -93.5241f, 239.99f, 4.50043f);
-        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 1895.03f, -98.0773f, 239.99f, 4.88135f);
-        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 1895.19f, -104.587f, 239.99f, 5.02271f);
-        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 1923.31f, -125.98f, 240, 4.2f);
+        // Sniffed positions
+        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 1897.3455f, -106.6076f, 240.1444f, 4.93928f);
+        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 1902.132f, -111.3594f, 240.0698f, 4.85202f);
+        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 1905.3264f, -104.7865f, 240.0523f, 4.76475f);
+        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 1912.1285f, -136.934f, 240.073f, 4.18879f);
+        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 1917.5591f, -135.7448f, 240.073f, 4.18879f);
+        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 1919.125f, -140.9566f, 240.073f, 3.97935f);
+        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 1948.4688f, -136.2951f, 240.0707f, 3.4383f);
+        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 1952.9653f, -130.5295f, 240.1347f, 3.80482f);
+        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 1956.4445f, -138.4028f, 240.1078f, 3.36849f);
 
         // Others
         me->SummonCreature(NPC_LICH_KING, 1906.98f, -153, 240, 4.2f);
@@ -1444,13 +1453,15 @@ struct boss_yoggsaron_brain : public NullCreatureAI
         me->SummonCreature(NPC_LAUGHING_SKULL, 1963.68f, 89.7549f, 239.667f, 3.70571f);
 
         // Influence
-        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 1931.41f, 39.0711f, 239.66f, 1.82467f);
-        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 1908.67f, 45.5867f, 239.666f, 0.72119f);
-        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 1897.68f, 66.1274f, 239.666f, 6.27395f);
-        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 1950.73f, 49.3446f, 239.666f, 2.63756f);
-        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 1923.16f, 97.5586f, 239.666f, 4.74635f);
-        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 1956.16f, 72.1403f, 239.666f, 3.19518f);
-        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 1944.81f, 92.3154f, 239.666f, 4.03556f);
+        // Sniffed positions
+        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 1897.3435f, 64.3142f, 239.7495f, 0.13963f);
+        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 1903.3931f, 86.6029f, 239.7495f, 5.61996f);
+        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 1908.993f, 44.2666f, 239.7495f, 0.92502f);
+        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 1923.3416f, 98.0123f, 239.7495f, 4.83456f);
+        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 1931.1404f, 38.4695f, 239.7495f, 1.71042f);
+        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 1945.4417f, 92.1795f, 239.7495f, 4.04916f);
+        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 1951.0402f, 49.8888f, 239.7495f, 2.49582f);
+        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 1956.5028f, 72.1946f, 239.7495f, 3.28122f);
 
         // Others
         me->SummonCreature(NPC_GARONA, 1928.58f, 65.64f, 242.37f, 2.1f);
@@ -1477,7 +1488,7 @@ struct boss_yoggsaron_brain : public NullCreatureAI
         else if (param == ACTION_INFLUENCE_TENTACLE_DIED)
         {
             _tentacleCount++;
-            if (_tentacleCount >= 7 /*TENTACLES COUNT*/)
+            if (_tentacleCount >= _tentacleTotal)
             {
                 // Stun
                 if (me->GetInstanceScript())
@@ -1495,6 +1506,7 @@ struct boss_yoggsaron_brain : public NullCreatureAI
             return;
 
         summons.DespawnAll();
+        _tentacleTotal = 0;
         switch (param)
         {
             case ACTION_ILLUSION_STORMWIND:
@@ -1529,7 +1541,7 @@ struct boss_yoggsaron_brain : public NullCreatureAI
 
     void DamageTaken(Unit* who, uint32& damage, DamageEffectType, SpellSchoolMask) override
     {
-        if (_tentacleCount < 7) // if all tentacles aren't killed
+        if (!_tentacleTotal || _tentacleCount < _tentacleTotal) // if all tentacles aren't killed
         {
             damage = 0;
             if (who)

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
@@ -268,6 +268,11 @@ enum Misc
     ACTION_ILLUSION_ICECROWN            = 2,
     ACTION_ILLUSION_STORMWIND           = 3,
 
+    // creature_summon_groups for the brain (33890)
+    SUMMON_GROUP_CHAMBER_TENTACLES      = 1,
+    SUMMON_GROUP_ICECROWN_TENTACLES     = 2,
+    SUMMON_GROUP_STORMWIND_TENTACLES    = 3,
+
     // ACTION_SARA_UPDATE_SUMMON_KEEPERS = 4, // defined in ulduar.h
 
     EVENT_PHASE_ONE                     = 1,
@@ -1368,15 +1373,7 @@ struct boss_yoggsaron_brain : public NullCreatureAI
 
     void PrepareChamberIllusion()
     {
-        // Sniffed positions
-        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 2069.298f, -43.5317f, 239.8006f, 0.47124f);
-        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 2069.4792f, -5.6997f, 239.8058f, 5.42797f);
-        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 2113.3298f, -65.7101f, 239.8058f, 1.78024f);
-        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 2139.8298f, -50.2865f, 239.8058f, 2.46091f);
-        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 2136.6406f, -1.9965f, 239.8058f, 3.83972f);
-        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 2116.9307f, 11.375f, 239.8058f, 4.41568f);
-        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 2146.2395f, -34.4045f, 239.8058f, 3.01942f);
-        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 2146.8801f, -17.0313f, 239.8058f, 3.35103f);
+        me->SummonCreatureGroup(SUMMON_GROUP_CHAMBER_TENTACLES);
 
         // Laughing Skulls
         if (urand(0, 1))
@@ -1419,16 +1416,7 @@ struct boss_yoggsaron_brain : public NullCreatureAI
             me->SummonCreature(NPC_LAUGHING_SKULL, 1921, -158, 240, 0);
 
         // Influence
-        // Sniffed positions
-        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 1897.3455f, -106.6076f, 240.1444f, 4.93928f);
-        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 1902.132f, -111.3594f, 240.0698f, 4.85202f);
-        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 1905.3264f, -104.7865f, 240.0523f, 4.76475f);
-        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 1912.1285f, -136.934f, 240.073f, 4.18879f);
-        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 1917.5591f, -135.7448f, 240.073f, 4.18879f);
-        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 1919.125f, -140.9566f, 240.073f, 3.97935f);
-        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 1948.4688f, -136.2951f, 240.0707f, 3.4383f);
-        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 1952.9653f, -130.5295f, 240.1347f, 3.80482f);
-        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 1956.4445f, -138.4028f, 240.1078f, 3.36849f);
+        me->SummonCreatureGroup(SUMMON_GROUP_ICECROWN_TENTACLES);
 
         // Others
         me->SummonCreature(NPC_LICH_KING, 1906.98f, -153, 240, 4.2f);
@@ -1453,15 +1441,7 @@ struct boss_yoggsaron_brain : public NullCreatureAI
         me->SummonCreature(NPC_LAUGHING_SKULL, 1963.68f, 89.7549f, 239.667f, 3.70571f);
 
         // Influence
-        // Sniffed positions
-        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 1897.3435f, 64.3142f, 239.7495f, 0.13963f);
-        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 1903.3931f, 86.6029f, 239.7495f, 5.61996f);
-        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 1908.993f, 44.2666f, 239.7495f, 0.92502f);
-        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 1923.3416f, 98.0123f, 239.7495f, 4.83456f);
-        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 1931.1404f, 38.4695f, 239.7495f, 1.71042f);
-        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 1945.4417f, 92.1795f, 239.7495f, 4.04916f);
-        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 1951.0402f, 49.8888f, 239.7495f, 2.49582f);
-        me->SummonCreature(NPC_INFLUENCE_TENTACLE, 1956.5028f, 72.1946f, 239.7495f, 3.28122f);
+        me->SummonCreatureGroup(SUMMON_GROUP_STORMWIND_TENTACLES);
 
         // Others
         me->SummonCreature(NPC_GARONA, 1928.58f, 65.64f, 242.37f, 2.1f);


### PR DESCRIPTION
## Changes Proposed:
The three Yogg-Saron brain rooms each summoned 7 Influence Tentacles, but sniffs of the encounter show 9 in the Icecrown room, 8 in Stormwind and 8 in the Chamber. The missing ones are Icecrown's center trio (the room had a single tentacle there), a Suit of Armor on Stormwind's north wall, and one of the Chamber's east-wall pair (the two retail spawns were merged into one spot between them).

- The hardcoded position lists are gone entirely: the tentacle spawns now live in `creature_summon_groups` (summoner 33890, one group per illusion) with sniffed coordinates and orientations, and each `Prepare*Illusion` just calls `SummonCreatureGroup`. This adds the missing tentacles and realigns the existing ones, which were each a few yards off, to the exact retail spots.
- The illusion-shatter logic no longer assumes 7 tentacles: the brain AI counts how many Influence Tentacles the active illusion summoned and requires all of them dead, both for the shatter trigger and for the brain's invulnerability window (with the brain staying protected before any illusion has been prepared).
- The per-room disguise classification (consorts / kneeling Deathsworn Zealots / Suits of Armor) was verified against every new coordinate.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Fable 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/27035

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [x] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

All 25 positions come from create blocks in two sniffs of the encounter covering all three illusion rooms; the Stormwind set appears in both captures with identical coordinates.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Bring Yogg-Saron to phase 2 and enter each brain room through the Descend Into Madness portals across several portal phases.
2. Count the disguised Influence Tentacles: 9 in the Lich King room (three in the center), 8 in Stormwind, 8 in the Chamber (two on the east wall).
3. Kill all tentacles in a room: the illusion shatters only after the last one dies (9 kills in Icecrown, not 7).
4. Confirm the brain stays immune to damage until all of the room's tentacles are dead.

## Known Issues and TODO List:

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
