### PR TITLE
fix(Scripts/Ulduar): reconstruct Freya's hard mode intro from sniff

### DIFF
--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_freya.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_freya.cpp
@@ -61,9 +61,14 @@ enum FreyaSpells
 
     // ELDERS
     SPELL_DRAINED_OF_POWER                      = 62467,
-    SPELL_STONEBARK_ESSENCE                     = 62483,
-    SPELL_IRONBRANCH_ESSENCE                    = 62484,
-    SPELL_BRIGHTLEAF_ESSENCE                    = 62485,
+    SPELL_STONEBARK_ESSENCE_CHANNEL             = 62483,
+    SPELL_IRONBRANCH_ESSENCE_CHANNEL            = 62484,
+    SPELL_BRIGHTLEAF_ESSENCE_CHANNEL            = 62485,
+    SPELL_STONEBARK_ESSENCE                     = 62386,
+    SPELL_FULL_HEAL                             = 43978,
+    SPELL_GREEN_BANISH_STATE_LARGE              = 62720, // Stonebark
+    SPELL_WHITE_BANISH_STATE_LARGE              = 62718, // Ironbranch
+    SPELL_PURPLE_BANISH_STATE                   = 61014, // Brightleaf
 
     // BRIGHTLEAF
     SPELL_BRIGHTLEAF_FLUX                       = 62239,
