### PR TITLE
feat(Core/Arena): add OnGetStartPersonalRating script hook

### DIFF
--- a/src/server/game/Battlegrounds/ArenaTeam.cpp
+++ b/src/server/game/Battlegrounds/ArenaTeam.cpp
@@ -137,6 +137,8 @@ bool ArenaTeam::AddMember(ObjectGuid playerGuid)
     else if (GetRating() >= 1000)
         personalRating = 1000;
 
+    sScriptMgr->OnGetStartPersonalRating(this, playerGuid, personalRating);
+
     // xinef: sync query
     // Try to get player's match maker rating from db and fall back to config setting if not found
     CharacterDatabasePreparedStatement* stmt = CharacterDatabase.GetPreparedStatement(CHAR_SEL_MATCH_MAKER_RATING);

--- a/src/server/game/Scripting/ScriptDefines/ArenaScript.cpp
+++ b/src/server/game/Scripting/ScriptDefines/ArenaScript.cpp
@@ -54,6 +54,11 @@ bool ScriptMgr::CanSaveArenaStatsForMember(ArenaTeam* team, ObjectGuid playerGui
     CALL_ENABLED_BOOLEAN_HOOKS(ArenaScript, ARENAHOOK_CAN_SAVE_ARENA_STATS_FOR_MEMBER, !script->CanSaveArenaStatsForMember(team, playerGuid));
 }
 
+void ScriptMgr::OnGetStartPersonalRating(ArenaTeam* team, ObjectGuid playerGuid, uint32& personalRating)
+{
+    CALL_ENABLED_HOOKS(ArenaScript, ARENAHOOK_ON_GET_START_PERSONAL_RATING, script->OnGetStartPersonalRating(team, playerGuid, personalRating));
+}
+
 ArenaScript::ArenaScript(char const* name, std::vector<uint16> enabledHooks)
     : ScriptObject(name, ARENAHOOK_END)
 {

--- a/src/server/game/Scripting/ScriptDefines/ArenaScript.h
+++ b/src/server/game/Scripting/ScriptDefines/ArenaScript.h
@@ -31,6 +31,7 @@ enum ArenaHook
     ARENAHOOK_ON_ARENA_START,
     ARENAHOOK_ON_BEFORE_TEAM_MEMBER_UPDATE,
     ARENAHOOK_CAN_SAVE_ARENA_STATS_FOR_MEMBER,
+    ARENAHOOK_ON_GET_START_PERSONAL_RATING,
     ARENAHOOK_END
 };
 
@@ -57,6 +58,10 @@ public:
     [[nodiscard]] virtual bool OnBeforeArenaTeamMemberUpdate(ArenaTeam* /*team*/, Player* /*player*/, bool /*won*/, uint32 /*opponentMatchmakerRating*/, int32 /*matchmakerChange*/) { return false; }
 
     [[nodiscard]] virtual bool CanSaveArenaStatsForMember(ArenaTeam* /*team*/, ObjectGuid /*playerGuid*/) { return true; }
+
+    // Called with the personal rating the core computed for a player joining the team, before it is
+    // stored on the member and written to arena_team_member.
+    virtual void OnGetStartPersonalRating(ArenaTeam* /*team*/, ObjectGuid /*playerGuid*/, uint32& /*personalRating*/) { }
 };
 
 #endif

--- a/src/server/game/Scripting/ScriptMgr.h
+++ b/src/server/game/Scripting/ScriptMgr.h
@@ -673,6 +673,7 @@ public: /* ArenaScript */
     void OnArenaStart(Battleground* const bg);
     bool OnBeforeArenaTeamMemberUpdate(ArenaTeam* team, Player* player, bool won, uint32 opponentMatchmakerRating, int32 matchmakerChange);
     bool CanSaveArenaStatsForMember(ArenaTeam* team, ObjectGuid playerGuid);
+    void OnGetStartPersonalRating(ArenaTeam* team, ObjectGuid playerGuid, uint32& personalRating);
 
 public: /* MiscScript */
 

--- a/src/test/server/game/Battlegrounds/ArenaHookDefaultsTest.cpp
+++ b/src/test/server/game/Battlegrounds/ArenaHookDefaultsTest.cpp
@@ -92,6 +92,16 @@ TEST_F(ArenaHookDefaultsTest, CanSaveArenaStatsForMemberDefaultsTrue)
     EXPECT_TRUE(sScriptMgr->CanSaveArenaStatsForMember(&team, ObjectGuid::Empty));
 }
 
+// OnGetStartPersonalRating must leave the rating untouched by default so a new
+// arena team member keeps the value ArenaTeam::AddMember computed for them.
+TEST_F(ArenaHookDefaultsTest, OnGetStartPersonalRatingKeepsCoreValue)
+{
+    ArenaTeam team;
+    uint32 personalRating = 1000;
+    sScriptMgr->OnGetStartPersonalRating(&team, ObjectGuid::Empty, personalRating);
+    EXPECT_EQ(personalRating, 1000u);
+}
+
 // OnBeforeArenaCheckWinConditions must return true by default so
 // the normal win condition check proceeds.
 TEST_F(ArenaHookDefaultsTest, OnBeforeArenaCheckWinConditionsDefaultsTrue)


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Adds an `ArenaScript` hook that lets a module change the personal rating a player receives when they join an arena team:

```cpp
virtual void OnGetStartPersonalRating(ArenaTeam* team, ObjectGuid playerGuid, uint32& personalRating) { }
```

It's called in `ArenaTeam::AddMember` right after the core computes the starting rating, so a module gets the value the player would have received and can adjust it before it's stored on the member and written to `arena_team_member`.

Today the only way to do that from a module is to let the join finish and then overwrite both the member and the row, which means deferring an update to the next world tick and leaving the roster showing the default rating in between.

The hook does nothing on its own. The default implementation is empty, so with no script registered the rating stays exactly what it is now.

I'm using it in [mod-arena-rating-memory](https://github.com/azerothcore/mod-arena-rating-memory), which gives a player back their old personal rating when they rejoin a team they used to be in, but the hook itself doesn't assume anything about that.

### AI-assisted Pull Requests

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Opus)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:

None.

## SOURCE:

Not applicable, this is a scripting hook and not a behaviour fix.

## Tests Performed:

- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Added a case to `ArenaHookDefaultsTest` covering the default: with no script registered the hook leaves `personalRating` untouched.

## How to Test the Changes:

- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Build with `-DBUILD_TESTING=1` and run `unit_tests`, `ArenaHookDefaultsTest.OnGetStartPersonalRatingKeepsCoreValue` should pass.
2. Without any module registering the hook, create an arena team and invite a player. Their personal rating in `arena_team_member` and in the arena frame is the same as before this PR (1000 on a team rated 1000+, 0 below that, or whatever `Arena.ArenaStartPersonalRating` is set to).
3. With a module implementing `OnGetStartPersonalRating` and setting a different value, the joining member gets that value in the arena frame and in `arena_team_member` right away, without a reload.

## Known Issues and TODO List:

- [ ] Nothing pending.
