### PR TITLE
fix(Scripts/Ulduar): drive Mimiron's Laser Barrage from its sniffed target NPC

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1786318207194583600.sql
+++ b/data/sql/updates/pending_db_world/rev_1786318207194583600.sql
@@ -1,0 +1,36 @@
+-- Mimiron DB Target: the NPC the P3Wx2 Laser Barrage beams track.
+-- Path, positions and lap time are the creature's sniffed movement spline.
+SET @CGUID := 13395;
+SET @PATH  := @CGUID;
+
+DELETE FROM `creature` WHERE `id` = 33576 AND `map` = 603;
+INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `MovementType`, `VerifiedBuild`) VALUES
+(@CGUID, 33576, 603, 0, 0, 3, 1, 2785.423, 2673.1191, 372.36053, 5.714255, 7200, 2, 68974);
+
+DELETE FROM `creature_addon` WHERE `guid` = @CGUID;
+INSERT INTO `creature_addon` (`guid`, `path_id`, `bytes1`, `bytes2`) VALUES
+(@CGUID, @PATH, 0, 1);
+
+-- Sniffed spline: 19 control points, CatmullRom, one lap every 34016 ms. The velocity is what makes
+-- the waypoint generator's own spline arithmetic land on that lap time, so the sweep rate matches.
+DELETE FROM `waypoint_data` WHERE `id` = @PATH;
+INSERT INTO `waypoint_data` (`id`, `point`, `position_x`, `position_y`, `position_z`, `velocity`, `smoothTransition`) VALUES
+(@PATH,  1, 2785.423 , 2673.1191, 372.36053, 20.8988, 1),
+(@PATH,  2, 2823.0237, 2649.0586, 371.9791 , 20.8988, 1),
+(@PATH,  3, 2854.097 , 2590.8262, 371.9791 , 20.8988, 1),
+(@PATH,  4, 2852.951 , 2547.1116, 372.36053, 20.8988, 1),
+(@PATH,  5, 2822.796 , 2489.515 , 372.36053, 20.8988, 1),
+(@PATH,  6, 2784.964 , 2465.2473, 372.36053, 20.8988, 1),
+(@PATH,  7, 2741.2397, 2456.771 , 372.36053, 20.8988, 1),
+(@PATH,  8, 2701.0356, 2464.3186, 372.36053, 20.8988, 1),
+(@PATH,  9, 2660.476 , 2489.578 , 372.36053, 20.8988, 1),
+(@PATH, 10, 2636.8928, 2525.6873, 372.36053, 20.8988, 1),
+(@PATH, 11, 2631.294 , 2547.8306, 372.36053, 20.8988, 1),
+(@PATH, 12, 2631.4365, 2591.7522, 372.36053, 20.8988, 1),
+(@PATH, 13, 2637.3616, 2613.7002, 372.36053, 20.8988, 1),
+(@PATH, 14, 2650.2214, 2636.1633, 372.36053, 20.8988, 1),
+(@PATH, 15, 2661.5715, 2649.7153, 372.36053, 20.8988, 1),
+(@PATH, 16, 2696.5955, 2672.6636, 372.36053, 20.8988, 1),
+(@PATH, 17, 2711.0989, 2677.7908, 372.36053, 20.8988, 1),
+(@PATH, 18, 2740.676 , 2683.1196, 372.36053, 20.8988, 1),
+(@PATH, 19, 2771.834 , 2677.767 , 372.36053, 20.8988, 1);

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_mimiron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_mimiron.cpp
@@ -1220,11 +1220,29 @@ private:
     uint8 _phase;
 };
 
