### PR TITLE
fix(copilot-config): drop the unsupported review-output rules

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,7 +1,7 @@
 # Copilot instructions
 
-For pull request review, follow `.agents/docs/code-review.md`.
+Review pull requests per `.agents/docs/code-review.md`.
 
 Instructions about the review's format or its overview comment are
 [unsupported](https://docs.github.com/en/copilot/tutorials/customize-code-review#unsupported-instruction-types)
-and get ignored, so they do not belong here.
+and do not belong here.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,10 +1,7 @@
 # Copilot instructions
 
-Follow `AGENTS.md` and the guides it routes to in `.agents/docs/`. For pull request review, follow
-`.agents/docs/code-review.md`.
+For pull request review, follow `.agents/docs/code-review.md`.
 
-## Review output
-
-- No overview paragraph, no "Changes" list, no per-file table.
-- Put findings in inline comments on the offending lines, not the review body.
-- With no findings, post one line saying so and nothing else.
+Instructions about the review's format or its overview comment are
+[unsupported](https://docs.github.com/en/copilot/tutorials/customize-code-review#unsupported-instruction-types)
+and get ignored, so they do not belong here.


### PR DESCRIPTION
Follow-up to #27084, which added rules GitHub documents as unsupported.

[Unsupported instruction types](https://docs.github.com/en/copilot/tutorials/customize-code-review#unsupported-instruction-types) lists two categories that between them cover every rule in the "Review output" section: "user experience or formatting changes" and "pull request overview modifications". #27085 confirmed it in practice, the overview, the "Changes" list and the per-file table all came back on a PR whose branch carried those rules.

What is left is the one instruction the docs do support, an in-repo pointer to the review guide, plus a note recording why the rest is not coming back. The `AGENTS.md` line goes too, Copilot reads that file natively.

The review rules themselves stay in `.agents/docs/code-review.md`, where they apply to every reviewing agent rather than to Copilot alone.

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Tooling config only.

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [X] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Opus 5)
- [X] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes no issue.

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [X] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

https://docs.github.com/en/copilot/tutorials/customize-code-review#unsupported-instruction-types

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [X] This pull request requires further testing and may have edge cases to be tested.

Not testable in-game. Docs only.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [X] This pull request requires further testing. Provide steps to test your changes.

1. Copilot's output should not change, since the removed rules were already being ignored. #27085 is the reference.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- This leaves the file doing very little. The alternative is deleting it and relying on Copilot following AGENTS.md's routing to the review guide, which is plausible but unproven. The explicit pointer is the one thing the docs guarantee is supported, so it stays.

## How to Test AzerothCore PRs

When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
