### PR TITLE
fix(Scripts/Ulduar): rework Freya's trio revive from sniff

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1786284849984373500.sql
+++ b/data/sql/updates/pending_db_world/rev_1786284849984373500.sql
@@ -1,0 +1,15 @@
+--
+DELETE FROM `creature_text` WHERE (`CreatureID` IN (32916, 32919, 33202, 33398, 33400, 33401));
+INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `TextRange`, `comment`) VALUES
+(32916, 0, 0, 'The %s withers into the earth and begins to regenerate.', 16, 0, 100, 0, 0, 0, 33463, 0, 'Snaplasher EMOTE_TRIO_WITHERS'),
+(32916, 1, 0, 'With the help of its allies the %s regenerates back to life.', 16, 0, 100, 0, 0, 0, 33464, 0, 'Snaplasher EMOTE_TRIO_REGENERATES'),
+(33400, 0, 0, 'The %s withers into the earth and begins to regenerate.', 16, 0, 100, 0, 0, 0, 33463, 0, 'Snaplasher EMOTE_TRIO_WITHERS'),
+(33400, 1, 0, 'With the help of its allies the %s regenerates back to life.', 16, 0, 100, 0, 0, 0, 33464, 0, 'Snaplasher EMOTE_TRIO_REGENERATES'),
+(32919, 0, 0, 'The %s withers into the earth and begins to regenerate.', 16, 0, 100, 0, 0, 0, 33463, 0, 'Storm Lasher EMOTE_TRIO_WITHERS'),
+(32919, 1, 0, 'With the help of its allies the %s regenerates back to life.', 16, 0, 100, 0, 0, 0, 33464, 0, 'Storm Lasher EMOTE_TRIO_REGENERATES'),
+(33401, 0, 0, 'The %s withers into the earth and begins to regenerate.', 16, 0, 100, 0, 0, 0, 33463, 0, 'Storm Lasher EMOTE_TRIO_WITHERS'),
+(33401, 1, 0, 'With the help of its allies the %s regenerates back to life.', 16, 0, 100, 0, 0, 0, 33464, 0, 'Storm Lasher EMOTE_TRIO_REGENERATES'),
+(33202, 0, 0, 'The %s withers into the earth and begins to regenerate.', 16, 0, 100, 0, 0, 0, 33463, 0, 'Ancient Water Spirit EMOTE_TRIO_WITHERS'),
+(33202, 1, 0, 'With the help of its allies the %s regenerates back to life.', 16, 0, 100, 0, 0, 0, 33464, 0, 'Ancient Water Spirit EMOTE_TRIO_REGENERATES'),
+(33398, 0, 0, 'The %s withers into the earth and begins to regenerate.', 16, 0, 100, 0, 0, 0, 33463, 0, 'Ancient Water Spirit EMOTE_TRIO_WITHERS'),
+(33398, 1, 0, 'With the help of its allies the %s regenerates back to life.', 16, 0, 100, 0, 0, 0, 33464, 0, 'Ancient Water Spirit EMOTE_TRIO_REGENERATES');

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_freya.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_freya.cpp
@@ -123,7 +123,7 @@ enum FreyaEvents
     EVENT_FREYA_GROUND_TREMOR                   = 6,
     EVENT_FREYA_IRON_ROOT                       = 7,
     EVENT_FREYA_UNSTABLE_SUN_BEAM               = 8,
-    EVENT_FREYA_RESPAWN_TRIO                    = 9,
+    EVENT_FREYA_TRIO_WAVE_END                   = 9,
 
     // STONEBARK
     EVENT_STONEBARK_FISTS_OF_STONE              = 10,
@@ -171,6 +171,10 @@ enum Texts
     EMOTE_ALLIES_OF_NATURE                       = 9,
     EMOTE_GROUND_TREMOR                          = 10,
     EMOTE_IRON_ROOTS                             = 11,
+
+    // Snaplasher / Storm Lasher / Ancient Water Spirit
+    EMOTE_TRIO_WITHERS                           = 0,
+    EMOTE_TRIO_REGENERATES                       = 1,
 };
 
 enum FreyaNPCs
@@ -199,15 +203,17 @@ enum Misc
     ACTION_REMOVE_10_STACK                      = 10,
     ACTION_REMOVE_25_STACK                      = 25,
     ACTION_REMOVE_2_STACK                       = 2,
-    ACTION_RESPAWN_TRIO                         = 1,
+    ACTION_TRIO_MEMBER_DOWN                     = 1,
     ACTION_LUMBERJACKED                         = -1,
     ACTION_ADD_DIED                             = -2,
