### PR TITLE
chore(copilot-config): reduce review noise

### DIFF
--- a/.agents/docs/code-review.md
+++ b/.agents/docs/code-review.md
@@ -5,7 +5,7 @@ Reviewing a changeset or PR, your own before submission or a contributor's. The 
 line, not as background reading.
 
 - A posted review carries findings only: no summary of the change, no restating what it does, no
-  praise. When there is nothing to report, say nothing.
+  praise. When there is nothing to report, say so in one line and stop.
 - A finding names what is wrong, why it matters and the fix, on the offending line. Findings are
   bugs, crashes, lifetime and memory errors, data-integrity problems (most often a `DELETE` whose
   `WHERE` does not match the `INSERT` it precedes), injection, and violations of a rule written down

--- a/.agents/docs/code-review.md
+++ b/.agents/docs/code-review.md
@@ -4,12 +4,11 @@ Reviewing a changeset or PR, your own before submission or a contributor's. The 
 (`cpp-guidelines.md`, `sql-guidelines.md`, `cpp-scripts.md`) apply as a checklist to every changed
 line, not as background reading.
 
-- A posted review carries findings only: no summary of the change, no restating what it does, no
-  praise. When there is nothing to report, say so in one line and stop.
+- A posted review carries findings only: no summary, no praise. Nothing to report means one line
+  saying so.
 - A finding names what is wrong, why it matters and the fix, on the offending line. Findings are
-  bugs, crashes, lifetime and memory errors, data-integrity problems (most often a `DELETE` whose
-  `WHERE` does not match the `INSERT` it precedes), injection, and violations of a rule written down
-  in AGENTS.md or `.agents/docs/`. Taste that no rule covers is not a finding.
+  bugs, crashes, lifetime and memory errors, data-integrity problems, injection, and violations of
+  a rule written down in AGENTS.md or `.agents/docs/`; taste no rule covers is not a finding.
 - Review codestyle on every changed line, even when style is not the change's subject. Run both
   linters and report violations as findings: `python apps/codestyle/codestyle-cpp.py` and
   `python apps/codestyle/codestyle-sql.py`.

--- a/.agents/docs/code-review.md
+++ b/.agents/docs/code-review.md
@@ -4,6 +4,12 @@ Reviewing a changeset or PR, your own before submission or a contributor's. The 
 (`cpp-guidelines.md`, `sql-guidelines.md`, `cpp-scripts.md`) apply as a checklist to every changed
 line, not as background reading.
 
+- A posted review carries findings only: no summary of the change, no restating what it does, no
+  praise. When there is nothing to report, say nothing.
+- A finding names what is wrong, why it matters and the fix, on the offending line. Findings are
+  bugs, crashes, lifetime and memory errors, data-integrity problems (most often a `DELETE` whose
+  `WHERE` does not match the `INSERT` it precedes), injection, and violations of a rule written down
+  in AGENTS.md or `.agents/docs/`. Taste that no rule covers is not a finding.
 - Review codestyle on every changed line, even when style is not the change's subject. Run both
   linters and report violations as findings: `python apps/codestyle/codestyle-cpp.py` and
   `python apps/codestyle/codestyle-sql.py`.

--- a/.github/agents/pr-reviewer.md
+++ b/.github/agents/pr-reviewer.md
@@ -108,10 +108,9 @@ Based on AGENTS.md, always verify:
 
 ## Feedback Style
 
-- Report defects only. Do not summarize the PR, restate what a change does, or point out good practices
-- Say nothing when there is nothing to report
-- Put each finding in an inline comment on the offending line: what is wrong, why it matters, and the fix
+- Be constructive and educational
 - Reference specific sections of AGENTS.md, C++ Code Standards, or SQL Standards when applicable
 - Suggest specific fixes with code examples if necessary
+- Highlight both issues and good practices
 - For C++ issues, cite specific rule from C++ Code Standards wiki
 - For SQL issues, cite specific rule from SQL Standards wiki

--- a/.github/agents/pr-reviewer.md
+++ b/.github/agents/pr-reviewer.md
@@ -108,9 +108,10 @@ Based on AGENTS.md, always verify:
 
 ## Feedback Style
 