-// Sniffed P3Wx2 Laser Barrage arcs start at a fixed room angle and advance 60 degrees
-// counterclockwise each cycle, independent of the player targeted during Spinning Up.
-// Phase 4 restarts the sequence from the initial angle.
-constexpr float VX001_BARRAGE_ARC_START = 6.17f;
-constexpr float VX001_BARRAGE_ARC_STEP = static_cast<float>(M_PI / 3);
+// The P3Wx2 Laser Barrage beams track the Mimiron DB Target, which circles the room on a waypoint
+// path that runs from instance load and is never restarted, so the arc carries across barrages,
+// phase changes and wipes. The beams follow caster facing, so aiming at it is what delivers the
+// sweep. Taking the bearing rather than copying an angle also keeps phase 4 right, where VX-001
+// rides the chassis up to 30yd off centre and the bearing shifts by as much as 16 degrees.
+inline void FaceBarrageArc(Unit* caster)
+{
+    InstanceScript* instance = caster->GetInstanceScript();
+    if (!instance)
+        return;
+
+    Creature* dbTarget = instance->GetCreature(DATA_MIMIRON_DB_TARGET);
+    if (!dbTarget)
+        return;
+
+    float arc = caster->GetAngle(dbTarget);
+
+    // SetFacingTo drops the transport transform for passengers, so phase 4 needs a seat-local angle
+    if (Unit* vehicle = caster->GetVehicleBase())
+        arc = Position::NormalizeOrientation(arc - vehicle->GetOrientation());
+
+    caster->SetFacingTo(arc);
+}
 
 struct npc_ulduar_vx001 : public ScriptedAI
 {
@@ -1239,8 +1257,6 @@ struct npc_ulduar_vx001 : public ScriptedAI
         _phase = 0;
         _fighting = false;
         _leftArm = false;
-        _barrageOrientation = 0;
-        _nextBarrageArc = VX001_BARRAGE_ARC_START;
         me->SetRegeneratingHealth(false);
         _events.Reset();
     }
@@ -1262,7 +1278,6 @@ struct npc_ulduar_vx001 : public ScriptedAI
                 case 2:
                     _phase = 2;
                     _fighting = true;
-                    _nextBarrageArc = VX001_BARRAGE_ARC_START;
                     me->SetUInt32Value(UNIT_NPC_EMOTESTATE, EMOTE_ONESHOT_SPELL_CAST_OMNI);
                     me->RemoveUnitFlag(UNIT_FLAG_NOT_SELECTABLE);
                     _events.Reset();
@@ -1281,7 +1296,6 @@ struct npc_ulduar_vx001 : public ScriptedAI
                 case 4:
                     _phase = 4;
                     _fighting = true;
-                    _nextBarrageArc = VX001_BARRAGE_ARC_START;
                     me->RemoveUnitFlag(UNIT_FLAG_NOT_SELECTABLE);
                     _events.Reset();
                     _events.ScheduleEvent(EVENT_REINSTALL_ROCKETS, 3s);
@@ -1294,11 +1308,6 @@ struct npc_ulduar_vx001 : public ScriptedAI
                     break;
             }
         }
-    }
-
-    uint32 GetData(uint32  /*id*/) const override
-    {
-        return _barrageOrientation;
     }
 
     void DoAction(int32 action) override
@@ -1425,21 +1434,17 @@ struct npc_ulduar_vx001 : public ScriptedAI
                 break;
             case EVENT_SPELL_SPINNING_UP:
                 _events.Repeat(60s);
+                // Sniffed: the target is parked on the DB Target from the cast until the barrage ends
+                if (Creature* dbTarget = instance->GetCreature(DATA_MIMIRON_DB_TARGET))
+                    me->SetTarget(dbTarget->GetGUID());
+                FaceBarrageArc(me);
+                me->CastSpell(me, SPELL_SPINNING_UP, true);
+                if (Unit* vehicle = me->GetVehicleBase())
                 {
-                    float arc = _nextBarrageArc;
-
-                    _barrageOrientation = (uint32)((arc * 100.0f) / (2 * M_PI));
-                    _nextBarrageArc = Position::NormalizeOrientation(arc + VX001_BARRAGE_ARC_STEP);
-                    // The beams follow unit facing, so facing the arc start doubles as the telegraph
-                    me->SetFacingTo(arc);
-                    me->CastSpell(me, SPELL_SPINNING_UP, true);
-                    if (Unit* vehicle = me->GetVehicleBase())
-                    {
-                        vehicle->SetUInt32Value(UNIT_NPC_EMOTESTATE, EMOTE_STATE_CUSTOM_SPELL_01);
-                        vehicle->HandleEmoteCommand(EMOTE_STATE_CUSTOM_SPELL_01);
-                    }
-                    _events.RescheduleEvent((_phase == 2 ? EVENT_SPELL_RAPID_BURST : EVENT_HAND_PULSE), 14s + 500ms);
+                    vehicle->SetUInt32Value(UNIT_NPC_EMOTESTATE, EMOTE_STATE_CUSTOM_SPELL_01);
+                    vehicle->HandleEmoteCommand(EMOTE_STATE_CUSTOM_SPELL_01);
                 }
