### PR TITLE
fix(Scripts/Ulduar): cast Deafening Roar when Keepers are missing

### DIFF
--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
@@ -704,7 +704,8 @@ struct boss_yoggsaron_sara : public ScriptedAI
             EntryCheckPredicate pred3(NPC_THORIM_KEEPER);
             summons.DoAction(ACTION_THORIM_START_STORM, pred3);
 
-            if (me->GetMap()->Is25ManRaid() && (GetData(DATA_GET_KEEPERS_COUNT) > 0))
+            // Deafening Roar: 25 man with at least one Keeper down
+            if (me->GetMap()->Is25ManRaid() && (GetData(DATA_GET_KEEPERS_COUNT) < 4))
                 summons.DoAction(ACTION_YOGG_SARON_HARD_MODE, pred2);
 
             summons.DespawnEntry(NPC_DEATH_ORB);
@@ -1250,7 +1251,7 @@ struct boss_yoggsaron : public ScriptedAI
         }
         else if (param == ACTION_YOGG_SARON_HARD_MODE)
         {
-            events.ScheduleEvent(EVENT_YS_DEAFENING_ROAR, 50s);
+            events.ScheduleEvent(EVENT_YS_DEAFENING_ROAR, 30s);
         }
         else if (param == ACTION_YOGG_SARON_SHADOW_BEACON)
         {
@@ -1305,7 +1306,7 @@ struct boss_yoggsaron : public ScriptedAI
                 Talk(SAY_YOGG_SARON_DEAFENING_ROAR);
                 Talk(EMOTE_YOGG_SARON_DEAFENING_ROAR);
                 me->CastSpell(me, SPELL_DEAFENING_ROAR, false);
-                events.Repeat(50s);
+                events.Repeat(30s);
                 break;
             case EVENT_YS_SHADOW_BEACON:
                 events.Repeat(5s);

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
@@ -1306,7 +1306,7 @@ struct boss_yoggsaron : public ScriptedAI
                 Talk(SAY_YOGG_SARON_DEAFENING_ROAR);
                 Talk(EMOTE_YOGG_SARON_DEAFENING_ROAR);
                 me->CastSpell(me, SPELL_DEAFENING_ROAR, false);
-                events.Repeat(30s);
+                events.Repeat(1min);
                 break;
             case EVENT_YS_SHADOW_BEACON:
                 events.Repeat(5s);


### PR DESCRIPTION
## Changes Proposed:
Yogg-Saron never cast Deafening Roar in phase 3 in the situations where it belongs. The hard mode action that schedules it was gated on `Is25ManRaid() && keepers > 0`, which is inverted: with zero Keepers (Alone in the Darkness, where the roar matters most) it never fired, while with all four Keepers up it wrongly would.

- The gate is now `Is25ManRaid() && keepers < 4`, matching the period documentation ("If fighting with 3 Keepers or less...") and TrinityCore's implementation ("only on 25-man with 0-3 keepers active").
- The timers were unsourced (50s initial and repeat). A sniff of a phase 3 shows the first roar 30s after the phase 3 yell and a steady 61s period between casts, so the script now uses a 30s initial delay and a 1 minute repeat. The commonly quoted "every 30 seconds" from the strategy guide matches only the initial delay; TrinityCore's 20-25s value is marked "timer guessed" in their code.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Fable 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/27034

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [x] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Timing from a sniff containing a full phase 3 (three roars); gating from https://www.wowhead.com/wotlk/guide/raids/ulduar/yogg-saron-strategy and TrinityCore's condition (https://github.com/TrinityCore/TrinityCore/commit/0a0698b1d4d1f7a35d5eb0b26313f793a1cfa8b3, credited via --author on the gating commit).

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. In a 25-man instance with at least one Keeper not active, bring the fight to phase 3.
2. ~30s after Yogg-Saron's phase 3 yell he casts Deafening Roar (with yell and emote), then once per minute.
3. With all four Keepers active, or in 10-man, the roar never happens.

## Known Issues and TODO List:

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
