### PR TITLE
fix(Scripts/Ulduar): remove Freya's Attuned to Nature stacks via dose reduction spells

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1786274172677884600.sql
+++ b/data/sql/updates/pending_db_world/rev_1786274172677884600.sql
@@ -1,0 +1,6 @@
+--
+DELETE FROM `spell_script_names` WHERE `spell_id` IN (62521, 62524, 62525);
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(62521, 'spell_freya_attuned_to_nature_dose_reduction'),
+(62524, 'spell_freya_attuned_to_nature_dose_reduction'),
+(62525, 'spell_freya_attuned_to_nature_dose_reduction');

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_freya.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_freya.cpp
@@ -36,6 +36,9 @@ enum FreyaSpells
     // FREYA
     SPELL_TOUCH_OF_EONAR                        = 62528,
     SPELL_ATTUNED_TO_NATURE                     = 62519,
+    SPELL_ATTUNED_TO_NATURE_2_DOSE              = 62524,
+    SPELL_ATTUNED_TO_NATURE_10_DOSE             = 62525,
+    SPELL_ATTUNED_TO_NATURE_25_DOSE             = 62521,
     SPELL_SUMMON_LIFEBINDER                     = 62870,
     SPELL_SUMMON_WAVE_1                         = 62685, // Summon Ancient Conservator
     SPELL_SUMMON_WAVE_3                         = 62686, // Summon Trio (Water Spirit, Storm Lasher, Snaplasher)
@@ -200,6 +203,7 @@ enum Misc
     ACTION_REMOVE_25_STACK                      = 25,
     ACTION_REMOVE_2_STACK                       = 2,
     ACTION_RESPAWN_TRIO                         = 1,
+    ACTION_ATTUNED_TO_NATURE_REMOVED            = 3,
     ACTION_LUMBERJACKED                         = -1,
     ACTION_ADD_DIED                             = -2,
 
@@ -399,10 +403,17 @@ struct boss_freya : public BossAI
             if (!_respawningTrio)
             {
                 _respawningTrio = true;
-                events.ScheduleEvent(EVENT_FREYA_RESPAWN_TRIO, 10s);
+                events.ScheduleEvent(EVENT_FREYA_RESPAWN_TRIO, 12s);
             }
 
             ++_trioKilled;
+            return;
+        }
+
+        if (param == ACTION_ATTUNED_TO_NATURE_REMOVED)
+        {
+            events.ScheduleEvent(EVENT_FREYA_NATURE_BOMB, 5s);
+            events.SetPhase(EVENT_PHASE_FINAL);
             return;
         }
 
@@ -415,22 +426,10 @@ struct boss_freya : public BossAI
             // do not return
         }
 
-        if (Aura* aur = me->GetAura(SPELL_ATTUNED_TO_NATURE))
-        {
-            // Back to Nature achievement
-            if (aur->GetStackAmount() - param < 25)
-                _backToNature = false;
-
-            if (aur->GetStackAmount() > param)
-                aur->SetStackAmount(aur->GetStackAmount() - param);
-            else // Aura out of stack
-            {
-                events.ScheduleEvent(EVENT_FREYA_NATURE_BOMB, 5s);
-                events.SetPhase(EVENT_PHASE_FINAL);
-                aur->Remove();
-                return;
-            }
-        }
+        // Back to Nature achievement - the dose reduction spell has already updated the aura
+        Aura* aur = me->GetAura(SPELL_ATTUNED_TO_NATURE);
+        if (!aur || aur->GetStackAmount() < 25)
+            _backToNature = false;
     }
 
     uint32 GetData(uint32 param) const override
@@ -995,13 +994,11 @@ struct boss_freya_summons : public ScriptedAI
     }
 
     EventMap events;
-    uint8 _stackCount;
     bool _hasDied;
     bool _isTrio;
 
     void Reset() override
     {
-        _stackCount = 0;
         events.Reset();
 
         // Detonating Lashers spawn submerged in the ground and stay passive for a
@@ -1037,14 +1034,37 @@ struct boss_freya_summons : public ScriptedAI
             if (Creature* freya = instance->GetCreature(BOSS_FREYA))
             {
                 if (!_hasDied)
-                    freya->AI()->DoAction(_stackCount);
+                {
+                    uint32 doseSpell = 0;
+                    int32 stackAction = 0;
+                    switch (me->GetEntry())
+                    {
+                        case NPC_ANCIENT_CONSERVATOR:
+                            doseSpell = SPELL_ATTUNED_TO_NATURE_25_DOSE;
+                            stackAction = ACTION_REMOVE_25_STACK;
+                            break;
+                        case NPC_ANCIENT_WATER_SPIRIT:
+                        case NPC_STORM_LASHER:
+                        case NPC_SNAPLASHER:
+                            doseSpell = SPELL_ATTUNED_TO_NATURE_10_DOSE;
+                            stackAction = ACTION_REMOVE_10_STACK;
+                            break;
+                        case NPC_DETONATING_LASHER:
+                            doseSpell = SPELL_ATTUNED_TO_NATURE_2_DOSE;
+                            stackAction = ACTION_REMOVE_2_STACK;
+                            break;
+                    }
+
+                    me->CastSpell(freya, doseSpell, true);
+                    freya->AI()->DoAction(stackAction);
+                }
 
                 if (_isTrio)
                 {
                     freya->AI()->DoAction(ACTION_RESPAWN_TRIO);
                     _hasDied = true;
                 }
-                if (!_isTrio)
+                else
                     freya->AI()->DoAction(ACTION_ADD_DIED);
             }
         }