-- Be constructive and educational
+- Report defects only. Do not summarize the PR, restate what a change does, or point out good practices
+- Say nothing when there is nothing to report
+- Put each finding in an inline comment on the offending line: what is wrong, why it matters, and the fix
 - Reference specific sections of AGENTS.md, C++ Code Standards, or SQL Standards when applicable
 - Suggest specific fixes with code examples if necessary
-- Highlight both issues and good practices
 - For C++ issues, cite specific rule from C++ Code Standards wiki
 - For SQL issues, cite specific rule from SQL Standards wiki

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,5 +6,5 @@ For pull request review, `.agents/docs/code-review.md` defines what counts as a 
 ## Review output
 
 - No overview paragraph, no "Changes" bullet list, no per-file table. The diff is on the same page.
-- Keep the review body empty. Findings belong in inline comments on the offending lines.
-- Post nothing at all when there is nothing to report.
+- Findings belong in inline comments on the offending lines, not in the review body.
+- When there are no findings, post only a single line saying so. No summary, no file list.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,38 @@
+# Copilot instructions for AzerothCore
+
+AzerothCore is a C++ MMORPG server emulator for World of Warcraft 3.3.5a (WotLK), built with CMake and backed by
+MySQL. The project's conventions live in `AGENTS.md`, which routes to the detailed guides in `.agents/docs/`. Read
+the guides that match what you are looking at before commenting on it.
+
+## Code review output
+
+Every pull request is read by a human maintainer. A review is only worth their time when it points at something
+they would otherwise miss, so restrict the output to that.
+
+- Do not open a review with a summary of the pull request. No overview paragraph, no "Changes" bullet list, no
+  per-file table. The diff is on the same page and the author already described the change.
+- Do not restate what a change does, and do not praise it or point out good practices.
+- If there is nothing concrete to report, post no comments at all. Silence is the correct output for a clean
+  pull request.
+- Put findings in inline comments on the offending lines. Keep the review body empty.
+- Write each comment as: what is wrong, why it matters, and the fix. Two or three sentences, no preamble, no
+  emoji, no headings.
+
+## What is worth a comment
+
+Only comment when you can name a concrete defect:
+
+- A bug, crash, deadlock, memory error, or use of an object past its lifetime.
+- A data-integrity problem, most often a SQL `DELETE` whose `WHERE` clause is broader or narrower than the
+  matching `INSERT`.
+- A security issue, such as an unescaped query built by string concatenation instead of a `PreparedStatement`.
+- A violation of a rule that is actually written down in `AGENTS.md` or `.agents/docs/`.
+
+Do not comment on:
+
+- Style questions that no project rule covers. Taste is not a finding.
+- Anything CI already enforces. The codestyle scripts under `apps/codestyle/` and the `-Werror` builds report
+  their own failures, and repeating them adds nothing.
+- Missing tests, docstrings, or code comments, unless their absence is itself the defect being reported.
+- Files under `data/sql/base/`, `data/sql/archive/`, `data/sql/updates/db_*/`, or `deps/`. Those are immutable or
+  vendored. The one thing worth saying about them is that a pull request should not be touching them at all.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,10 +1,10 @@
-# Copilot instructions for AzerothCore
+# Copilot instructions
 
-Project conventions live in `AGENTS.md`, which routes to the task-scoped guides in `.agents/docs/`. Follow those.
-For pull request review, `.agents/docs/code-review.md` defines what counts as a finding and how to report it.
+Follow `AGENTS.md` and the guides it routes to in `.agents/docs/`. For pull request review, follow
+`.agents/docs/code-review.md`.
 
 ## Review output
 
-- No overview paragraph, no "Changes" bullet list, no per-file table. The diff is on the same page.
-- Findings belong in inline comments on the offending lines, not in the review body.
-- When there are no findings, post only a single line saying so. No summary, no file list.
+- No overview paragraph, no "Changes" list, no per-file table.
+- Put findings in inline comments on the offending lines, not the review body.
+- With no findings, post one line saying so and nothing else.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,38 +1,10 @@
 # Copilot instructions for AzerothCore
 
-AzerothCore is a C++ MMORPG server emulator for World of Warcraft 3.3.5a (WotLK), built with CMake and backed by
-MySQL. The project's conventions live in `AGENTS.md`, which routes to the detailed guides in `.agents/docs/`. Read
-the guides that match what you are looking at before commenting on it.
+Project conventions live in `AGENTS.md`, which routes to the task-scoped guides in `.agents/docs/`. Follow those.
+For pull request review, `.agents/docs/code-review.md` defines what counts as a finding and how to report it.
 