+    ACTION_TRIO_MEMBER_REVIVED                  = -3,
 
     EVENT_PHASE_ADDS                            = 1,
     EVENT_PHASE_FINAL                           = 2,
 
     DATA_GET_ELDER_COUNT                        = 1,
     DATA_BACK_TO_NATURE                         = 2,
+    DATA_TRIO_DOWN                              = 3,
 
     CRITERIA_LUMBERJACKED                       = 21686,
 
@@ -231,11 +237,10 @@ struct boss_freya : public BossAI
             instance->SetBossState(BOSS_FREYA, DONE);
     }
 
-    uint8 _trioKilled;
+    uint8 _trioDown;
     uint8 _spawnedAmount;
     uint8 _setPermutation;
     uint8 _lumberjacked;
-    bool _respawningTrio;
     bool _backToNature;
     uint8 _deforestation;
     uint8 _aliveAddsCount;
@@ -259,9 +264,8 @@ struct boss_freya : public BossAI
 
         _lumberjacked = 0;
         _spawnedAmount = 0;
-        _trioKilled = 0;
+        _trioDown = 0;
         _setPermutation = urand(0, 5);
-        _respawningTrio = false;
         _backToNature = true;
         _deforestation = 0;
         _aliveAddsCount = 0;
@@ -358,6 +362,7 @@ struct boss_freya : public BossAI
             case GROUP_TRIO:
                 Talk(SAY_SUMMON_TRIO);
                 DoCast(SPELL_SUMMON_WAVE_3);
+                _trioDown = 0;
                 break;
             case GROUP_CONSERVATOR:
                 Talk(SAY_SUMMON_CONSERVATOR);
@@ -394,15 +399,19 @@ struct boss_freya : public BossAI
             return;
         }
 
-        if (param == ACTION_RESPAWN_TRIO)
+        if (param == ACTION_TRIO_MEMBER_DOWN)
         {
-            if (!_respawningTrio)
-            {
-                _respawningTrio = true;
-                events.ScheduleEvent(EVENT_FREYA_RESPAWN_TRIO, 10s);
-            }
+            // Once the whole trio is down none of them can come back, so the wave
+            // is decided here and only waits out the last member's revive window
+            if (++_trioDown >= 3)
+                events.RescheduleEvent(EVENT_FREYA_TRIO_WAVE_END, 11s);
 
-            ++_trioKilled;
+            return;
+        }
+
+        if (param == ACTION_TRIO_MEMBER_REVIVED)
+        {
+            --_trioDown;
             return;
         }
 
@@ -446,6 +455,9 @@ struct boss_freya : public BossAI
         }
         if (param == DATA_BACK_TO_NATURE)
             return _backToNature;
+
+        if (param == DATA_TRIO_DOWN)
+            return _trioDown;
 
         return 0;
     }
@@ -569,15 +581,11 @@ struct boss_freya : public BossAI
                     me->CastSpell(target, SPELL_SUNBEAM, false);
                 events.Repeat(15s, 20s);
                 break;
-            case EVENT_FREYA_RESPAWN_TRIO:
+            case EVENT_FREYA_TRIO_WAVE_END:
+                // _trioDown stays set so a member resolving on this same tick
+                // still sees the trio as wiped and does not come back
                 _deforestation = 0;
-                _respawningTrio = false;
-                if (_trioKilled < 3)
-                    summons.DoAction(ACTION_RESPAWN_TRIO);
-                else
-                    events.RescheduleEvent(EVENT_FREYA_ADDS_SPAM, 5s, 0, EVENT_PHASE_ADDS);
-
-                _trioKilled = 0;
+                events.RescheduleEvent(EVENT_FREYA_ADDS_SPAM, 5s, 0, EVENT_PHASE_ADDS);
                 break;
             case EVENT_FREYA_NATURE_BOMB:
                 {
@@ -1041,10 +1049,18 @@ struct boss_freya_summons : public ScriptedAI
 
                 if (_isTrio)
                 {
-                    freya->AI()->DoAction(ACTION_RESPAWN_TRIO);
+                    freya->AI()->DoAction(ACTION_TRIO_MEMBER_DOWN);
                     _hasDied = true;
+                    Talk(EMOTE_TRIO_WITHERS);
+
+                    // The corpse keeps ticking its events, so each member counts
+                    // down its own revive window instead of sharing one with Freya
+                    me->m_Events.AddEventAtOffset([this]()
+                    {
+                        ReviveWithAllies();
+                    }, 11s);
                 }
-                if (!_isTrio)
+                else
                     freya->AI()->DoAction(ACTION_ADD_DIED);
             }
         }
@@ -1052,13 +1068,24 @@ struct boss_freya_summons : public ScriptedAI
             me->CastSpell(me, SPELL_DETONATE, true);
     }
 