@@ -1056,8 +1076,14 @@ struct boss_freya_summons : public ScriptedAI
     {
         if (_isTrio && param == ACTION_RESPAWN_TRIO)
         {
-            me->setDeathState(DeathState::JustRespawned);
-            Reset();
+            // Members still alive when the trio revives are only healed to full
+            if (me->isDead())
+            {
+                me->setDeathState(DeathState::JustRespawned);
+                Reset();
+            }
+            else
+                me->SetFullHealth();
         }
     }
 
@@ -1068,29 +1094,18 @@ struct boss_freya_summons : public ScriptedAI
             me->CastSpell(me, SPELL_HEALTHY_SPORE_SUMMON, true);
             events.ScheduleEvent(EVENT_ANCIENT_CONSERVATOR_GRIP, 6s);
             events.ScheduleEvent(EVENT_ANCIENT_CONSERVATOR_NATURE_FURY, 14s);
-            _stackCount = ACTION_REMOVE_25_STACK;
         }
         else if (me->GetEntry() == NPC_ANCIENT_WATER_SPIRIT)
-        {
             events.ScheduleEvent(EVENT_WATER_SPIRIT_CHARGE, 12s);
-            _stackCount = ACTION_REMOVE_10_STACK;
-        }
         else if (me->GetEntry() == NPC_STORM_LASHER)
         {
             events.ScheduleEvent(EVENT_STORM_LASHER_LIGHTNING_LASH, 10s);
             events.ScheduleEvent(EVENT_STORM_LASHER_STORMBOLT, 6s);
-            _stackCount = ACTION_REMOVE_10_STACK;
         }
         else if (me->GetEntry() == NPC_DETONATING_LASHER)
-        {
             events.ScheduleEvent(EVENT_DETONATING_LASHER_FLAME_LASH, 10s);
-            _stackCount = ACTION_REMOVE_2_STACK;
-        }
         else if (me->GetEntry() == NPC_SNAPLASHER)
-        {
             me->CastSpell(me, SPELL_HARDENED_BARK, true);
-            _stackCount = ACTION_REMOVE_10_STACK;
-        }
     }
 
     void UpdateAI(uint32 diff) override
@@ -1216,6 +1231,50 @@ private:
     uint32 const _elderCount;
 };
 
