### PR TITLE
fix(Core/GameObject): use the full spell focus radius

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1786298744183384100.sql
+++ b/data/sql/updates/pending_db_world/rev_1786298744183384100.sql
@@ -1,0 +1,11 @@
+--
+-- Spell focus radius is no longer halved by the core, so the inflated values that compensated for
+-- that go back to their sniffed radius.
+UPDATE `gameobject_template` SET `Data1` = 50 WHERE `entry` = 20919; -- Tuber Node
+UPDATE `gameobject_template` SET `Data1` = 50 WHERE `entry` = 184643; -- Void Conduit Spell Focus
+UPDATE `gameobject_template` SET `Data1` = 50 WHERE `entry` = 184750; -- Unguarded Summoning Site
+UPDATE `gameobject_template` SET `Data1` = 5 WHERE `entry` = 185144; -- Bleeding Hollow Forge Spell Focus
+UPDATE `gameobject_template` SET `Data1` = 50 WHERE `entry` = 190033; -- Alystros the Verdant Keeper Spell Focus
+UPDATE `gameobject_template` SET `Data1` = 5 WHERE `entry` = 190224; -- Scourge Mummy Fire
+UPDATE `gameobject_template` SET `Data1` = 10 WHERE `entry` = 190731; -- Scourgewagon
+UPDATE `gameobject_template` SET `Data1` = 5 WHERE `entry` = 192011; -- Thane Ufrang the Mighty's Spell Focus

--- a/src/server/game/Grids/Notifiers/GridNotifiers.h
+++ b/src/server/game/Grids/Notifiers/GridNotifiers.h
@@ -691,7 +691,7 @@ namespace Acore
             if (go->GetGOInfo()->spellFocus.focusId != i_focusId)
                 return false;
 
-            float dist = (float)((go->GetGOInfo()->spellFocus.dist) / 2);
+            float const dist = go->GetGOInfo()->spellFocus.dist;
 
             return go->IsWithinDistInMap(i_unit, dist);
         }


### PR DESCRIPTION
## Changes Proposed:

`Data1` of a `GAMEOBJECT_TYPE_SPELL_FOCUS` template is the radius, not the diameter, but `GameObjectFocusCheck` halved it. Every spell focus object in the game was therefore usable only from half its intended range. The division was integer on top of that, so odd radii lost the remainder as well: a radius of 3 became 1 yard, and entry 186624 with a radius of 1 became 0.

That halving is why we keep running into spell focus objects that "need" a bigger range than the sniffed data gives them. Eight templates carry inflated `Data1` values as a result, seven inherited from the legacy import and one from https://github.com/azerothcore/azerothcore-wotlk/pull/4075. The second commit puts them back to their sniffed radius:

| entry | name | before | after |
|---|---|---|---|
| 20919 | Tuber Node | 100 | 50 |
| 184643 | Void Conduit Spell Focus | 90 | 50 |
| 184750 | Unguarded Summoning Site | 100 | 50 |
| 185144 | Bleeding Hollow Forge Spell Focus | 14 | 5 |
| 190033 | Alystros the Verdant Keeper Spell Focus | 80 | 50 |
| 190224 | Scourge Mummy Fire | 15 | 5 |
| 190731 | Scourgewagon | 15 | 10 |
| 192011 | Thane Ufrang the Mighty's Spell Focus | 17 | 5 |

Every spawn of those eight sits at the exact same coordinates TrinityCore uses, except one of the two 192011 spawns, so these radii are known to work at those positions.

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Opus 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:

None open on our side.

## SOURCE:

The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Core change cherry-picked from https://github.com/TrinityCore/TrinityCore/commit/2de20560fe7caccd57fbfd1b17856fac43d5f921, committed with `--author` crediting Killyana. It closed https://github.com/TrinityCore/TrinityCore/issues/24177, which carries a retail screenshot of Forge 173064 (`Data1` = 10) being used at 10 yards. The fix has been in TrinityCore since February 2020 and is unchanged there today.

## Tests Performed:

This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

The core change only widens a range check, so nothing that works today can stop working from the core commit alone. The DB commit is where the regression surface is, since three of those templates end up with a smaller effective radius than they have now.

1. Stand next to an anvil or forge and start moving away while trying to craft. Before the change it cuts out at 5 yards, after it at 10.
2. Bleeding Hollow Forge, Hellfire Peninsula (185144): effective radius goes from 7 to 5 yards. Check the forge is still usable from where you would naturally stand at it.
3. Thane Ufrang the Mighty's Spell Focus (192011), quest Shadow Vault Decree: effective radius goes from 8 to 5 yards. We spawn two of these 11 yards apart, so their circles no longer overlap. Confirm the quest still completes from both.
4. Scourge Mummy Fire (190224): effective radius goes from 7 to 5 yards.
5. Regression sweep on anything else that uses a spell focus and is not in the table above, since all of those gain range rather than lose it: moonwells, summoning sites, quest braziers, Lunar Festival spotlights.

## Known Issues and TODO List:

- [ ] Entry 30 "Dalaran Forge Spell Focus" is ours, TrinityCore has no equivalent template, so there is no sniffed value to restore it to. It is left at `Data1` = 4 and goes from 2 to 4 effective yards. That is an improvement but probably still short of the real thing, and it may want a follow-up once someone can check it on a reference server.
- [ ] https://github.com/azerothcore/azerothcore-wotlk/pull/24518 cloned entry 30 with `Data1` = 16 to make the Forge of Fate reachable. It was closed unmerged, and with this fix in place it either becomes unnecessary or needs a much smaller bump.

## How to Test AzerothCore PRs

When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