+                _events.RescheduleEvent((_phase == 2 ? EVENT_SPELL_RAPID_BURST : EVENT_HAND_PULSE), 14s + 500ms);
                 break;
             case EVENT_FLAME_SUPPRESSION_10:
                 me->CastSpell(me, SPELL_FLAME_SUPPRESSANT_10yd, false);
@@ -1507,8 +1512,6 @@ private:
     bool _isEvading;
     bool _fighting;
     bool _leftArm;
-    uint32 _barrageOrientation;
-    float _nextBarrageArc;
     uint8 _phase;
 };
 
@@ -2145,53 +2148,36 @@ class spell_mimiron_rapid_burst_aura : public AuraScript
     }
 };
 
-enum p3wx2LaserBarrage
-{
-    SPELL_P3WX2_LASER_BARRAGE_1 = 63297,
-    SPELL_P3WX2_LASER_BARRAGE_2 = 64042
-};
-
+// The beams themselves come from the spell chain: effect 2 links 63300, which triggers 63297 and
+// 64042 every 100ms on its own. All this script owns is where the caster is pointing.
 class spell_mimiron_p3wx2_laser_barrage_aura : public AuraScript
 {
     PrepareAuraScript(spell_mimiron_p3wx2_laser_barrage_aura);
 
-    bool Load() override
+    void HandleEffectApply(AuraEffect const*   /*aurEff*/, AuraEffectHandleModes   /*mode*/)
     {
-        _lastMSTime = GameTime::GetGameTimeMS().count();
-        _lastOrientation = -1.0f;
-        return true;
+        if (Unit* caster = GetCaster())
+            FaceBarrageArc(caster);
     }
 
     void HandleEffectPeriodic(AuraEffect const*   /*aurEff*/)
     {
         if (Unit* caster = GetCaster())
-        {
-            if (!caster->IsCreature())
-                return;
-            uint32 diff = getMSTimeDiff(_lastMSTime, GameTime::GetGameTimeMS().count());
-            if (_lastOrientation == -1.0f)
-            {
-                _lastOrientation = (caster->ToCreature()->AI()->GetData(0) * 2 * M_PI) / 100.0f;
-                diff = 0;
-            }
-            float new_o = Position::NormalizeOrientation(_lastOrientation - (M_PI / 60) * (diff / 250.0f));
-            _lastMSTime = GameTime::GetGameTimeMS().count();
-            _lastOrientation = new_o;
-            caster->SetFacingTo(new_o);
+            FaceBarrageArc(caster);
+    }
 
-            caster->CastSpell((Unit*)nullptr, SPELL_P3WX2_LASER_BARRAGE_1, true);
-            caster->CastSpell((Unit*)nullptr, SPELL_P3WX2_LASER_BARRAGE_2, true);
-        }
+    void HandleEffectRemove(AuraEffect const*   /*aurEff*/, AuraEffectHandleModes   /*mode*/)
+    {
+        if (Unit* caster = GetCaster())
+            caster->SetTarget(ObjectGuid::Empty);
     }
 
     void Register() override
     {
+        AfterEffectApply += AuraEffectApplyFn(spell_mimiron_p3wx2_laser_barrage_aura::HandleEffectApply, EFFECT_1, SPELL_AURA_PERIODIC_TRIGGER_SPELL, AURA_EFFECT_HANDLE_REAL);
         OnEffectPeriodic += AuraEffectPeriodicFn(spell_mimiron_p3wx2_laser_barrage_aura::HandleEffectPeriodic, EFFECT_1, SPELL_AURA_PERIODIC_TRIGGER_SPELL);
+        AfterEffectRemove += AuraEffectApplyFn(spell_mimiron_p3wx2_laser_barrage_aura::HandleEffectRemove, EFFECT_1, SPELL_AURA_PERIODIC_TRIGGER_SPELL, AURA_EFFECT_HANDLE_REAL);
     }
-
-private:
-    uint32 _lastMSTime;
-    float _lastOrientation;
 };
 
 class go_ulduar_do_not_push_this_button : public GameObjectScript

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp
@@ -106,6 +106,7 @@ ObjectData const creatureData[] =
     { NPC_MIMIRON_LEVIATHAN_MKII,   DATA_MIMIRON_LEVIATHAN_MKII },
     { NPC_MIMIRON_VX001,            DATA_MIMIRON_VX001          },
     { NPC_MIMIRON_ACU,              DATA_MIMIRON_ACU            },
