### PR TITLE
fix(DB/SAI): make Negolash emerge from the sea and walk to the Ruined Lifeboat

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1786220066682267000.sql
+++ b/data/sql/updates/pending_db_world/rev_1786220066682267000.sql
@@ -29,3 +29,12 @@ DELETE FROM `creature_text` WHERE `CreatureID` = 1494;
 INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `TextRange`, `comment`) VALUES
 (1494, 0, 0, 'Mmmh...I SMELL FOOD!', 14, 0, 100, 0, 0, 0, 731, 0, 'Negolash - On Just Summoned'),
 (1494, 1, 0, 'AH, A FEAST!  WHO LEFT THIS HERE...?', 14, 0, 100, 0, 0, 0, 763, 0, 'Negolash - On Waypoint Path Ended');
+
+-- Conditions to avoid double spawns
+DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 22) AND (`SourceGroup` = 1) AND (`SourceEntry` = 2289) AND (`SourceId` = 1) AND (`ElseGroup` = 0) AND (`ConditionTypeOrReference` = 29) AND (`ConditionTarget` = 1) AND (`ConditionValue1` = 1494) AND (`ConditionValue2` = 100) AND (`ConditionValue3` = 0);
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(22, 1, 2289, 1, 0, 29, 1, 1494, 100, 0, 1, 0, 0, '', 'Don\'t spawn a new Negolash if there\'s one already up.');
+
+DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 22) AND (`SourceGroup` = 2) AND (`SourceEntry` = 2289) AND (`SourceId` = 1) AND (`ElseGroup` = 0) AND (`ConditionTypeOrReference` = 30) AND (`ConditionTarget` = 1) AND (`ConditionValue1` = 2332) AND (`ConditionValue2` = 20) AND (`ConditionValue3` = 0);
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(22, 2, 2289, 1, 0, 30, 1, 2332, 20, 0, 1, 0, 0, '', 'Don\'t summon gameobjects in Enticing Negolash if there are already objects nearby');

--- a/data/sql/updates/pending_db_world/rev_1786220066682267000.sql
+++ b/data/sql/updates/pending_db_world/rev_1786220066682267000.sql
@@ -1,17 +1,31 @@
 --
 -- Quest 619 "Enticing Negolash": Negolash (1494) should not attack the summoner.
