### PR TITLE
fix(Scripts/Ulduar): restore the Clash of Thunder mock fight before Thorim

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1786234021307663400.sql
+++ b/data/sql/updates/pending_db_world/rev_1786234021307663400.sql
@@ -4,3 +4,18 @@
 UPDATE `creature_template` SET `faction` = 1693 WHERE `entry` IN (32882, 33154);
 UPDATE `creature_template` SET `faction` = 1692 WHERE `entry` IN (32883, 32885, 32907, 32908, 33150, 33151, 33152, 33153);
 UPDATE `creature_template` SET `faction` = 2119 WHERE `entry` IN (32886, 33159);
+
+-- Restrict the acolyte's mock fight heals to the pack. Circle of Healing (61964) is a
+-- TARGET_UNIT_SRC_AREA_ENTRY spell (100 yd, no target cap) and heals anything in the arena
+-- without these conditions; the sniff shows it hitting exactly the six pack members.
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 13 AND `SourceEntry` IN (61964, 61965, 61967);
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(13, 1, 61964, 0, 0, 31, 0, 3, 32882, 0, 0, 0, 0, '', 'Thorim arena - Circle of Healing targets Jormungar Behemoth'),
+(13, 1, 61964, 0, 1, 31, 0, 3, 32883, 0, 0, 0, 0, '', 'Thorim arena - Circle of Healing targets Captured Mercenary Soldier'),
+(13, 1, 61964, 0, 2, 31, 0, 3, 32885, 0, 0, 0, 0, '', 'Thorim arena - Circle of Healing targets Captured Mercenary Soldier'),
+(13, 1, 61964, 0, 3, 31, 0, 3, 32886, 0, 0, 0, 0, '', 'Thorim arena - Circle of Healing targets Dark Rune Acolyte'),
+(13, 1, 61964, 0, 4, 31, 0, 3, 32907, 0, 0, 0, 0, '', 'Thorim arena - Circle of Healing targets Captured Mercenary Captain'),
+(13, 1, 61964, 0, 5, 31, 0, 3, 32908, 0, 0, 0, 0, '', 'Thorim arena - Circle of Healing targets Captured Mercenary Captain'),
+(13, 1, 61965, 0, 0, 31, 0, 3, 32882, 0, 0, 0, 0, '', 'Thorim arena - Greater Heal targets Jormungar Behemoth'),
+(13, 1, 61967, 0, 0, 31, 0, 3, 32907, 0, 0, 0, 0, '', 'Thorim arena - Renew targets Captured Mercenary Captain'),
+(13, 1, 61967, 0, 1, 31, 0, 3, 32908, 0, 0, 0, 0, '', 'Thorim arena - Renew targets Captured Mercenary Captain');

--- a/data/sql/updates/pending_db_world/rev_1786234021307663400.sql
+++ b/data/sql/updates/pending_db_world/rev_1786234021307663400.sql
@@ -1,9 +1,9 @@
 -- Thorim: Clash of Thunder factions (sniffed). The captured mercenaries (1692) and the
 -- Jormungar Behemoth (1693) are mutually hostile, driving the pre-encounter mock fight;
 -- the arena Dark Rune Acolyte (2119) is friendly to both sides so it can heal across it.
-UPDATE `creature_template` SET `faction` = 1693 WHERE `entry` IN (32882, 33154);
-UPDATE `creature_template` SET `faction` = 1692 WHERE `entry` IN (32883, 32885, 32907, 32908, 33150, 33151, 33152, 33153);
-UPDATE `creature_template` SET `faction` = 2119 WHERE `entry` IN (32886, 33159);
+UPDATE `creature_template` SET `faction` = 1693, `VerifiedBuild` = 68887 WHERE `entry` IN (32882, 33154);
+UPDATE `creature_template` SET `faction` = 1692, `VerifiedBuild` = 68887 WHERE `entry` IN (32883, 32885, 32907, 32908, 33150, 33151, 33152, 33153);
+UPDATE `creature_template` SET `faction` = 2119, `VerifiedBuild` = 68887 WHERE `entry` IN (32886, 33159);
 
 -- Restrict the acolyte's mock fight heals to the pack. Circle of Healing (61964) is a
 -- TARGET_UNIT_SRC_AREA_ENTRY spell (100 yd, no target cap) and heals anything in the arena