+// 62521 - Attuned to Nature 25 Dose Reduction
+// 62524 - Attuned to Nature 2 Dose Reduction
+// 62525 - Attuned to Nature 10 Dose Reduction
+class spell_freya_attuned_to_nature_dose_reduction : public SpellScript
+{
+    PrepareSpellScript(spell_freya_attuned_to_nature_dose_reduction);
+
+    void HandleScript(SpellEffIndex /*effIndex*/)
+    {
+        // The aura to reduce (Attuned to Nature) is stored in the effect value
+        uint32 auraId = GetEffectValue();
+        Unit* target = GetHitUnit();
+        Aura* aura = target->GetAura(auraId);
+        if (!aura)
+            return;
+
+        int32 doses = 0;
+        switch (GetSpellInfo()->Id)
+        {
+            case SPELL_ATTUNED_TO_NATURE_2_DOSE:
+                doses = 2;
+                break;
+            case SPELL_ATTUNED_TO_NATURE_10_DOSE:
+                doses = 10;
+                break;
+            case SPELL_ATTUNED_TO_NATURE_25_DOSE:
+                doses = 25;
+                break;
+        }
+
+        aura->ModStackAmount(-doses);
+
+        if (!target->HasAura(auraId))
+            if (Creature* freya = target->ToCreature())
+                if (freya->IsAIEnabled)
+                    freya->AI()->DoAction(ACTION_ATTUNED_TO_NATURE_REMOVED);
+    }
+
+    void Register() override
+    {
+        OnEffectHitTarget += SpellEffectFn(spell_freya_attuned_to_nature_dose_reduction::HandleScript, EFFECT_0, SPELL_EFFECT_SCRIPT_EFFECT);
+    }
+};
+
 // 62450 - Unstable Sun Beam
 class spell_freya_unstable_sun_beam : public SpellScript
 {
@@ -1245,6 +1304,7 @@ void AddSC_boss_freya()
     RegisterUlduarCreatureAI(boss_freya_summons);
     RegisterUlduarCreatureAI(boss_freya_nature_bomb);
 
+    RegisterSpellScript(spell_freya_attuned_to_nature_dose_reduction);
     RegisterSpellScript(spell_freya_unstable_sun_beam);
 
     new achievement_freya_getting_back_to_nature();

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_freya.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_freya.cpp
@@ -1240,9 +1240,12 @@ class spell_freya_attuned_to_nature_dose_reduction : public SpellScript
 
     void HandleScript(SpellEffIndex /*effIndex*/)
     {
+        Unit* target = GetHitUnit();
+        if (!target)
+            return;
+
         // The aura to reduce (Attuned to Nature) is stored in the effect value
         uint32 auraId = GetEffectValue();
-        Unit* target = GetHitUnit();
         Aura* aura = target->GetAura(auraId);
         if (!aura)
             return;
@@ -1264,9 +1267,11 @@ class spell_freya_attuned_to_nature_dose_reduction : public SpellScript
         aura->ModStackAmount(-doses);
 
         if (!target->HasAura(auraId))
-            if (Creature* freya = target->ToCreature())
-                if (freya->IsAIEnabled)
-                    freya->AI()->DoAction(ACTION_ATTUNED_TO_NATURE_REMOVED);
+        {
+            Creature* freya = target->ToCreature();
+            if (freya && freya->IsAIEnabled)
+                freya->AI()->DoAction(ACTION_ATTUNED_TO_NATURE_REMOVED);
+        }
     }
 
     void Register() override


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Fixes Freya keeping leftover Attuned to Nature (62519) stacks after the last add dies, delaying the final phase by up to a minute until the 60s adds-spam fallback force-removed the aura.

Root cause: each add's stack contribution was stored in an AI member set on `JustEngagedWith`. When a partially killed trio revived, `summons.DoAction(ACTION_RESPAWN_TRIO)` broadcast also hit trio members that were **still alive**, running `setDeathState(JustRespawned)` + `Reset()` on them and wiping that member to 0. Since they never left combat it was never set again, so their eventual death removed nothing: 10 stacks leaked per member alive at the revive tick. Intermittent because it needs a partial trio kill, matching the report.

The fix replaces the bookkeeping with what a sniff shows retail doing: every dying add casts its dose reduction spell on Freya (62524 = 2 doses per Detonating Lasher, 62525 = 10 per trio member, 62521 = 25 per Ancient Conservator), each at its own death time. A new `spell_freya_attuned_to_nature_dose_reduction` spell script removes the doses from the aura id carried in the spell's effect value. The dose spell is derived from the creature entry at death time, so there is no wipeable state left. Notably, the sniff disproves TrinityCore's model of batching the trio's 3x10 removal at the third death: the three 62525 casts were spread 6-8.5s apart in both trio kills (per-death removal).

Also in this PR:
- Trio revive now only fake-respawns dead members; still-living ones are healed to full instead (matches the "revive at full health" behavior guides describe, without corrupting their AI state).
- The final phase now starts the moment the aura reaches 0 stacks, synchronously from the spell script, instead of relying on subtraction order. The 60s fallback stays as a safety net.
- Trio revive window changed from 10s to 12s per guides and TrinityCore (the sniff contained no revive, so this part is not sniff-verified).
- Deforestation and Getting Back to Nature achievement accounting is preserved.

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Claude Fable 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/27015

## SOURCE:
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [x] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Sniff of a Freya hard-mode kill: 62524 cast x20 by Detonating Lashers, 62525 x6 by trio members (per-death, spread 6-8.5s within each trio), 62521 x2 by Ancient Conservators, all targeting Freya - exactly 2 waves of each type totaling the 150 starting stacks. The spell script shape (doses removed from the aura id in the effect value) matches TrinityCore's handler for the same spells: https://github.com/TrinityCore/TrinityCore/blob/3.3.5/src/server/scripts/Northrend/Ulduar/Ulduar/boss_freya.cpp. The issue's linked classic kill video shows stacks reaching zero exactly as the last add dies.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Builds without errors (Windows, MSVC Release). Tested in-game on Freya.

## How to Test the Changes:
- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Engage Freya and clear all 6 add waves normally: Attuned to Nature must hit 0 stacks the moment the last add dies (each death now logs a dose reduction cast on Freya), and nature bombs must start ~5s later - no leftover stacks, no delay.
2. Original repro: during a trio wave kill exactly one member, wait 12s for the revive (dead one respawns, the two living ones are healed to full), then kill all three. The wave must remove exactly 30 stacks in total across both kills of the revived member (no double removal, no leak).
3. Achievements regression: Deforestation (two trios within the window) and Getting Back to Nature still track correctly.

## Known Issues and TODO List:

- [ ] The 12s trio revive window comes from guides/TrinityCore; the sniff contained no revive, so it could not be sniff-verified.

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
