### PR TITLE
fix(Core/Spells): fix crash on non-unit targets in area target check

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -9161,8 +9161,10 @@ namespace Acore
                   || _referenceType == TARGET_REFERENCE_TYPE_TARGET)
             {
                 float effectiveRange = _range;
-                if (_caster->IsControlledByPlayer() && !target->ToUnit()->IsControlledByPlayer())
-                    effectiveRange += target->GetCombatReach();
+                // searcher also visits non-unit objects (corpses, dynobjects) when the spell can target them
+                if (Unit const* unitTarget = target->ToUnit())
+                    if (_caster->IsControlledByPlayer() && !unitTarget->IsControlledByPlayer())
+                        effectiveRange += unitTarget->GetCombatReach();
 
                 if (target->GetExactDist(_position) > effectiveRange)
                     return false;


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Fixes a worldserver crash introduced by https://github.com/azerothcore/azerothcore-wotlk/pull/26967.

`WorldObjectSpellAreaTargetCheck::operator()` dereferences `target->ToUnit()` unconditionally:

```cpp
if (_caster->IsControlledByPlayer() && !target->ToUnit()->IsControlledByPlayer())
    effectiveRange += target->GetCombatReach();
```

The searcher is a `WorldObjectListSearcher` and also visits corpses and dynamic objects when the spell's searcher mask includes them. For a `Corpse`, `ToUnit()` returns `nullptr` and the map thread segfaults. First seen in production with Death Knight Raise Dead, whose corpse search (`spell_dk_raise_dead::CheckCast`) includes the corpse grid container, so any player corpse within range crashes the server:

```
#0  Acore::WorldObjectSpellAreaTargetCheck::operator() at Spell.cpp:9164
#1  Acore::WorldObjectListSearcher<...>::Visit
#2  VisitorHelper<Acore::WorldObjectListSearcher<...>, Corpse>
...
#18 spell_dk_raise_dead::CheckCast
```

The cmangos original this was ported from (https://github.com/cmangos/mangos-wotlk/commit/faac94f) runs inside a notifier that only iterates units, so it never needed a null check. AzerothCore's check receives any `WorldObject`, so the combat reach padding is now guarded with `ToUnit()`. Non-unit objects fall through to the plain center distance check, matching their behavior before the regression. Unit targets are unaffected.

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Fable 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Regression from https://github.com/azerothcore/azerothcore-wotlk/pull/26967, no issue filed

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Production crash backtrace (gdb) pointing at the unguarded dereference.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Kill a player character so a player corpse is left on the ground.
2. On a Death Knight, stand within 30 yards of that corpse and cast Raise Dead.
3. Without this fix the worldserver crashes in `WorldObjectSpellAreaTargetCheck`; with it the cast works normally.
4. Regression check: AoE spells (player and creature cast) still hit targets at the expected radius, since this code path runs for all src/dest/target referenced area spells.

## Known Issues and TODO List:

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