--- a/data/sql/updates/pending_db_world/rev_1786234021307663400.sql
+++ b/data/sql/updates/pending_db_world/rev_1786234021307663400.sql
@@ -5,9 +5,10 @@ UPDATE `creature_template` SET `faction` = 1693, `VerifiedBuild` = 68887 WHERE `
 UPDATE `creature_template` SET `faction` = 1692, `VerifiedBuild` = 68887 WHERE `entry` IN (32883, 32885, 32907, 32908, 33150, 33151, 33152, 33153);
 UPDATE `creature_template` SET `faction` = 2119, `VerifiedBuild` = 68887 WHERE `entry` IN (32886, 33159);
 
--- Restrict the acolyte's mock fight heals to the pack. Circle of Healing (61964) is a
+-- Restrict the acolyte's mock fight Circle of Healing (61964) to the pack. It is a
 -- TARGET_UNIT_SRC_AREA_ENTRY spell (100 yd, no target cap) and heals anything in the arena
 -- without these conditions; the sniff shows it hitting exactly the six pack members.
+-- Greater Heal (61965) and Renew (61967) are single-target and script-targeted instead.
 DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 13 AND `SourceEntry` IN (61964, 61965, 61967);
 INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
 (13, 1, 61964, 0, 0, 31, 0, 3, 32882, 0, 0, 0, 0, '', 'Thorim arena - Circle of Healing targets Jormungar Behemoth'),
@@ -15,7 +16,4 @@ INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry
 (13, 1, 61964, 0, 2, 31, 0, 3, 32885, 0, 0, 0, 0, '', 'Thorim arena - Circle of Healing targets Captured Mercenary Soldier'),
 (13, 1, 61964, 0, 3, 31, 0, 3, 32886, 0, 0, 0, 0, '', 'Thorim arena - Circle of Healing targets Dark Rune Acolyte'),
 (13, 1, 61964, 0, 4, 31, 0, 3, 32907, 0, 0, 0, 0, '', 'Thorim arena - Circle of Healing targets Captured Mercenary Captain'),
-(13, 1, 61964, 0, 5, 31, 0, 3, 32908, 0, 0, 0, 0, '', 'Thorim arena - Circle of Healing targets Captured Mercenary Captain'),
-(13, 1, 61965, 0, 0, 31, 0, 3, 32882, 0, 0, 0, 0, '', 'Thorim arena - Greater Heal targets Jormungar Behemoth'),
-(13, 1, 61967, 0, 0, 31, 0, 3, 32907, 0, 0, 0, 0, '', 'Thorim arena - Renew targets Captured Mercenary Captain'),
-(13, 1, 61967, 0, 1, 31, 0, 3, 32908, 0, 0, 0, 0, '', 'Thorim arena - Renew targets Captured Mercenary Captain');
+(13, 1, 61964, 0, 5, 31, 0, 3, 32908, 0, 0, 0, 0, '', 'Thorim arena - Circle of Healing targets Captured Mercenary Captain');

--- a/data/sql/updates/pending_db_world/rev_1786234021307663400.sql
+++ b/data/sql/updates/pending_db_world/rev_1786234021307663400.sql
@@ -1,0 +1,6 @@
+-- Thorim: Clash of Thunder factions (sniffed). The captured mercenaries (1692) and the
+-- Jormungar Behemoth (1693) are mutually hostile, driving the pre-encounter mock fight;
+-- the arena Dark Rune Acolyte (2119) is friendly to both sides so it can heal across it.
+UPDATE `creature_template` SET `faction` = 1693 WHERE `entry` IN (32882, 33154);
+UPDATE `creature_template` SET `faction` = 1692 WHERE `entry` IN (32883, 32885, 32907, 32908, 33150, 33151, 33152, 33153);
+UPDATE `creature_template` SET `faction` = 2119 WHERE `entry` IN (32886, 33159);

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_thorim.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_thorim.cpp
@@ -18,6 +18,7 @@
 #include "AchievementCriteriaScript.h"
 #include "CreatureScript.h"
 #include "GameObjectScript.h"
+#include "ObjectAccessor.h"
 #include "PassiveAI.h"
 #include "Player.h"
 #include "ScriptedCreature.h"
@@ -61,6 +62,10 @@ enum ThorimSpells
     SPELL_GREATER_HEAL                      = 62334,
     SPELL_HOLY_SMITE                        = 62335,
     SPELL_RENEW                             = 62333,
+    // NPC variants used while healing the arena mock fight
+    SPELL_GREATER_HEAL_RP                   = 61965,
+    SPELL_RENEW_RP                          = 61967,
+    SPELL_CIRCLE_OF_HEALING_RP              = 61964,
 
     // CAPTURED MERCENARY SOLDIER
     SPELL_BARBED_SHOT                       = 62318,
@@ -70,6 +75,8 @@ enum ThorimSpells
     // CAPTURED MERCENARY CAPTAIN
     SPELL_DEVASTATE                         = 62317,
     SPELL_HEROIC_STRIKE                     = 62444,
+    SPELL_SUNDER_ARMOR                      = 57807,
+    SPELL_THREAT                            = 34915, // serverside, keeps the behemoth glued to the captain
 
     // JORMUNGAR BEHEMOTH
     SPELL_ACID_BREATH                       = 62315,
@@ -178,6 +185,9 @@ enum ThorimEvents
     EVENT_DR_ACOLYTE_GH                     = 20,
     EVENT_DR_ACOLYTE_HS                     = 21,
     EVENT_DR_ACOLYTE_R                      = 22,
+    EVENT_DR_ACOLYTE_RP_GH                  = 23,
+    EVENT_DR_ACOLYTE_RP_RENEW               = 24,
+    EVENT_DR_ACOLYTE_RP_COH                 = 25,
 
     EVENT_CM_SOLDIER_BS                     = 30,
     EVENT_CM_SOLDIER_S                      = 31,
@@ -185,6 +195,8 @@ enum ThorimEvents
 
     EVENT_CM_CAPTAIN_D                      = 40,
     EVENT_CM_CAPTAIN_HC                     = 41,
+    EVENT_CM_CAPTAIN_SA                     = 42,
+    EVENT_CM_CAPTAIN_THREAT                 = 43,
 
     EVENT_JB_ACID_BREATH                    = 50,
     EVENT_JB_SWEEP                          = 51,
@@ -288,6 +300,7 @@ enum Misc
     ACTION_SIF_START_DOMINION   = 5,
     ACTION_SIF_TRANSFORM        = 6,
     ACTION_IRON_HONOR_DIED      = 7,
+    ACTION_ENGAGE_PLAYERS       = 8,
 
     EVENT_PHASE_START           = 1,
     EVENT_PHASE_RING            = 2,
@@ -1022,9 +1035,39 @@ struct boss_thorim_start_npcs : public ScriptedAI
             events.Reset();
             _isCaster = (me->GetEntry() == NPC_DARK_RUNE_ACOLYTE_I);
             _playerAttack = false;
-            if (me->GetEntry() != NPC_JORMUNGAR_BEHEMOT)
-                if (Creature* cr = me->FindNearestCreature(NPC_JORMUNGAR_BEHEMOT, 30.0f))
-                    AttackStart(cr);
+            StartMockBattle();
+        }
+
+        void JustReachedHome() override
+        {
+            // Reset() runs at evade start, when UNIT_STATE_EVADE still blocks Unit::Attack
+            StartMockBattle();
+        }
+
+        void StartMockBattle()
+        {
+            events.Reset();
+
+            // The acolyte is friendly to both sides and heals the fight from its spawn point
+            if (me->GetEntry() == NPC_DARK_RUNE_ACOLYTE_I)
+            {
+                me->SetReactState(REACT_PASSIVE);
+                events.ScheduleEvent(EVENT_DR_ACOLYTE_RP_GH, 5s);
+                events.ScheduleEvent(EVENT_DR_ACOLYTE_RP_RENEW, 8s);
+                events.ScheduleEvent(EVENT_DR_ACOLYTE_RP_COH, 20s);
+                return;
+            }
+
+            if (me->GetEntry() == NPC_JORMUNGAR_BEHEMOT)
+                return;
+
+            if (Creature* behemoth = me->FindNearestCreature(NPC_JORMUNGAR_BEHEMOT, 60.0f))
+            {
+                if (me->GetEntry() == NPC_CAPTURED_MERCENARY_SOLDIER_ALLY || me->GetEntry() == NPC_CAPTURED_MERCENARY_SOLDIER_HORDE)
+                    AttackStartNoMove(behemoth); // soldiers shoot from their spawn point
+                else
+                    AttackStart(behemoth);
+            }
         }
 
         void DamageTaken(Unit* who, uint32&, DamageEffectType, SpellSchoolMask) override
@@ -1040,14 +1083,29 @@ struct boss_thorim_start_npcs : public ScriptedAI
                             thorim->AI()->AttackStart(who);
                         }
                     }
-                _playerAttack = true;
-                me->GetThreatMgr().ResetAllThreat();
-                me->CallForHelp(40.0f);
-                AttackStart(who);
+
+                // The whole pack turns on the raid at once; CallForHelp cannot cross the mock fight's faction split
+                std::list<Creature*> pack;
+                me->GetCreatureListWithEntryInGrid(pack, { NPC_JORMUNGAR_BEHEMOT, NPC_CAPTURED_MERCENARY_SOLDIER_ALLY, NPC_CAPTURED_MERCENARY_SOLDIER_HORDE,
+                    NPC_CAPTURED_MERCENARY_CAPTAIN_ALLY, NPC_CAPTURED_MERCENARY_CAPTAIN_HORDE, NPC_DARK_RUNE_ACOLYTE_I }, 100.0f);
+                for (Creature* member : pack)
+                    member->AI()->SetGUID(who->GetGUID(), ACTION_ENGAGE_PLAYERS);
             }
 
             if (!_playerAttack && me->HealthBelowPct(60))
                 me->SetHealth(me->GetMaxHealth());
+        }
+
+        void SetGUID(ObjectGuid const& guid, int32 id) override
+        {
+            if (id != ACTION_ENGAGE_PLAYERS || _playerAttack)
+                return;
+
+            _playerAttack = true;
+            me->SetReactState(REACT_AGGRESSIVE);
+            me->GetThreatMgr().ClearAllThreat();
+            if (Unit* attacker = ObjectAccessor::GetUnit(*me, guid))
+                AttackStart(attacker);
         }
 
         void JustDied(Unit*) override
@@ -1061,6 +1119,8 @@ struct boss_thorim_start_npcs : public ScriptedAI
         {
             if (me->GetEntry() == NPC_DARK_RUNE_ACOLYTE_I)
             {
+                // Entering real combat ends the mock fight heal rotation
+                events.Reset();
                 events.ScheduleEvent(EVENT_DR_ACOLYTE_GH, 10s);
                 events.ScheduleEvent(EVENT_DR_ACOLYTE_HS, 5s);
                 events.ScheduleEvent(EVENT_DR_ACOLYTE_R, 7s);
@@ -1075,6 +1135,8 @@ struct boss_thorim_start_npcs : public ScriptedAI
             {
                 events.ScheduleEvent(EVENT_CM_CAPTAIN_D, 9s);
                 events.ScheduleEvent(EVENT_CM_CAPTAIN_HC, 5s);
+                events.ScheduleEvent(EVENT_CM_CAPTAIN_SA, 8s);
+                events.ScheduleEvent(EVENT_CM_CAPTAIN_THREAT, 1200ms);
             }
             else if (me->GetEntry() == NPC_JORMUNGAR_BEHEMOT)
             {
@@ -1088,7 +1150,39 @@ struct boss_thorim_start_npcs : public ScriptedAI
         void UpdateAI(uint32 diff) override
         {
             if (!UpdateVictim())
+            {
+                // The acolyte tends both sides of the mock fight from outside of combat
+                if (_isCaster && !_playerAttack)
+                {
+                    events.Update(diff);
+                    if (me->HasUnitState(UNIT_STATE_CASTING))
+                        return;
+
+                    switch (events.ExecuteEvent())
+                    {
+                        case EVENT_DR_ACOLYTE_RP_GH:
+                            if (Creature* behemoth = me->FindNearestCreature(NPC_JORMUNGAR_BEHEMOT, 60.0f))
+                                me->CastSpell(behemoth, SPELL_GREATER_HEAL_RP, false);
+                            events.Repeat(23s);
+                            break;
+                        case EVENT_DR_ACOLYTE_RP_RENEW:
+                        {
+                            Creature* captain = me->FindNearestCreature(NPC_CAPTURED_MERCENARY_CAPTAIN_ALLY, 60.0f);
+                            if (!captain)
+                                captain = me->FindNearestCreature(NPC_CAPTURED_MERCENARY_CAPTAIN_HORDE, 60.0f);
+                            if (captain)
+                                me->CastSpell(captain, SPELL_RENEW_RP, false);
+                            events.Repeat(23s);
+                            break;
+                        }
+                        case EVENT_DR_ACOLYTE_RP_COH:
+                            me->CastSpell(me, SPELL_CIRCLE_OF_HEALING_RP, false);
+                            events.Repeat(23s);
+                            break;
+                    }
+                }
                 return;
+            }
 
             events.Update(diff);
             if (me->HasUnitState(UNIT_STATE_CASTING))
@@ -1117,7 +1211,7 @@ struct boss_thorim_start_npcs : public ScriptedAI
                     break;
                 case EVENT_CM_SOLDIER_BS:
                     me->CastSpell(me->GetVictim(), SPELL_BARBED_SHOT, false);
-                    events.Repeat(9s);
+                    events.Repeat(12s);
                     break;
                 case EVENT_CM_SOLDIER_WC:
                     me->CastSpell(me->GetVictim(), SPELL_WING_CLIP, false);
@@ -1127,7 +1221,7 @@ struct boss_thorim_start_npcs : public ScriptedAI
                     if (me->GetDistance(me->GetVictim()) > 8)
                         me->CastSpell(me->GetVictim(), SPELL_SHOOT, false);
 
-                    events.Repeat(1500ms);
+                    events.Repeat(3700ms);
                     break;
                 case EVENT_CM_CAPTAIN_D:
                     me->CastSpell(me->GetVictim(), SPELL_DEVASTATE, false);
@@ -1135,7 +1229,18 @@ struct boss_thorim_start_npcs : public ScriptedAI
                     break;
                 case EVENT_CM_CAPTAIN_HC:
                     me->CastSpell(me->GetVictim(), SPELL_HEROIC_STRIKE, false);
-                    events.Repeat(5s);
+                    events.Repeat(12s);
+                    break;
+                case EVENT_CM_CAPTAIN_SA:
+                    me->CastSpell(me->GetVictim(), SPELL_SUNDER_ARMOR, false);
+                    events.Repeat(12s);
+                    break;
+                case EVENT_CM_CAPTAIN_THREAT:
+                    if (!_playerAttack)
+                    {
+                        me->CastSpell(me->GetVictim(), SPELL_THREAT, true);
+                        events.Repeat(1200ms);
+                    }
                     break;
                 case EVENT_JB_ACID_BREATH:
                     me->CastSpell(me->GetVictim(), SPELL_ACID_BREATH, false);
@@ -1143,7 +1248,7 @@ struct boss_thorim_start_npcs : public ScriptedAI
                     break;
                 case EVENT_JB_SWEEP:
                     me->CastSpell(me->GetVictim(), SPELL_SWEEP, false);
-                    events.Repeat(5s);
+                    events.Repeat(15s);
                     break;
             }
 

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_thorim.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_thorim.cpp
@@ -356,7 +356,7 @@ struct boss_thorim : public BossAI
     void SpawnAllNPCs()
     {
         // Jormungar Behemoth 32882
-        me->SummonCreature(NPC_JORMUNGAR_BEHEMOT, 2149.68f, -263.477f, 419.679f, 3.12102f, TEMPSUMMON_CORPSE_TIMED_DESPAWN, 5000);
+        me->SummonCreature(NPC_JORMUNGAR_BEHEMOT, 2146.611f, -266.653f, 419.8175f, 2.70526f, TEMPSUMMON_CORPSE_TIMED_DESPAWN, 5000);
 
         // Captured Mercenary Soldier 32885
         me->SummonCreature(_isAlly ? NPC_CAPTURED_MERCENARY_SOLDIER_ALLY : NPC_CAPTURED_MERCENARY_SOLDIER_HORDE, 2127.24f, -251.309f, 419.793f, 5.89921f, TEMPSUMMON_CORPSE_TIMED_DESPAWN, 5000);

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_thorim.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_thorim.cpp
@@ -1277,7 +1277,7 @@ struct boss_thorim_gauntlet_npcs : public ScriptedAI
                 events.ScheduleEvent(EVENT_IR_GUARD_IMPALE, 12s);
                 events.ScheduleEvent(EVENT_IR_GUARD_WHIRL, 5s);
             }
-            else if (me->GetEntry() == NPC_DARK_RUNE_ACOLYTE_I)
+            else if (me->GetEntry() == NPC_DARK_RUNE_ACOLYTE_G)
             {
                 events.ScheduleEvent(EVENT_DR_ACOLYTE_GH, 10s);
                 events.ScheduleEvent(EVENT_DR_ACOLYTE_HS, 5s);


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

The mercenary pack in Thorim's arena (the Clash of Thunder) never fights the Jormungar Behemoth. Both sides sit in generic monster factions (14/16) that are friendly to each other, so the scripted `AttackStart` is rejected by `CombatManager::CanBeginCombat` and the pack just idles.

Changes, all based on a fresh sniff of the encounter:
- `creature_template.faction`: mercenaries 1692, behemoth 1693, arena Dark Rune Acolyte 2119, including the 25-man difficulty entries. 1692 and 1693 list each other as enemies in FactionTemplate.dbc, which is what actually drives the fight; 2119 is friendly to both sides and hostile to players.
- The acolyte no longer joins the brawl. It heals it from the sidelines while out of combat, on the sniffed rotation: Greater Heal (61965) always on the behemoth, Renew (61967) always on the captain, Circle of Healing (61964), full cycle every ~23s.
- Circle of Healing 61964 is a `TARGET_UNIT_SRC_AREA_ENTRY` spell (100 yd, no target cap) and needs `conditions` rows; without them it heals anything in range, players included. Added the implicit-target conditions restricting it to the pack, mirroring the sniffed hit pattern. The two single-target heals are targeted by the script and support no such conditions.
- Soldiers hold their spawn spot and shoot the behemoth from range instead of chasing into melee.
- The captain keeps the behemoth pinned with the serverside Threat spell (34915, present in `spell_dbc`; the sniff shows it every 1.2s) and gains Sunder Armor (57807).
- On the first player hit the whole pack converts to the raid at once, matching the instantaneous conversion in the sniff. `CallForHelp` cannot do this anymore since it does not cross the new faction split.
- The mock fight restarts after a wipe. `Reset()` runs at evade start while `UNIT_STATE_EVADE` still blocks `Unit::Attack`, so the restart is issued from `JustReachedHome()`.
- Ability timers aligned to the sniffed cadence (Acid Breath ~12s, Sweep ~15s, Heroic Strike, Sunder Armor and Barbed Shot ~12s, Shoot ~3.7s).
- Behemoth spawn position and orientation corrected from the sniff. The other five spawn points already matched it to the fifth decimal.
- `VerifiedBuild` stamped on the touched `creature_template` rows.
- The gauntlet Dark Rune Acolytes (33110) never cast their heals or Holy Smite (and never even melee): the gauntlet AI scheduled their events behind a check for the arena acolyte's entry (32886), which never runs that AI. Spotted while working on the arena pack.

Damage in the mock fight is real. The pre-existing heal-to-full keep-alive (below 60% while not fighting players) is kept, since the `creature_sparring` table is spawn-GUID based and cannot apply to script summons.

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Fable 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #15403

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [x] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

The faction values and spell IDs independently match TrinityCore's data for these NPCs; the script logic is original and sniff-driven.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Builds clean on Windows (MSVC, Release). Tested in-game: the pack spars on arrival, the acolyte heals only the pack, the whole pack (behemoth included) turns on the raid on the first hit, Thorim engages, and the fight resumes after a reset.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Enter Ulduar (10 or 25) and ride to Thorim's arena.
2. Observe the pack: the captain melees the behemoth, the three soldiers shoot it from their spawn spots, the acolyte heals the behemoth and captain, nobody dies, and no player, pet or trigger ever receives its heals.
3. Attack any pack member: the entire pack turns on the players at once and Thorim engages.
4. Wipe or leave: the pack resets and the mock fight resumes.

## Known Issues and TODO List:

- [ ]
- [ ]

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