-## Code review output
+## Review output
 
-Every pull request is read by a human maintainer. A review is only worth their time when it points at something
-they would otherwise miss, so restrict the output to that.
-
-- Do not open a review with a summary of the pull request. No overview paragraph, no "Changes" bullet list, no
-  per-file table. The diff is on the same page and the author already described the change.
-- Do not restate what a change does, and do not praise it or point out good practices.
-- If there is nothing concrete to report, post no comments at all. Silence is the correct output for a clean
-  pull request.
-- Put findings in inline comments on the offending lines. Keep the review body empty.
-- Write each comment as: what is wrong, why it matters, and the fix. Two or three sentences, no preamble, no
-  emoji, no headings.
-
-## What is worth a comment
-
-Only comment when you can name a concrete defect:
-
-- A bug, crash, deadlock, memory error, or use of an object past its lifetime.
-- A data-integrity problem, most often a SQL `DELETE` whose `WHERE` clause is broader or narrower than the
-  matching `INSERT`.
-- A security issue, such as an unescaped query built by string concatenation instead of a `PreparedStatement`.
-- A violation of a rule that is actually written down in `AGENTS.md` or `.agents/docs/`.
-
-Do not comment on:
-
-- Style questions that no project rule covers. Taste is not a finding.
-- Anything CI already enforces. The codestyle scripts under `apps/codestyle/` and the `-Werror` builds report
-  their own failures, and repeating them adds nothing.
-- Missing tests, docstrings, or code comments, unless their absence is itself the defect being reported.
-- Files under `data/sql/base/`, `data/sql/archive/`, `data/sql/updates/db_*/`, or `deps/`. Those are immutable or
-  vendored. The one thing worth saying about them is that a pull request should not be touching them at all.
+- No overview paragraph, no "Changes" bullet list, no per-file table. The diff is on the same page.
+- Keep the review body empty. Findings belong in inline comments on the offending lines.
+- Post nothing at all when there is nothing to report.


### PR DESCRIPTION
Same problem as #27083, other bot.

Copilot code review opens every PR with an overview, a "Changes" list and a per-file table, whether or not it found anything. On #27004 that table has four rows directly under "generated no comments".

Copilot has no config file. It does already read root `AGENTS.md`, so project standards reach it. What it cannot learn from anywhere is the shape of the review it should post, so `.github/copilot-instructions.md` carries only that: no overview, no per-file table, findings inline rather than in the review body, and a single line when there is nothing to report so it stays visible that the review ran.

What counts as a finding is not Copilot-specific, so it goes into `.agents/docs/code-review.md`, the doc AGENTS.md already routes reviewers to, where it applies to every reviewing agent.

For context on #24655, which aimed at the same goal: it put the instructions in `.github/agents/pr-reviewer.md`. Copilot code review does not read that directory, its instruction sources are `.github/copilot-instructions.md`, `.github/instructions/**` and `AGENTS.md`. This PR leaves that file untouched.

Best effort, not a config key: instructions steer a model, they do not disable a feature. Going further needs repository settings and an admin (review effort level, and the ruleset that auto-requests a review).

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Agent docs and tooling config only.

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [X] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Opus 5)
- [X] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes no issue.

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [X] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Which instruction files Copilot code review reads, per GitHub docs:
- https://docs.github.com/en/copilot/how-tos/configure-custom-instructions/add-repository-instructions
- https://docs.github.com/en/copilot/how-tos/use-copilot-agents/request-a-code-review/use-code-review

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [X] This pull request requires further testing and may have edge cases to be tested.

Not testable in-game. Copilot reads instructions from the PR branch, so its review of this PR is the first data point.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [X] This pull request requires further testing. Provide steps to test your changes.

1. Compare Copilot's review here against #27004 and #27078.
2. After merge, watch the next few PRs: no overview, no per-file table, no comment on a clean PR.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- `.github/agents/pr-reviewer.md` never takes effect: custom agents require YAML frontmatter with a `description`, which it lacks, and Copilot code review does not read custom agents in any case. Worth a separate look, either add the frontmatter and point it at a surface that uses it, or drop the directory.
- The "Add a code-review agent skill" footer on every Copilot review cannot be turned off from the repo.

## How to Test AzerothCore PRs

When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