-    void DoAction(int32 param) override
+    void ReviveWithAllies()
     {
-        if (_isTrio && param == ACTION_RESPAWN_TRIO)
-        {
-            me->setDeathState(DeathState::JustRespawned);
-            Reset();
-        }
+        InstanceScript* instance = me->GetInstanceScript();
+        if (!instance)
+            return;
+
+        Creature* freya = instance->GetCreature(BOSS_FREYA);
+        if (!freya)
+            return;
+
+        // A member only comes back while at least one of its allies is still up
+        if (freya->AI()->GetData(DATA_TRIO_DOWN) >= 3)
+            return;
+
+        Talk(EMOTE_TRIO_REGENERATES);
+        me->setDeathState(DeathState::JustRespawned);
+        Reset();
+        freya->AI()->DoAction(ACTION_TRIO_MEMBER_REVIVED);
     }
 
     void JustEngagedWith(Unit*) override


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

> [!NOTE]
> Draft: this overlaps #27063, see the last section before merging.

Reworks how Freya's elemental trio (Snaplasher, Storm Lasher, Ancient Water Spirit) revives, based on a sniff.

**The two emotes.** Each member emotes when it goes down and again when it comes back:

- "The %s withers into the earth and begins to regenerate." (broadcast text 33463)
- "With the help of its allies the %s regenerates back to life." (broadcast text 33464)

Both texts already exist in `broadcast_text` but nothing referenced them, so we never sent either. Added as `creature_text` with `Type` 16 (`CHAT_MSG_MONSTER_EMOTE`), which is what the sniff shows for these. Note this is deliberately not the 41 (`RaidBossEmote`) that Freya's own emotes use, the capture confirms hers are 41 and the trio's are 16. Rows are on all six entries (32916/33400, 32919/33401, 33202/33398), since `CreatureTextMgr` resolves text by `GetEntry()` with no difficulty fallback.

**Revive window is 11 seconds, not 10.** Pairing each down emote with its matching revive emote gives seven clean intervals in the capture, all between 10.93 and 10.99 seconds.

**The window is per member, not shared.** In the capture the Snaplasher goes down at 07:14:46.458 and the Water Spirit at 07:14:51.345; they come back at 07:14:57.384 and 07:15:02.274, each 11 seconds after its own down and so 4.9 seconds apart. We currently schedule a single timer on Freya from the first death and revive everyone together on it.

Each member now counts its own window on `me->m_Events`. This works on a corpse because `Creature::Update` calls `Unit::Update` while in the Corpse state, which reaches `WorldObject::Update` and `m_Events.Update`; it is also the pattern the Detonating Lasher already uses in this file, and it is wipe-safe since despawning the summon destroys its pending event. Freya keeps only a count of how many are currently down, which members query when their window closes: all three down means stay dead, otherwise revive.

That counter is deliberately not cleared at wave end. Freya's wave-end event and the last member's own window land on the same tick with no defined ordering, so clearing it there would let that member see a cleared count and revive after the wave was already over. It clears when the next trio wave spawns instead, which makes the outcome order-independent.

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Claude Fable 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/27015

Removing the broadcast means a living trio member is no longer reset by a sibling's death, which is the root cause of that issue's leftover Attuned to Nature stacks.

## SOURCE:
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [x] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Sniff of a Freya kill containing eight trio revives, with the emote pairs giving both the window length and the per member behaviour.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Builds without errors (Windows, MSVC Release).

## How to Test the Changes:
- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Pull Freya and wait for a trio wave. Kill one member: it emotes that it withers into the earth, and 11 seconds later emotes that it regenerates and comes back up fighting.
2. Kill two members several seconds apart. They must come back separately, each 11 seconds after its own death, not together.
3. Kill all three within the window: none come back, and the next wave follows.
4. Linked issue check: after a partial trio kill and revive, finish the encounter and confirm Attuned to Nature reaches zero as the last add dies, with no leftover stacks.
5. Repeat on 25-man to cover the second set of text rows.

## Known Issues and TODO List:

- [ ] Overlaps #27063. That PR also touches this code, changing the shared window to 12s and guarding the broadcast so it only respawns dead members. Both of those hunks are superseded here, and the 12s value is contradicted by the emote timings above. Its dose reduction spell script is independent and still worth keeping, so the suggestion is to strip the two trio hunks from #27063 and let this PR own the revive logic. Kept as a draft until that is settled.
- [ ] The trio also cast a one shot revive visual when they come back (62848 Snaplasher, 62849 Ancient Water Spirit, 62851 Storm Lasher). Not included here, it is a small addition to the same revive path.

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
