### PR TITLE
fix(Scripts/Commands): .account set gmlevel wipes access on the wrong realm

### DIFF
--- a/src/server/scripts/Commands/cs_account.cpp
+++ b/src/server/scripts/Commands/cs_account.cpp
@@ -833,7 +833,7 @@ public:
             return false;
         }
 
-        // If gmRealmID is -1, delete access on every realm, else only on the requested one
+        // If gmRealmID is -1, delete access on every realm, else on the requested one and any all-realms row
         LoginDatabasePreparedStatement* stmt;
 
         if (gmRealmID == -1)

--- a/src/server/scripts/Commands/cs_account.cpp
+++ b/src/server/scripts/Commands/cs_account.cpp
@@ -826,14 +826,14 @@ public:
             }
         }
 
-        // Check if provided realm.Id.Realm has a negative value other than -1
+        // Check if provided gmRealmID has a negative value other than -1
         if (gmRealmID < -1)
         {
             handler->SendErrorMessage(LANG_INVALID_REALMID);
             return false;
         }
 
-        // If gmRealmID is -1, delete all values for the account id, else, insert values for the specific realm.Id.Realm
+        // If gmRealmID is -1, delete access on every realm, else only on the requested one
         LoginDatabasePreparedStatement* stmt;
 
         if (gmRealmID == -1)
@@ -845,7 +845,7 @@ public:
         {
             stmt = LoginDatabase.GetPreparedStatement(LOGIN_DEL_ACCOUNT_ACCESS_BY_REALM);
             stmt->SetData(0, targetAccountId);
-            stmt->SetData(1, realm.Id.Realm);
+            stmt->SetData(1, gmRealmID);
         }
 
         LoginDatabase.Execute(stmt);


### PR DESCRIPTION
`.account set gmlevel` deletes the account's access rows using the realm the GM is currently on instead of the realm that was passed in. The `INSERT` right below it already uses `gmRealmID`, so the two disagree.

The prepared statement is `DELETE FROM account_access WHERE id = ? AND (RealmID = ? OR RealmID = -1)`, and `account_access` has `PRIMARY KEY (id, RealmID)`.

For a GM sitting on realm 1, `.account set gmlevel someacct 3 2` does this:

- the account loses its access on realm 1, which nobody asked to touch
- realm 2's existing row is left alone, so the `INSERT` hits the primary key and fails. It's an async execute, so nothing surfaces and the GM still gets "You change security level of account ...".

Single realm setups never see it, since there `gmRealmID` and `realm.Id.Realm` hold the same value.

The two comments nearby said `realm.Id.Realm` where they meant the requested realm, which is the same mixup, so they're corrected as well.

## Changes Proposed:
-  [X] Core (units, players, creatures, game systems).

### AI-assisted Pull Requests

- [X] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request.
   - Tools/models used: Claude Code, Claude Opus 5
- [X] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes no issue.

## SOURCE:
Code inspection: the `DELETE` and the `INSERT` in the same block disagree on which realm they act on.

## Tests Performed:
- [ ] Tested in-game by the author.
- [X] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

Needs a two realm setup:

1. give an account access on realm 1 and realm 2
2. from realm 1, run `.account set gmlevel <account> 3 2`
3. before the fix, realm 1's row is gone and realm 2's level is unchanged. After it, realm 2 is updated and realm 1 is untouched
4. worth also checking that `#realmID` of -1 still clears every realm, and that setting a level for the current realm still behaves