--- He spawns in the sea, yells once and slowly walks towards the Ruined Lifeboat (GO 2289).
--- Spawn position from vmangos quest_end_scripts (sql/migrations/20211001113141_world.sql).
+-- He spawns in the sea, yells once and slowly walks a sniffed path towards the Ruined Lifeboat (GO 2289),
+-- then faces the closest player and yells again.
+-- Spawn position and waypoints from sniff, spawn position matches vmangos quest_end_scripts.
 DELETE FROM `smart_scripts` WHERE `entryorguid` = 2289 AND `source_type` = 1;
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
-(2289, 1, 0, 0, 20, 0, 100, 0, 619, 0, 0, 0, 0, 0, 12, 1494, 4, 300000, 0, 0, 0, 8, 0, 0, 0, 0, -14598.6, 76.0563, -11.249, 0.925025, 'Ruined Lifeboat - On Quest ''Enticing Negolash'' Rewarded - Summon Negolash'),
+(2289, 1, 0, 0, 20, 0, 100, 0, 619, 0, 0, 0, 0, 0, 12, 1494, 4, 300000, 0, 0, 0, 8, 0, 0, 0, 0, -14598.613, 76.05631, -11.248953, 0.925025, 'Ruined Lifeboat - On Quest ''Enticing Negolash'' Rewarded - Summon Negolash'),
 (2289, 1, 1, 0, 20, 0, 100, 0, 619, 0, 0, 0, 0, 0, 241, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Ruined Lifeboat - On Quest ''Enticing Negolash'' Rewarded - Summon Gameobject Group 0');
 
--- Negolash: yell once on summon (was: on out of combat, which fired again after evading), then walk to the boat
+-- Negolash: yell once on summon, then walk waypoint path 14941 to the boat
 DELETE FROM `smart_scripts` WHERE `entryorguid` = 1494 AND `source_type` = 0;
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
-(1494, 0, 0, 1, 54, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Negolash - On Just Summoned - Say Line 0'),
-(1494, 0, 1, 2, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 59, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Negolash - On Link - Set Walk'),
-(1494, 0, 2, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 69, 1, 0, 0, 5, 0, 0, 20, 2289, 100, 0, 0, 0, 0, 0, 0, 'Negolash - On Link - Move To Closest Gameobject ''Ruined Lifeboat'''),
-(1494, 0, 3, 0, 4, 0, 100, 0, 0, 0, 0, 0, 0, 0, 59, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Negolash - On Aggro - Set Run'),
-(1494, 0, 4, 0, 34, 0, 100, 0, 8, 1, 0, 0, 0, 0, 101, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Negolash - On Movement Inform - Set Home Position');
+(1494, 0, 0, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Negolash - On Just Summoned - Say Line 0'),
+(1494, 0, 1, 0, 54, 0, 100, 0, 0, 0, 0, 0, 0, 0, 232, 14941, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Negolash - On Just Summoned - Start Waypoint Path 14941'),
+(1494, 0, 2, 3, 109, 0, 100, 0, 0, 14941, 0, 0, 0, 0, 66, 0, 0, 0, 0, 0, 0, 21, 50, 0, 0, 0, 0, 0, 0, 0, 'Negolash - On Waypoint Path 14941 Ended - Set Orientation Closest Player'),
+(1494, 0, 3, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Negolash - On Link - Say Line 1');
+
+-- Sniffed path from the sea to the Ruined Lifeboat, walking
+DELETE FROM `waypoint_data` WHERE `id` = 14941;
+INSERT INTO `waypoint_data` (`id`, `point`, `position_x`, `position_y`, `position_z`, `orientation`, `velocity`, `delay`, `smoothTransition`, `move_type`, `action`, `action_chance`, `wpguid`) VALUES
+(14941, 1, -14604.297, 89.271706, -9.999119, NULL, 0, 0, 0, 0, 0, 100, 0),
+(14941, 2, -14614.698, 108.31858, -8.333432, NULL, 0, 0, 0, 0, 0, 100, 0),
+(14941, 3, -14626.871, 127.859375, -4.644101, NULL, 0, 0, 0, 0, 0, 100, 0),
+(14941, 4, -14647.208, 142.4898, 0.73462296, NULL, 0, 0, 0, 0, 0, 100, 0);
+
+-- Second yell when he reaches the food (BroadcastTextId 763)
+DELETE FROM `creature_text` WHERE `CreatureID` = 1494;
+INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `TextRange`, `comment`) VALUES
+(1494, 0, 0, 'Mmmh...I SMELL FOOD!', 14, 0, 100, 0, 0, 0, 731, 0, 'Negolash - On Just Summoned'),
+(1494, 1, 0, 'AH, A FEAST!  WHO LEFT THIS HERE...?', 14, 0, 100, 0, 0, 0, 763, 0, 'Negolash - On Waypoint Path Ended');

--- a/data/sql/updates/pending_db_world/rev_1786220066682267000.sql
+++ b/data/sql/updates/pending_db_world/rev_1786220066682267000.sql
@@ -12,4 +12,6 @@ DELETE FROM `smart_scripts` WHERE `entryorguid` = 1494 AND `source_type` = 0;
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
 (1494, 0, 0, 1, 54, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Negolash - On Just Summoned - Say Line 0'),
 (1494, 0, 1, 2, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 59, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Negolash - On Link - Set Walk'),
-(1494, 0, 2, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 69, 1, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, -14648.5, 147.0, 2.0, 3.14159, 'Negolash - On Link - Move To Ruined Lifeboat');
+(1494, 0, 2, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 69, 1, 0, 0, 5, 0, 0, 20, 2289, 100, 0, 0, 0, 0, 0, 0, 'Negolash - On Link - Move To Closest Gameobject ''Ruined Lifeboat'''),
+(1494, 0, 3, 0, 4, 0, 100, 0, 0, 0, 0, 0, 0, 0, 59, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Negolash - On Aggro - Set Run'),
+(1494, 0, 4, 0, 34, 0, 100, 0, 8, 1, 0, 0, 0, 0, 101, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Negolash - On Movement Inform - Set Home Position');

--- a/data/sql/updates/pending_db_world/rev_1786220066682267000.sql
+++ b/data/sql/updates/pending_db_world/rev_1786220066682267000.sql
@@ -4,7 +4,7 @@
 -- Spawn position from vmangos quest_end_scripts (sql/migrations/20211001113141_world.sql).
 DELETE FROM `smart_scripts` WHERE `entryorguid` = 2289 AND `source_type` = 1;
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
-(2289, 1, 0, 0, 20, 0, 100, 0, 619, 0, 0, 0, 0, 0, 12, 1494, 1, 300000, 0, 0, 0, 8, 0, 0, 0, 0, -14598.6, 76.0563, -11.249, 0.925025, 'Ruined Lifeboat - On Quest ''Enticing Negolash'' Rewarded - Summon Negolash'),
+(2289, 1, 0, 0, 20, 0, 100, 0, 619, 0, 0, 0, 0, 0, 12, 1494, 4, 300000, 0, 0, 0, 8, 0, 0, 0, 0, -14598.6, 76.0563, -11.249, 0.925025, 'Ruined Lifeboat - On Quest ''Enticing Negolash'' Rewarded - Summon Negolash'),
 (2289, 1, 1, 0, 20, 0, 100, 0, 619, 0, 0, 0, 0, 0, 241, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Ruined Lifeboat - On Quest ''Enticing Negolash'' Rewarded - Summon Gameobject Group 0');
 
 -- Negolash: yell once on summon (was: on out of combat, which fired again after evading), then walk to the boat

--- a/data/sql/updates/pending_db_world/rev_1786220066682267000.sql
+++ b/data/sql/updates/pending_db_world/rev_1786220066682267000.sql
@@ -1,0 +1,15 @@
+--
+-- Quest 619 "Enticing Negolash": Negolash (1494) should not attack the summoner.
+-- He spawns in the sea, yells once and slowly walks towards the Ruined Lifeboat (GO 2289).
+-- Spawn position from vmangos quest_end_scripts (sql/migrations/20211001113141_world.sql).
+DELETE FROM `smart_scripts` WHERE `entryorguid` = 2289 AND `source_type` = 1;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(2289, 1, 0, 0, 20, 0, 100, 0, 619, 0, 0, 0, 0, 0, 12, 1494, 1, 300000, 0, 0, 0, 8, 0, 0, 0, 0, -14598.6, 76.0563, -11.249, 0.925025, 'Ruined Lifeboat - On Quest ''Enticing Negolash'' Rewarded - Summon Negolash'),
+(2289, 1, 1, 0, 20, 0, 100, 0, 619, 0, 0, 0, 0, 0, 241, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Ruined Lifeboat - On Quest ''Enticing Negolash'' Rewarded - Summon Gameobject Group 0');
+
+-- Negolash: yell once on summon (was: on out of combat, which fired again after evading), then walk to the boat
+DELETE FROM `smart_scripts` WHERE `entryorguid` = 1494 AND `source_type` = 0;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(1494, 0, 0, 1, 54, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Negolash - On Just Summoned - Say Line 0'),
+(1494, 0, 1, 2, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 59, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Negolash - On Link - Set Walk'),
+(1494, 0, 2, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 69, 1, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, -14648.5, 147.0, 2.0, 3.14159, 'Negolash - On Link - Move To Ruined Lifeboat');


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
- [ ] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [x] Database (SAI, creatures, etc).

Turning in quest 619 "Enticing Negolash" at the Ruined Lifeboat (GO 2289) summoned Negolash (1494) with `attackInvoker` set, so he immediately charged the player instead of coming for the food placed in the boat. His "Mmmh...I SMELL FOOD!" yell was attached to an Out of Combat event, which fired again every time he dropped combat (double yell on evade) and never at the moment he was summoned, even though the `creature_text` comment says "Negolash Yell on Summon".

Changes:
- Summon Negolash without attacking the invoker, at his sniffed spawn position in deep water (-14598.613, 76.05631, -11.248953), so he rises out of the sea like in the reference video. The previous AC/TC position was at the waterline, making him appear on the beach.
- Replace his Out of Combat yell with an On Just Summoned chain: yell once, then walk his sniffed waypoint path 14941 to the boat. The path system handles walk speed, evade resume and home position automatically.
- When the path ends he faces the closest player and yells his second, previously unused text "AH, A FEAST!  WHO LEFT THIS HERE...?" (BroadcastTextId 763).
- Summon type 4 (timed despawn out of combat) so his 5 minute timer cannot despawn him mid-fight.
- Spawn position, waypoints and second text sniffed and provided by @Gultask, who also suggested the waypoint approach.

### AI-assisted Pull Requests

- [x] AI tools (e.g. ChatGPT, Claude, or similar) were used entirely or partially in preparing this pull request. Claude Code was used.

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/27049

## SOURCE:
The changes have been validated through:
- Sniffed spawn position, waypoints and text provided by @Gultask in the PR discussion
- vmangos summon position (matches the sniff): https://github.com/vmangos/core/blob/master/sql/migrations/20211001113141_world.sql
- Reference video: https://www.youtube.com/watch?v=ZvIIyU9i6AE&t=197s
- https://www.wowhead.com/wotlk/quest=8554/facing-negolash

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.

Verified: Negolash spawns in the sea southeast of the boat, yells once, walks his waypoint path to the lifeboat without attacking the summoner, resumes the path after combat drops, faces the closest player and yells "AH, A FEAST!  WHO LEFT THIS HERE...?" when he arrives, the food gameobjects spawn in the boat, and a repeated turn-in behaves the same.

## How to Test the Changes:
1. `.go gameobject id 2289`
2. `.additem 4457 10`
3. `.additem 4595 5`
4. Click the Ruined Lifeboat and turn in quest 619 "Enticing Negolash".
5. Observe Negolash rising out of the sea to the southeast, yelling "Mmmh...I SMELL FOOD!" once, then walking his path towards the boat without attacking you.
6. Aggro him mid-path and drop combat (`.combatstop`): he resumes his path.
7. When he reaches the boat he faces the closest player and yells "AH, A FEAST!  WHO LEFT THIS HERE...?".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
