### PR TITLE
chore(coderabbit-config): further reduce review noise

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -6,11 +6,50 @@ language: en-US
 reviews:
   profile: chill
   request_changes_workflow: false
+
+  # Keep the bot's output to actionable inline comments only. Everything below
+  # is boilerplate CodeRabbit posts on every PR regardless of findings, which
+  # buries the few real comments and trains maintainers to skip them.
   high_level_summary: false
-  poem: false
-  review_status: false
-  collapse_walkthrough: true
+  changed_files_summary: false
   sequence_diagrams: false
+  estimate_code_review_effort: false
+  assess_linked_issues: false
+  related_issues: false
+  related_prs: false
+  suggested_labels: false
+  suggested_reviewers: false
+  review_status: false
+  review_details: false
+  in_progress_fortune: false
+  poem: false
+  enable_prompt_for_ai_agents: false
+  collapse_walkthrough: true
+
+  pre_merge_checks:
+    docstrings:
+      mode: "off"
+    title:
+      mode: "off"
+    description:
+      mode: "off"
+    issue_assessment:
+      mode: "off"
+
+  finishing_touches:
+    docstrings:
+      enabled: false
+    unit_tests:
+      enabled: false
+    simplify:
+      enabled: false
+    autofix:
+      enabled: false
+    fix_ci:
+      enabled: false
+    resolve_merge_conflict:
+      enabled: false
+
   auto_review:
     enabled: true
     # Review on PR open only; don't re-post a walkthrough on every push.


### PR DESCRIPTION
Follow-up to #26235. CodeRabbit still posts a wall of boilerplate on every PR even when it has nothing to say, so its actual findings drown in it and maintainers have started ignoring the bot entirely.

Example, #27050, a two line SQL change. Around one useful inline comment it posted: a walkthrough file table, an effort estimate, four suggested labels (including "To Be Merged" on a PR nobody had reviewed yet), a five row pre-merge check table listing checks it had skipped, an "generate unit tests" checkbox, an autofix checkbox block, a run configuration panel, and the same finding a second time as an AI agent prompt.

This turns off every section that is not an actionable inline comment:

- Walkthrough content: `changed_files_summary`, `estimate_code_review_effort`, `assess_linked_issues`, `related_issues`, `related_prs`
- Suggestions: `suggested_labels`, `suggested_reviewers`
- Status panels: `review_status`, `review_details`, `in_progress_fortune`
- `enable_prompt_for_ai_agents`, which repeated every finding at roughly three times the length
- All four `pre_merge_checks` (title, description, docstrings, issue assessment)
- All six `finishing_touches` recipes (docstrings, unit tests, simplify, autofix, fix CI, resolve merge conflict)

Auto review stays on and unchanged, so nothing changes for contributors and no manual trigger is needed.

Two things have no config key and will still appear on the summary comment: the "Review Change Stack" banner and the "Thanks for using CodeRabbit" footer. Removing those would mean gating auto review behind a label or disabling it entirely, which is a bigger call and not proposed here.

## Changes Proposed:

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Repository tooling config only, no core, script or database change.

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [X] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Opus 5), to look up the CodeRabbit config schema and map each block posted on #27050 to the key that produces it.
- [X] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes no issue.

## SOURCE:

The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [X] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Every key and its default is from the CodeRabbit YAML reference and the published schema:
- https://docs.coderabbit.ai/reference/yaml-template
- https://docs.coderabbit.ai/pr-reviews/pre-merge-checks
- https://coderabbit.ai/integrations/schema.v2.json

## Tests Performed:

This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [X] This pull request requires further testing and may have edge cases to be tested.

Not testable in-game. The file parses as valid YAML against the v2 schema. Note that `mode: "off"` is quoted on purpose, unquoted `off` parses as boolean false in YAML and the schema expects the string.

CodeRabbit reads `.coderabbit.yml` from the PR branch, so its review of this PR is itself the check: it should come back with inline comments only, or nothing at all.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [X] This pull request requires further testing.

1. Compare CodeRabbit's output on this PR against its output on #27050.
2. After merge, open any small PR and confirm no walkthrough table, no pre-merge check table, no finishing touch checkboxes and no AI agent prompt blocks.

## Known Issues and TODO List:

- The change stack banner and the CodeRabbit footer stay, no config key exists for them.
- If the remaining summary comment is still considered too much, the next step is `reviews.auto_review.labels` so the bot only runs once a PR is marked ready for review. Happy to follow up with that if maintainers want it.

## How to Test AzerothCore PRs

When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