+    { NPC_MIMIRON_DB_TARGET,        DATA_MIMIRON_DB_TARGET      },
     // Freya elders
     { NPC_ELDER_IRONBRANCH,         DATA_ELDER_IRONBRANCH       },
     { NPC_ELDER_STONEBARK,          DATA_ELDER_STONEBARK        },

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/ulduar.h
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/ulduar.h
@@ -70,6 +70,7 @@ enum UlduarData
     DATA_MIMIRON_LEVIATHAN_MKII             = 301,
     DATA_MIMIRON_VX001                      = 302,
     DATA_MIMIRON_ACU                        = 303,
+    DATA_MIMIRON_DB_TARGET                  = 304,
 
     // Mimiron doors
     DATA_GO_MIMIRON_DOOR_1                  = 311,
@@ -196,6 +197,7 @@ enum UlduarNPCs
     NPC_MIMIRON_LEVIATHAN_MKII              = 33432,
     NPC_MIMIRON_VX001                       = 33651,
     NPC_MIMIRON_ACU                         = 33670,
+    NPC_MIMIRON_DB_TARGET                   = 33576,
 
     // Freya
     NPC_ELDER_BRIGHTLEAF                    = 32915,


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

VX-001's P3Wx2 Laser Barrage was modelled as a fixed room angle advancing 60 degrees per cast, swept at `M_PI/60` per 250ms (12 deg/s), with the start angle handed to the aura script through a lossy `uint32` and reset on entering phases 2 and 4.

Sniffs show something different. The beams track **Mimiron DB Target (33576)**, an NPC that circles the room on a cyclic path. Its spline is issued once at instance load and never restarted, so the arc is continuous: it does not reset between barrages, on the phase 2 to phase 4 transition, or across a wipe and re-pull.

### Why the 60 degree step looked right

It was an aliasing artifact. The lap is 34016ms and Spinning Up repeats roughly every 61.6s, which is just short of two full laps, so consecutive barrages appear to step forward by about 68 degrees. A capture with a 62.25s interval instead shows about 61 degrees. Same rotation, different sampling interval, which is why a fixed 60 degree step matched one capture and not others.

### Evidence

Fitting a single continuous rotation to every clean beam-axis sample in the longest capture (2035 samples, 1635s, 48 revolutions):

| model | circular concentration R |
|---|---|
| one free-running rotation at 10.582 deg/s | **0.99714** |
| 10.5 deg/s | 0.76433 |
| 12 deg/s (what the script used) | 0.08155 |

The carrier is stated in the packets, not inferred. Its create block carries `SplineFlags: Flying, CatmullRom, Cyclic`, `Duration: 34016`, 19 control points forming a ring of radius ~113yd about the room centre. 360/34.016 = 10.5833 deg/s, matching the beam fit to 0.01%. Its own progress along the loop is broadcast, and interpolating the measured beam bearing onto it gives an invariant with no fitted rate at all:

