### PR TITLE
fix(DB/Creature): add Freya's Storm Lasher spawn visuals

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1786283661882539700.sql
+++ b/data/sql/updates/pending_db_world/rev_1786283661882539700.sql
@@ -1,0 +1,5 @@
+--
+DELETE FROM `creature_template_addon` WHERE (`entry` IN (32919, 33401));
+INSERT INTO `creature_template_addon` (`entry`, `path_id`, `mount`, `bytes1`, `bytes2`, `emote`, `visibilityDistanceType`, `auras`) VALUES
+(32919, 0, 0, 0, 0, 0, 0, '62639 62641 62640'),
+(33401, 0, 0, 0, 0, 0, 0, '62639 62641 62640');


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Freya's Storm Lasher has no `creature_template_addon` row, so it spawns bare. A sniff shows it applying three self-auras the moment it spawns:

- 62639 Storm Lasher Visual
- 62641 Random Lightning Visual Arc Up v2.0, which periodically triggers 62642 every 200 ms (this is the arcing lightning, it fires 668 times over the fight in the capture)
- 62640 Storm Lasher Visual 2

Added as an addon row rather than script casts for two reasons. The Detonating Lasher is the existing precedent in this same encounter: its submerge visual is a real cast in the sniff too, yet we carry it as an addon row (`28819 64481`), which matches the capture exactly. And `Creature::setDeathState(DeathState::JustRespawned)` calls `LoadCreaturesAddon(true)`, which is the path the trio revive uses, so the visuals come back when a Storm Lasher revives with no extra code. The sniff agrees: five applications on one Storm Lasher GUID, being two spawns plus three revives.

The row is added on both difficulty entries (32919 and 33401), the same as the Detonating Lasher which carries its addon on both 32918 and 33399. `creature_template_addon` is keyed per entry with no difficulty inheritance, so the 25-man variant would otherwise get nothing.

The other adds were checked against the capture and need no rows: Snaplasher's Hardened Bark and the Conservator's Grip are script-driven, and the Water Spirit has no unique spawn auras.

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Claude Fable 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- None

## SOURCE:
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [x] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Sniff of a Freya kill: every Storm Lasher spawn and revive applies the three auras, in the order used here. Spell data cross-checked on Wowhead's 3.3.5 database. Note the difficulty entry split is our own modelling and cannot come from a sniff, since modern retail has no separate 25-man creature entries; both entries are covered here by following the Detonating Lasher's existing data.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Database-only change, no build required.

## How to Test the Changes:
- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Pull Freya and wait for a trio wave (Snaplasher, Storm Lasher, Ancient Water Spirit). The Storm Lasher must now have lightning arcing over it, instead of being visually bare.
2. Kill one trio member and let the trio revive: the revived Storm Lasher must still show the lightning.
3. Repeat on 25-man and confirm the same, this is what the second row covers.

## Known Issues and TODO List:

- [ ] The trio also cast a one-shot revive visual when they come back (62848 Snaplasher, 62849 Ancient Water Spirit, 62851 Storm Lasher). That needs a script change in the trio revive path and is left out of this database-only PR.

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
