### PR TITLE
fix(Core/Spells): Blood Tap brings back a spent blood rune again

### DIFF
--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -5814,18 +5814,27 @@ void Spell::EffectActivateRune(SpellEffIndex effIndex)
     // refreshing.
     if (m_spellInfo->Id == 45529)
     {
+        uint32 firstCooldown = player->GetRuneCooldown(0);
+        uint32 secondCooldown = player->GetRuneCooldown(1);
+
         uint8 bloodRune = 0;
-        if (player->GetRuneCooldown(1) && (!player->GetRuneCooldown(0) || player->GetRuneCooldown(1) < player->GetRuneCooldown(0)))
+        if (secondCooldown && (!firstCooldown || secondCooldown < firstCooldown))
             bloodRune = 1;
 
-        player->SetRuneCooldown(bloodRune, 0);
-        player->SetGracePeriod(bloodRune, player->IsInCombat()); // xinef: reset grace period
+        // Leave a rune that is already up alone, or its grace period would be thrown away
+        // and the next one spent from that slot would come back later than it should.
+        if (player->GetRuneCooldown(bloodRune))
+        {
+            player->SetRuneCooldown(bloodRune, 0);
+            player->SetGracePeriod(bloodRune, player->IsInCombat()); // xinef: reset grace period
+        }
     }
     else
     {
         for (uint32 j = 0; j < MAX_RUNES && count > 0; ++j)
         {
-            if (player->GetRuneCooldown(j) && player->GetCurrentRune(j) == RuneType(m_spellInfo->Effects[effIndex].MiscValue))
+            if (player->GetRuneCooldown(j)
+                && player->GetCurrentRune(j) == RuneType(m_spellInfo->Effects[effIndex].MiscValue))
             {
                 player->SetRuneCooldown(j, 0);
                 player->SetGracePeriod(j, player->IsInCombat()); // xinef: reset grace period

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -5808,36 +5808,29 @@ void Spell::EffectActivateRune(SpellEffIndex effIndex)
 
     uint32 count = damage;
     if (count == 0) count = 1;
-    for (uint32 j = 0; j < MAX_RUNES && count > 0; ++j)
+    // Blood Tap goes by rune slot, not by what the rune is showing: both blood slots count
+    // whether or not they have already turned into death runes. With one of them ready the
+    // other is the one to bring back, and with both spent it takes the one closest to
+    // refreshing.
+    if (m_spellInfo->Id == 45529)
     {
-        if (player->GetRuneCooldown(j) && player->GetCurrentRune(j) == RuneType(m_spellInfo->Effects[effIndex].MiscValue))
-        {
-            if (m_spellInfo->Id == 45529)
-                if (player->GetBaseRune(j) != RuneType(m_spellInfo->Effects[effIndex].MiscValueB))
-                    continue;
-            player->SetRuneCooldown(j, 0);
-            player->SetGracePeriod(j, player->IsInCombat()); // xinef: reset grace period
-            --count;
-        }
-    }
+        uint8 bloodRune = 0;
+        if (player->GetRuneCooldown(1) && (!player->GetRuneCooldown(0) || player->GetRuneCooldown(1) < player->GetRuneCooldown(0)))
+            bloodRune = 1;
 
-    // Blood Tap
-    if (m_spellInfo->Id == 45529 && count > 0)
+        player->SetRuneCooldown(bloodRune, 0);
+        player->SetGracePeriod(bloodRune, player->IsInCombat()); // xinef: reset grace period
+    }
+    else
     {
-        for (uint32 l = 0; l < MAX_RUNES && count > 0; ++l)
+        for (uint32 j = 0; j < MAX_RUNES && count > 0; ++j)
         {
-            // Check if both runes are on cd as that is the only time when this needs to come into effect
-            if ((player->GetRuneCooldown(l) && player->GetCurrentRune(l) == RuneType(m_spellInfo->Effects[effIndex].MiscValueB)) && (player->GetRuneCooldown(l + 1) && player->GetCurrentRune(l + 1) == RuneType(m_spellInfo->Effects[effIndex].MiscValueB)))
+            if (player->GetRuneCooldown(j) && player->GetCurrentRune(j) == RuneType(m_spellInfo->Effects[effIndex].MiscValue))
             {
-                // Should always update the rune with the lowest cd
-                if (player->GetRuneCooldown(l) >= player->GetRuneCooldown(l + 1))
-                    l++;
-                player->SetRuneCooldown(l, 0);
-                player->SetGracePeriod(l, player->IsInCombat()); // xinef: reset grace period
+                player->SetRuneCooldown(j, 0);
+                player->SetGracePeriod(j, player->IsInCombat()); // xinef: reset grace period
                 --count;
             }
-            else
-                break;
         }
     }
 


### PR DESCRIPTION
## Changes Proposed:

Closes #27073. Blood Tap should activate a spent blood rune and turn it into a death rune. With one blood rune ready and the other spent, it left the spent one alone and converted the one that was already available instead.

`Spell::EffectActivateRune` picked the rune by the type it is currently showing:

```cpp
if (player->GetRuneCooldown(j) && player->GetCurrentRune(j) == RuneType(m_spellInfo->Effects[effIndex].MiscValue))
{
    if (m_spellInfo->Id == 45529)
        if (player->GetBaseRune(j) != RuneType(m_spellInfo->Effects[effIndex].MiscValueB))
            continue;
```

For Blood Tap (45529) `MiscValue` is `RUNE_DEATH`, so a spent rune only matched once it had already been converted. A plain spent blood rune never did. The extra loop underneath was there to cover that, but it only fires when **both** runes of the pair are spent, which is why the reporter saw it work only with two death runes and one empty.

With nothing activated, effect 1 of the spell (the `SPELL_AURA_CONVERT_RUNE` aura) walks the runes looking for one that is off cooldown, so it converted the rune the player already had available. That is the "it overrides my available rune" in the report.

Blood Tap now picks by rune slot, the way TrinityCore does it, so both blood slots qualify whether or not they have turned into death runes yet:

```cpp
uint32 firstCooldown = player->GetRuneCooldown(0);
uint32 secondCooldown = player->GetRuneCooldown(1);

uint8 bloodRune = 0;
if (secondCooldown && (!firstCooldown || secondCooldown < firstCooldown))
    bloodRune = 1;
```

One ready and one spent activates the spent one; both spent activates whichever refreshes first. That covers what the removed loop did, and it also drops a couple of problems that loop had: it stepped one slot at a time while reading `l + 1`, so it compared slots (0,1), (1,2), (2,3) instead of the real rune pairs, and at `l = 5` it read index 6, past the end of the array.

A rune that is already up is left alone, so its grace period is not thrown away and the next one spent from that slot still refreshes on time.

### Known limitation

Effect 1 of the spell, the `SPELL_AURA_CONVERT_RUNE` aura, still walks the runes from index 0, so with slot 0 ready and slot 1 spent it activates slot 1 and converts slot 0. Both slots are the same base-blood pair and both end up ready, one death and one blood, so the resource state is the same either way and only the icon differs. TrinityCore pairs the two effects with an extra AuraScript; that is not ported here.

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request.
   - Tools/models used: Claude Code (Opus 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #27073

## SOURCE:

TrinityCore handles Blood Tap in `spell_dk_blood_tap` and picks the slot the same way, never looking at the current rune type:

> ```cpp
> // Rune reset:
> // If both runes are on cooldown, reset the shorter one
> // If only one rune is on cooldown, reset that rune
> if (!player->GetRuneCooldown(1))
>     resetIndex = 0; // 1 is ready, so reset 0 (no matter if it's on cd)
> else if (!player->GetRuneCooldown(0) || player->GetRuneCooldown(1) < player->GetRuneCooldown(0))
>     resetIndex = 1; // 0 is ready, or both are on cd and 1 is shorter, so reset 1
> else
>     resetIndex = 0; // both are on cd and 0 is shorter, reset 0
> ```

[TrinityCore/TrinityCore, 3.3.5, src/server/scripts/Spells/spell_dk.cpp](https://github.com/TrinityCore/TrinityCore/blob/3.3.5/src/server/scripts/Spells/spell_dk.cpp)

The in-game tooltip agrees: "Immediately activates a Blood Rune and converts it into a Death Rune."

## Tests Performed:

**Not tested in game.** It builds and passes `apps/codestyle/codestyle-cpp.py`, and the selection was checked case by case against the TrinityCore logic above, but I have not been able to log in and verify it on a character. Please treat it as untested and give it a run before merging.

## How to Test the Changes:

Using the steps from the issue:

1. `.level 80` on a death knight, `.learn all my class`, and spec into a talent that turns spent blood runes into death runes (Reaping or Blood of the North).
2. `.go xyz -8722.548 355.6318 101.01977` for a training dummy.
3. Blood Strike twice so both blood runes are spent, then Obliterate twice to burn the frost runes and keep the blood ones isolated.
4. Wait for one of the two to come back, so you have one ready and one still spent.
5. Blood Tap. The spent one should come back, leaving both available, one of them a death rune.

Worth also checking the two cases either side of it: with both blood runes spent it should bring back the one with less time left, and with both already available it should just convert one. Empower Rune Weapon (47568) shares this function, so it is worth a look too.