@@ -245,6 +250,7 @@ struct boss_freya : public BossAI
     void Reset() override
     {
         _Reset();
+        me->SetCombatMovement(true);
 
         for (uint8 i = 0; i < 3; ++i)
         {
@@ -473,10 +479,6 @@ struct boss_freya : public BossAI
         Creature* elder = instance->GetCreature(DATA_ELDER_STONEBARK);
         if (elder && elder->IsAlive())
         {
-            elder->CastSpell(elder, SPELL_DRAINED_OF_POWER, true);
-            elder->CastSpell(elder, SPELL_STONEBARK_ESSENCE, true);
-            elder->SetInCombatWithZone();
-
             events.ScheduleEvent(EVENT_FREYA_GROUND_TREMOR, 35s);
             _elderGUID[0] = elder->GetGUID();
         }
@@ -484,10 +486,6 @@ struct boss_freya : public BossAI
         elder = instance->GetCreature(DATA_ELDER_IRONBRANCH);
         if (elder && elder->IsAlive())
         {
-            elder->CastSpell(elder, SPELL_DRAINED_OF_POWER, true);
-            elder->CastSpell(elder, SPELL_IRONBRANCH_ESSENCE, true);
-            elder->SetInCombatWithZone();
-
             events.ScheduleEvent(EVENT_FREYA_IRON_ROOT, 20s);
             _elderGUID[1] = elder->GetGUID();
         }
@@ -495,10 +493,6 @@ struct boss_freya : public BossAI
         elder = instance->GetCreature(DATA_ELDER_BRIGHTLEAF);
         if (elder && elder->IsAlive())
         {
-            elder->CastSpell(elder, SPELL_DRAINED_OF_POWER, true);
-            elder->CastSpell(elder, SPELL_BRIGHTLEAF_ESSENCE, true);
-            elder->SetInCombatWithZone();
-
             events.ScheduleEvent(EVENT_FREYA_UNSTABLE_SUN_BEAM, 1min);
             _elderGUID[2] = elder->GetGUID();
         }
@@ -506,6 +500,51 @@ struct boss_freya : public BossAI
         if (_elderGUID[0] || _elderGUID[1] || _elderGUID[2])
         {
             Talk(SAY_AGGRO_WITH_ELDER);
+
+            static constexpr uint32 essenceChannel[3] = { SPELL_STONEBARK_ESSENCE_CHANNEL,
+                SPELL_IRONBRANCH_ESSENCE_CHANNEL, SPELL_BRIGHTLEAF_ESSENCE_CHANNEL };
+            static constexpr uint32 banishState[3] = { SPELL_GREEN_BANISH_STATE_LARGE,
+                SPELL_WHITE_BANISH_STATE_LARGE, SPELL_PURPLE_BANISH_STATE };
+
+            for (uint8 i = 0; i < 3; ++i)
+            {
+                elder = ObjectAccessor::GetCreature(*me, _elderGUID[i]);
+                if (!elder)
+                    continue;
+
+                elder->CastSpell(elder, SPELL_FULL_HEAL, true);
+                elder->SetUnitFlag(UNIT_FLAG_NOT_SELECTABLE);
+                elder->SetInCombatWithZone();
+                elder->CastSpell(me, essenceChannel[i], false);
+                if (essenceChannel[i] == SPELL_STONEBARK_ESSENCE_CHANNEL)
+                    elder->CastSpell(me, SPELL_STONEBARK_ESSENCE, true);
+                elder->CastSpell(elder, banishState[i], true);
+            }
+
+            // Freya stands still while the Elders channel their essences into her.
+            // The motion stop is deferred a tick because the engaging AttackStart
+            // issues its MoveChase after JustEngagedWith returns.
+            me->SetCombatMovement(false);
+            scheduler.Schedule(1ms, [this](TaskContext /*context*/)
+            {
+                // MoveIdle replaces the default waypoint generator (path 1365540),
+                // otherwise her conservatory patrol resumes once the chase is cleared
+                me->GetMotionMaster()->Clear();
+                me->GetMotionMaster()->MoveIdle();
+                me->StopMoving();
+                if (Unit* victim = me->GetVictim())
+                    me->SetFacingToObject(victim);
+            });
+
+            scheduler.Schedule(5s, [this](TaskContext /*context*/)
+            {
+                me->SetCombatMovement(true);
+                me->ResumeChasingVictim();
+
+                for (ObjectGuid const& elderGuid : _elderGUID)
+                    if (Creature* drained = ObjectAccessor::GetCreature(*me, elderGuid))
+                        drained->CastSpell(drained, SPELL_DRAINED_OF_POWER, false);
+            });
         }
         else
         {
@@ -663,6 +702,7 @@ struct boss_freya_elder_stonebark : public ScriptedAI
     {
         events.Reset();
         _chargesCount = 0;
+        me->RemoveUnitFlag(UNIT_FLAG_NOT_SELECTABLE);
     }
 
     void KilledUnit(Unit*) override
@@ -687,12 +727,15 @@ struct boss_freya_elder_stonebark : public ScriptedAI
 
     void JustEngagedWith(Unit*) override
     {
+        // Pulled into combat silently by Freya's hard mode activation
+        if (me->HasUnitFlag(UNIT_FLAG_NOT_SELECTABLE))
+            return;
+
         events.ScheduleEvent(EVENT_STONEBARK_FISTS_OF_STONE, 40s);
         events.ScheduleEvent(EVENT_STONEBARK_GROUND_TREMOR, 5s);
         events.ScheduleEvent(EVENT_STONEBARK_PETRIFIED_BARK, 20s);
 
-        if (!me->HasAura(SPELL_DRAINED_OF_POWER)) // Prevents speech if combat is initiated by hardmode activation
-            Talk(SAY_ELDER_AGGRO);
+        Talk(SAY_ELDER_AGGRO);
     }
 
     void DamageTaken(Unit*, uint32& damage, DamageEffectType damageType, SpellSchoolMask damageSchoolMask) override
@@ -748,6 +791,7 @@ struct boss_freya_elder_brightleaf : public ScriptedAI
     {
         events.Reset();
         summons.DespawnAll();
+        me->RemoveUnitFlag(UNIT_FLAG_NOT_SELECTABLE);
     }
 
     void KilledUnit(Unit*) override
@@ -772,12 +816,15 @@ struct boss_freya_elder_brightleaf : public ScriptedAI
 
     void JustEngagedWith(Unit*) override
     {
+        // Pulled into combat silently by Freya's hard mode activation
+        if (me->HasUnitFlag(UNIT_FLAG_NOT_SELECTABLE))
+            return;
+
         events.ScheduleEvent(EVENT_BRIGHTLEAF_FLUX, 10s);
         events.ScheduleEvent(EVENT_BRIGHTLEAF_SOLAR_FLARE, 5s);
         events.ScheduleEvent(EVENT_BRIGHTLEAF_UNSTABLE_SUN_BEAM, 8s);
 
-        if (!me->HasAura(SPELL_DRAINED_OF_POWER)) // Prevents speech if combat is initiated by hardmode activation
-            Talk(SAY_ELDER_AGGRO);
+        Talk(SAY_ELDER_AGGRO);
     }
 
     void UpdateAI(uint32 diff) override
@@ -848,6 +895,7 @@ struct boss_freya_elder_ironbranch : public ScriptedAI
     void Reset() override
     {
         events.Reset();
+        me->RemoveUnitFlag(UNIT_FLAG_NOT_SELECTABLE);
     }
 
     void KilledUnit(Unit*) override
@@ -872,12 +920,15 @@ struct boss_freya_elder_ironbranch : public ScriptedAI
 
     void JustEngagedWith(Unit*) override
     {
+        // Pulled into combat silently by Freya's hard mode activation
+        if (me->HasUnitFlag(UNIT_FLAG_NOT_SELECTABLE))
+            return;
+
         events.ScheduleEvent(EVENT_IRONBRANCH_IMPALE, 10s);
         events.ScheduleEvent(EVENT_IRONBRANCH_IRON_ROOT, 15s);
         events.ScheduleEvent(EVENT_IRONBRANCH_THORN_SWARM, 3s);
 
-        if (!me->HasAura(SPELL_DRAINED_OF_POWER)) // Prevents speech if combat is initiated by hardmode activation
-            Talk(SAY_ELDER_AGGRO);
+        Talk(SAY_ELDER_AGGRO);
     }
 
     void UpdateAI(uint32 diff) override

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_freya.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_freya.cpp
@@ -514,6 +514,7 @@ struct boss_freya : public BossAI
 
                 elder->CastSpell(elder, SPELL_FULL_HEAL, true);
                 elder->SetUnitFlag(UNIT_FLAG_NOT_SELECTABLE);
+                elder->SetReactState(REACT_PASSIVE);
                 elder->SetInCombatWithZone();
                 elder->CastSpell(me, essenceChannel[i], false);
                 if (essenceChannel[i] == SPELL_STONEBARK_ESSENCE_CHANNEL)
@@ -703,6 +704,7 @@ struct boss_freya_elder_stonebark : public ScriptedAI
         events.Reset();
         _chargesCount = 0;
         me->RemoveUnitFlag(UNIT_FLAG_NOT_SELECTABLE);
+        me->SetReactState(REACT_AGGRESSIVE);
     }
 
     void KilledUnit(Unit*) override
@@ -792,6 +794,7 @@ struct boss_freya_elder_brightleaf : public ScriptedAI
         events.Reset();
         summons.DespawnAll();
         me->RemoveUnitFlag(UNIT_FLAG_NOT_SELECTABLE);
+        me->SetReactState(REACT_AGGRESSIVE);
     }
 
     void KilledUnit(Unit*) override
@@ -896,6 +899,7 @@ struct boss_freya_elder_ironbranch : public ScriptedAI
     {
         events.Reset();
         me->RemoveUnitFlag(UNIT_FLAG_NOT_SELECTABLE);
+        me->SetReactState(REACT_AGGRESSIVE);
     }
 
     void KilledUnit(Unit*) override


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Reconstructs Freya's hard mode intro (Elders alive at the pull) from a sniff. The sniffed sequence, reproduced here:

1. **Pull**: Freya casts Touch of Eonar and Attuned to Nature and yells. Each living Elder casts Full Heal (43978) on itself, becomes untargetable (`UNIT_FLAG_NOT_SELECTABLE`, flag update at pull +41ms in the sniff), enters combat silently, starts a real 5 second essence channel at Freya (62483/62484/62485, all three are 5s channeled spells in 3.3.5 DBC) and applies its banish state visual (Stonebark 62720 green, Ironbranch 62718 white, Brightleaf 61014 purple). Stonebark additionally casts Stonebark's Essence (62386, +50% physical damage) on Freya - the only essence buff visible in the sniff.
2. **Freya stands still** for those 5 seconds: her only movement packet at the pull is a facing-only spline, and her first real movement spline comes at +4.9s, exactly when the channels end. Implemented by disabling combat movement plus clearing the chase one tick after engage (the engaging `AttackStart` issues its `MoveChase` after `JustEngagedWith` returns) and parking the motion idle slot, since her default waypoint patrol (path 1365540) otherwise resumes underneath the cleared chase.
3. **Channel end (+5s)**: each Elder casts Drained of Power (62467) on itself. Its stun aura produces the `UNIT_FLAG_STUNNED` bit and root packets on its own (the sniff flag updates are timestamp-matched to the 62467 casts), so no flags are set manually for it. Freya resumes chasing at the same moment, matching the sniff.

Previously AC cast the essences and Drained of Power instantly at the pull (no channels, no untargetability, no hold) and Freya immediately ran at the raid. The Elders also played their solo-encounter aggro yells when dragged into combat this way; the sniff contains zero elder chat at the pull, so they are silenced (and their miniboss ability schedules skipped) when pulled via hard mode activation. Wipe handling: Freya's reset force-evades the Elders, which clears the auras, and their `Reset` clears the untargetable flag.

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Claude Fable 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- None

## SOURCE:
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [x] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Sniff of a hard mode Freya kill with all three Elders alive. Spell data cross-checked on Wowhead's 3.3.5 database (essence channels are Channeled/5s; Drained of Power is Apply Aura: Stun; banish states and Full Heal all exist as 3.3.5 spells).

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Builds without errors (Windows, MSVC Release). Tested in-game: hold works from any point of her patrol, Elders stay silent and untargetable, Drained lands at channel end.

## How to Test the Changes:
- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Pull Freya with all three Elders alive. She must yell, stand in place facing her target for ~5 seconds while each Elder channels a beam at her, then start attacking.
2. During those 5 seconds the Elders must be untargetable, silent (no aggro yells) and cast nothing offensive; at the end they get Drained of Power and stay stunned/untargetable.
3. With Stonebark alive, Freya's melee should hit noticeably harder (Stonebark's Essence, +50% physical damage) - this was silently missing before, so tank damage goes up in hard mode.
4. Wipe and re-pull: intro repeats cleanly; after a wipe the Elders are targetable and normal again.
5. Kill the Elders first and pull Freya: normal aggro yell, no hold, she engages immediately.
6. Pull an Elder on its own (no Freya): it must still yell and fight normally.

## Known Issues and TODO List:

- [ ] Only Stonebark's essence buff (62386) is visible in the sniff; if Ironbranch/Brightleaf have equivalent stat buffs they could not be identified from this data.
- [ ] The Elders drop their in-combat flag ~9s after the pull on retail; on AC they stay in zone combat until wipe/kill (cosmetic difference).

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