```
beam_deg + 360 * SplineDist = 46.73 deg constant, R = 0.997118, drift 0.24 deg over 1635s
```

VX-001 also names it: at every Spinning Up its `ChannelObjects` and target field are set to 33576, and released when the barrage ends, on all 25 barrages across both phases in that capture.

Forcing the single rate and solving the phase per block shows the rotation runs straight through phase transitions and through a wipe:

| block | samples | R | phase |
|---|---|---|---|
| attempt A, phase 2 | 569 | 0.99958 | 313.61 |
| attempt A, phase 4 | 794 | 0.99670 | 313.03 |
| attempt B, phase 2 | 339 | 0.99958 | 313.28 |
| attempt B, phase 4 | 333 | 0.99177 | 314.48 |

The same spline, byte for byte, appears in all three captures used here.

### The arc is a bearing, not an angle

Least-squares fitting the beam origin from the beam packets alone returns VX-001's own position to 0.0002yd: (2744.4309, 2569.3853) in phase 2, and (2732.5720, 2558.9343) / (2713.7622, 2574.5347) in phase 4 once it boards the chassis. Scoring both models against all 2035 samples:

| model | R | rms | max error |
|---|---|---|---|
| bearing to the orbiting NPC | **0.999740** | 1.31 deg | 3.45 deg |
| bare angle ramp, no parallax | 0.997095 | 4.37 deg | 16.57 deg |

That 16.57 deg is the phase 4 case, where the chassis carries VX-001 up to 30yd off centre. The residual 1.31 deg is the sniffed destination update quantum and is not reproducible from 3.3.5 data, where the beams follow unit facing.

### What changed

- **DB**: spawns 33576 with `MovementType = 2` and a 19 point `waypoint_data` path, `smoothTransition = 1`. The points are the spline packet's control points verbatim. `waypoint_data.velocity` is `20.8988`, which is what makes the waypoint generator's own spline length arithmetic produce a lap of exactly 34016ms, so the sweep rate matches rather than the speed field. `creature_template_movement.Flight` is already set for this entry, so the generator flies it unchanged.
- **Script**: the arc is now `caster->GetAngle(dbTarget)`. `_barrageOrientation`, `_nextBarrageArc`, the `GetData` override and its `arc * 100 / 2pi` `uint32` round-trip, and both phase 4 resets are gone.
- `SetFacingTo` drops the transport transform for passengers, so phase 4 converts the bearing to a seat-local angle before applying it. Without this the beams come out at `chassis orientation + arc`.
- VX-001 parks its target on 33576 for the windup and barrage, as sniffed.
- The aura no longer hand-casts 63297 and 64042. Effect 2 of 63274 links 63300, whose two periodic effects already trigger them every 100ms, which is the beam cadence in the sniff.

### AI-assisted Pull Requests

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Claude Opus 5), for the sniff analysis and the implementation.
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes

## SOURCE:

The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [x] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Tests Performed:

This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Builds clean, and the implemented path was scored against the capture before testing: simulating the core's own spline evaluation over these waypoints gives a lap of exactly 34016ms and matches the measured beam axes at R = 0.999771, rms 1.23 deg, with no drift across 27 minutes.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes.

1. Pull Mimiron to phase 2 and watch one barrage. The beams should sweep clockwise, covering roughly 105 degrees over the 10s channel, smoothly.
2. Let two consecutive barrages run. The second must not start where the first did.
3. Wipe mid-barrage and re-pull. The sweep must not restart at the same angle, since the path keeps running.
4. Push to phase 4. The sweep should carry across the transition rather than jumping when VX-001 boards the chassis.
5. In phase 4, walk the assembled boss during a barrage. The beam should stay on the room-fixed sweep while the model turns.
6. Confirm the beams still fire, since they now come from the spell chain rather than the script.

## Known Issues and TODO List:

- [ ] The waypoint generator relaunches the path each lap rather than using a cyclic spline, so there is a seam once per 34s that a single cyclic spline would not have.
