### PR TITLE
fix(Core/Loot): tied loot rolls no longer always go to the oldest character

### DIFF
--- a/src/server/game/Groups/Group.cpp
+++ b/src/server/game/Groups/Group.cpp
@@ -1603,6 +1603,7 @@ void Group::CountTheRoll(Rolls::iterator rollI)
         if (!roll->playerVote.empty())
         {
             uint8 maxresul = 0;
+            uint32 tiedRolls = 0;
             ObjectGuid maxguid; // pussywizard: start with 0 >_>
             Player* player = nullptr;
 
@@ -1624,6 +1625,19 @@ void Group::CountTheRoll(Rolls::iterator rollI)
                 {
                     maxguid  = itr->first;
                     maxresul = randomN;
+                    tiedRolls = 1;
+                }
+                else if (maxresul == randomN)
+                {
+                    // A tie is settled by a second, invisible roll among the tied players;
+                    // the visible one they were sent above stays as it is. Picking the
+                    // holder with a 1-in-n chance as ties come in gives each of them the
+                    // same odds without having to collect them first. Without this the
+                    // strict comparison kept whoever came first, and playerVote is ordered
+                    // by guid, so the oldest character won every tie.
+                    ++tiedRolls;
+                    if (urand(1, tiedRolls) == 1)
+                        maxguid = itr->first;
                 }
             }
 
@@ -1681,6 +1695,7 @@ void Group::CountTheRoll(Rolls::iterator rollI)
         if (!roll->playerVote.empty())
         {
             uint8 maxresul = 0;
+            uint32 tiedRolls = 0;
             ObjectGuid maxguid; // pussywizard: start with 0
             Player* player = nullptr;
             RollVote rollvote = NOT_VALID;
@@ -1705,6 +1720,19 @@ void Group::CountTheRoll(Rolls::iterator rollI)
                     maxguid  = itr->first;
                     maxresul = randomN;
                     rollvote = itr->second;
+                    tiedRolls = 1;
+                }
+                else if (maxresul == randomN)
+                {
+                    // Same invisible tie-break as the need rolls above. rollvote travels
+                    // with the winner: greed and disenchant share this list and decide
+                    // whether the item is handed over or shattered.
+                    ++tiedRolls;
+                    if (urand(1, tiedRolls) == 1)
+                    {
+                        maxguid  = itr->first;
+                        rollvote = itr->second;
+                    }
                 }
             }
 


### PR DESCRIPTION
## Changes Proposed:

Closes #26958. On a tied roll the item currently goes to whoever comes first in `playerVote`, and that list is ordered by guid, so the oldest character wins every tie.

`Group::CountTheRoll` compared with a strict `<`, so an equal roll never replaced the current holder:

```cpp
if (maxresul < randomN)
{
    maxguid  = itr->first;
    maxresul = randomN;
}
```

Ties now settle with a second roll, applied to both the need pass and the greed/disenchant one. The visible roll is untouched: each player still gets the `SendLootRoll` with the number they actually rolled, and the tie-break happens behind it, which is what the blue post linked in the issue describes.

Tied players are picked with a 1-in-n chance as the ties come in, so each of them has the same odds without collecting them into a list first. Checked over 300k simulated rolls:

```
2 tied -> 50.1%  49.9%
3 tied -> 33.4%  33.4%  33.2%
5 tied -> 20.0%  19.9%  20.1%  20.0%  20.0%
```

In the greed pass `rollvote` travels with the winner, since greed and disenchant share that list and it decides whether the item is handed over or shattered.

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request.
   - Tools/models used: Claude Code (Opus 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #26958

## SOURCE:
- [ ] Live research
- [ ] Sniffs
- [x] Video evidence, knowledge databases or other public sources

Blizzard blue post quoted in the issue: "In the event of a tied roll, another internal (invisible) roll occurs. The highest roller for that second roll will receive the item."

## Tests Performed:
- [ ] Tested in-game by the author.
- [x] This pull request requires further testing and may have edge cases to be tested.

Not tested in game yet: reproducing a tie needs two accounts rolling need on the same item until two 1-100 rolls land on the same number, so it is slow to hit by hand. The distribution was checked by simulation instead, shown above. Putting it up so others can test it.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

Two accounts in a group on group loot, `.gobject add 194821`, both roll Need on the same item and repeat until the two rolls tie. Before this change the lower guid, checked with `.pinfo`, won every single tie. After it, either can win. Both players should still see the same tied number on screen: the second roll is not sent to the client.

## Known Issues and TODO List:

Only the tie is addressed. Nothing else about roll ordering or loot distribution changes.