### PR TITLE
fix(Scripts/Ulduar): summon Sif during Thorim's intro instead of pre-spawning her

### DIFF
--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_thorim.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_thorim.cpp
@@ -207,7 +207,7 @@ enum ThorimEvents
     EVENT_IH_GUARD_HAMSTRING                = 91,
     EVENT_IH_GUARD_SHIELD_SMASH             = 92,
 
-    EVENT_SIF_START_TALK                    = 100,
+    EVENT_THORIM_SUMMON_SIF                 = 100,
     EVENT_SIF_JOIN_TALK                     = 101,
     EVENT_SIF_FINISH_DOMINION               = 102,
     EVENT_SIF_FROSTBOLT_VALLEY              = 103,
@@ -284,7 +284,6 @@ enum Misc
     ACTION_START_TRASH_DIED     = 1,
     ACTION_ALLOW_HIT            = 2,
     ACTION_SIF_JOIN_FIGHT       = 3,
-    ACTION_SIF_START_TALK       = 4,
     ACTION_SIF_START_DOMINION   = 5,
     ACTION_SIF_TRANSFORM        = 6,
     ACTION_IRON_HONOR_DIED      = 7,
@@ -376,9 +375,6 @@ struct boss_thorim : public BossAI
 
         // Ancient Rune Giant 32873
         me->SummonCreature(NPC_ANCIENT_RUNE_GIANT, 2134.57f, -440.318f, 438.331f, 0.226893f);
-
-        // Sif 33196
-        me->SummonCreature(NPC_SIF, 2147.86f, -301.2f, 438.246f, 2.488f);
     }
 
     void CloseDoors()
@@ -643,13 +639,12 @@ struct boss_thorim : public BossAI
 
                 break;
             case EVENT_THORIM_AGGRO2:
-                {
-                    Talk(SAY_AGGRO_2);
-
-                    EntryCheckPredicate pred(NPC_SIF);
-                    summons.DoAction(ACTION_SIF_START_TALK, pred);
-                    break;
-                }
+                Talk(SAY_AGGRO_2);
+                events.ScheduleEvent(EVENT_THORIM_SUMMON_SIF, 6500ms);
+                break;
+            case EVENT_THORIM_SUMMON_SIF:
+                me->SummonCreature(NPC_SIF, 2148.3f, -297.845f, 438.331f, 2.688f);
+                break;
             case EVENT_THORIM_START_PHASE1:
                 {
                     events.ScheduleEvent(EVENT_THORIM_STORMHAMMER, 8s, 0, EVENT_PHASE_START);
@@ -793,11 +788,14 @@ struct boss_thorim_sif : public ScriptedAI
             _allowCast = false;
         }
 
+        void IsSummonedBy(WorldObject* /*summoner*/) override
+        {
+            Talk(SAY_SIF_AGGRO);
+        }
+
         void DoAction(int32 param) override
         {
-            if (param == ACTION_SIF_START_TALK)
-                events.ScheduleEvent(EVENT_SIF_START_TALK, 9s);
-            else if (param == ACTION_SIF_START_DOMINION)
+            if (param == ACTION_SIF_START_DOMINION)
             {
                 if (me->GetInstanceScript())
                     if (Creature* cr = me->GetInstanceScript()->GetCreature(BOSS_THORIM))
@@ -809,7 +807,6 @@ struct boss_thorim_sif : public ScriptedAI
             {
                 me->InterruptNonMeleeSpells(false);
                 events.ScheduleEvent(EVENT_SIF_JOIN_TALK, 9s);
-                events.CancelEvent(EVENT_SIF_START_TALK);
                 events.CancelEvent(EVENT_SIF_FINISH_DOMINION);
             }
             else if (param == ACTION_SIF_TRANSFORM)
@@ -832,9 +829,6 @@ struct boss_thorim_sif : public ScriptedAI
                 case EVENT_SIF_FINISH_DOMINION:
                     Talk(SAY_SIF_HM_MISSED);
                     me->DespawnOrUnsummon(5s);
-                    break;
-                case EVENT_SIF_START_TALK:
-                    Talk(SAY_SIF_AGGRO);
                     break;
                 case EVENT_SIF_JOIN_TALK:
                     Talk(SAY_SIF_HM_REACHED);


### PR DESCRIPTION
## Changes Proposed:
Sif was summoned together with the rest of the Thorim event NPCs on reset, so she was standing on the balcony next to Thorim before the encounter even started. A sniff shows she only spawns mid-intro, 15.5s after Thorim's first aggro yell, right between his second yell and her own first line, and yells immediately on spawn.

This PR:
- Removes Sif from the reset-time spawns and summons her from the intro event chain instead, at the sniffed timing (6.5s after Thorim's second yell).
- Uses the sniffed spawn position (matches TrinityCore's).
- Makes her yell her intro line on spawn (the sniff shows the yell 200ms after her spawn packet). Previously the yell fired at aggro +18s, now at +15.5s vs the sniffed +15.7s.

The Touch of Dominion channel is unaffected, she is summoned well before it starts.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes 

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [x] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:
- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Enter Ulduar and go to Thorim. Before engaging, check the balcony: Sif must not be there.
2. Kill the mock-fight pack to start the event. After Thorim's second yell ("I remember you..."), Sif should appear next to him and immediately yell her intro line.
3. A few seconds later, when the arena waves start, she should begin channeling Touch of Dominion on Thorim.
4. Let the hard mode timer run out: she should yell and despawn as before. On a wipe, the intro (including her summon) should replay on the next attempt.

## Known Issues and TODO List:

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
