### PR TITLE
fix(Core/Spells): Blood Tap converts the rune it brings back

### DIFF
--- a/data/sql/updates/pending_db_world/rev_17864847660000000.sql
+++ b/data/sql/updates/pending_db_world/rev_17864847660000000.sql
@@ -1,0 +1,5 @@
+-- Blood Tap (45529) is now handled by a spell/aura script pair, so that the rune the spell
+-- brings back is the same one its aura converts into a death rune.
+DELETE FROM `spell_script_names` WHERE `spell_id` = 45529 AND `ScriptName` = 'spell_dk_blood_tap';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(45529, 'spell_dk_blood_tap');

--- a/src/server/game/Spells/Spell.h
+++ b/src/server/game/Spells/Spell.h
@@ -580,6 +580,9 @@ public:
     void SetDelayStart(uint64 m_time) { m_delayStart = m_time; }
     uint64 GetDelayMoment() const { return m_delayMoment; }
     uint64 GetDelayTrajectory() const { return m_delayTrajectory; }
+    // SMSG_SPELL_GO reports the rune mask from before the cast, so a script taking over
+    // SPELL_EFFECT_ACTIVATE_RUNE has to record it itself
+    void SetRuneState(uint8 state) { m_runesState = state; }
 
     uint64 CalculateDelayMomentForDst() const;
     void RecalculateDelayMomentForDst();

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -67,6 +67,11 @@
 //  see: https://github.com/azerothcore/azerothcore-wotlk/issues/9766
 #include "GridNotifiersImpl.h"
 
+enum DeathKnightSpells
+{
+    SPELL_DK_EMPOWER_RUNE_WEAPON    = 47568
+};
+
 pEffect SpellEffects[TOTAL_SPELL_EFFECTS] =
 {
     &Spell::EffectNULL,                                     //  0
@@ -5808,41 +5813,19 @@ void Spell::EffectActivateRune(SpellEffIndex effIndex)
 
     uint32 count = damage;
     if (count == 0) count = 1;
+
     for (uint32 j = 0; j < MAX_RUNES && count > 0; ++j)
     {
         if (player->GetRuneCooldown(j) && player->GetCurrentRune(j) == RuneType(m_spellInfo->Effects[effIndex].MiscValue))
         {
-            if (m_spellInfo->Id == 45529)
-                if (player->GetBaseRune(j) != RuneType(m_spellInfo->Effects[effIndex].MiscValueB))
-                    continue;
             player->SetRuneCooldown(j, 0);
             player->SetGracePeriod(j, player->IsInCombat()); // xinef: reset grace period
             --count;
         }
     }
 
-    // Blood Tap
-    if (m_spellInfo->Id == 45529 && count > 0)
-    {
-        for (uint32 l = 0; l < MAX_RUNES && count > 0; ++l)
-        {
-            // Check if both runes are on cd as that is the only time when this needs to come into effect
-            if ((player->GetRuneCooldown(l) && player->GetCurrentRune(l) == RuneType(m_spellInfo->Effects[effIndex].MiscValueB)) && (player->GetRuneCooldown(l + 1) && player->GetCurrentRune(l + 1) == RuneType(m_spellInfo->Effects[effIndex].MiscValueB)))
-            {
-                // Should always update the rune with the lowest cd
-                if (player->GetRuneCooldown(l) >= player->GetRuneCooldown(l + 1))
-                    l++;
-                player->SetRuneCooldown(l, 0);
-                player->SetGracePeriod(l, player->IsInCombat()); // xinef: reset grace period
-                --count;
-            }
-            else
-                break;
-        }
-    }
-
     // Empower rune weapon
-    if (m_spellInfo->Id == 47568)
+    if (m_spellInfo->Id == SPELL_DK_EMPOWER_RUNE_WEAPON)
     {
         // Need to do this just once
         if (effIndex != 0)

--- a/src/server/scripts/Spells/spell_dk.cpp
+++ b/src/server/scripts/Spells/spell_dk.cpp
@@ -44,6 +44,7 @@ enum DeathKnightSpells
     SPELL_DK_BLACK_ICE_R1                       = 49140,
     SPELL_DK_BLOOD_BOIL_TRIGGERED               = 65658,
     SPELL_DK_BLOOD_GORGED_HEAL                  = 50454,
+    SPELL_DK_BLOOD_TAP_VISUAL                   = 47804,
     SPELL_DK_BLOOD_PRESENCE                     = 48266,
     SPELL_DK_CORPSE_EXPLOSION_TRIGGERED         = 43999,
     SPELL_DK_CORPSE_EXPLOSION_VISUAL            = 51270,
@@ -456,6 +457,115 @@ class spell_dk_chains_of_ice_aura : public AuraScript
     {
         OnEffectUpdatePeriodic += AuraEffectUpdatePeriodicFn(spell_dk_chains_of_ice_aura::HandlePeriodic, EFFECT_1, SPELL_AURA_PERIODIC_DUMMY);
     }
+};
+
+// 45529 - Blood Tap
+class spell_dk_blood_tap_aura : public AuraScript
+{
+    PrepareAuraScript(spell_dk_blood_tap_aura);
+
+public:
+    void SetRuneIndex(uint8 index) { _runeIndex = index; }
+
+private:
+    void HandleApply(AuraEffect const* aurEff, AuraEffectHandleModes /*mode*/)
+    {
+        // The default handler walks the slots from 0, so it can convert a rune other than the
+        // one the spell just brought back. The spell script tells us which one it was.
+        PreventDefaultAction();
+
+        if (_runeIndex >= MAX_RUNES)
+            return;
+
+        Player* player = GetTarget()->ToPlayer();
+        if (!player || !player->IsClass(CLASS_DEATH_KNIGHT, CLASS_CONTEXT_ABILITY))
+            return;
+
+        // Taking ownership of the slot matters even when it already shows a death rune. Reaping
+        // and friends are passive, so RestoreBaseRune turns their runes back to blood as soon as
+        // they are spent, while ours survive being spent for the full duration.
+        player->AddRuneByAuraEffect(_runeIndex, RuneType(aurEff->GetMiscValueB()), aurEff);
+    }
+
+    void Register() override
+    {
+        OnEffectApply += AuraEffectApplyFn(spell_dk_blood_tap_aura::HandleApply, EFFECT_1, SPELL_AURA_CONVERT_RUNE, AURA_EFFECT_HANDLE_REAL);
+    }
+
+    uint8 _runeIndex = MAX_RUNES;
+};
+
+class spell_dk_blood_tap : public SpellScript
+{
+    PrepareSpellScript(spell_dk_blood_tap);
+
+    void HandleActivateRune(SpellEffIndex effIndex)
+    {
+        PreventHitDefaultEffect(effIndex);
+
+        Player* player = GetCaster()->ToPlayer();
+        if (!player || !player->IsClass(CLASS_DEATH_KNIGHT, CLASS_CONTEXT_ABILITY))
+            return;
+
+        GetSpell()->SetRuneState(player->GetRunesState());
+
+        // The DBC asks for a death rune here, so matching on the rune's current type misses a
+        // spent blood rune that has not been converted yet. Go by the slot's base type instead.
+        RuneType const baseType = RuneType(GetSpellInfo()->Effects[EFFECT_0].MiscValueB);
+        int32 count = GetEffectValue();
+        if (count <= 0)
+            count = 1;
+
+        while (count > 0)
+        {
+            uint8 spent = MAX_RUNES;
+            for (uint8 i = 0; i < MAX_RUNES; ++i)
+            {
+                // A rune that is already up keeps its grace period, so leave it alone
+                if (player->GetBaseRune(i) != baseType || !player->GetRuneCooldown(i))
+                    continue;
+                if (spent == MAX_RUNES || player->GetRuneCooldown(i) < player->GetRuneCooldown(spent))
+                    spent = i;
+            }
+
+            if (spent == MAX_RUNES)
+                break;
+
+            player->SetRuneCooldown(spent, 0);
+            player->SetGracePeriod(spent, player->IsInCombat()); // xinef: reset grace period
+            _runeIndex = spent;
+            --count;
+        }
+
+        // Nothing was spent, so fall back to what the default aura handler would have done and
+        // convert a rune that is already up
+        if (_runeIndex >= MAX_RUNES)
+            for (uint8 i = 0; i < MAX_RUNES; ++i)
+                if (player->GetBaseRune(i) == baseType && !player->GetRuneCooldown(i) && player->GetCurrentRune(i) == baseType)
+                {
+                    _runeIndex = i;
+                    break;
+                }
+
+        // Carries the rune list to the client, which otherwise keeps showing the rune we just
+        // handed back as still on cooldown. The core handler cast this too
+        player->CastSpell(player, SPELL_DK_BLOOD_TAP_VISUAL, true);
+    }
+
+    void SetRuneIndex(SpellEffIndex /*effIndex*/)
+    {
+        if (Aura* aura = GetHitAura())
+            if (spell_dk_blood_tap_aura* script = aura->GetScript<spell_dk_blood_tap_aura>("spell_dk_blood_tap"))
+                script->SetRuneIndex(_runeIndex);
+    }
+
+    void Register() override
+    {
+        OnEffectLaunch += SpellEffectFn(spell_dk_blood_tap::HandleActivateRune, EFFECT_0, SPELL_EFFECT_ACTIVATE_RUNE);
+        OnEffectHitTarget += SpellEffectFn(spell_dk_blood_tap::SetRuneIndex, EFFECT_1, SPELL_EFFECT_APPLY_AURA);
+    }
+
+    uint8 _runeIndex = MAX_RUNES;
 };
 
 // 50452 - Bloodworm
@@ -3024,6 +3134,7 @@ void AddSC_deathknight_spell_scripts()
     RegisterSpellScript(spell_dk_anti_magic_zone);
     RegisterSpellScript(spell_dk_blood_boil);
     RegisterSpellScript(spell_dk_blood_gorged);
+    RegisterSpellAndAuraScriptPair(spell_dk_blood_tap, spell_dk_blood_tap_aura);
     RegisterSpellScript(spell_dk_corpse_explosion);
     RegisterSpellScript(spell_dk_death_coil);
     RegisterSpellScript(spell_dk_death_gate);


### PR DESCRIPTION
## Changes Proposed:

Blood Tap chooses which rune to refresh by the type the rune is currently showing, and the spell's
own DBC row makes that the wrong question to ask. Effects of 45529, read from `Spell.dbc`:

| # | Effect | MiscValue | MiscValueB |
| --- | --- | --- | --- |
| 0 | `SPELL_EFFECT_ACTIVATE_RUNE` | 3 (`RUNE_DEATH`) | 0 (`RUNE_BLOOD`) |
| 1 | `SPELL_EFFECT_APPLY_AURA`, `SPELL_AURA_CONVERT_RUNE` | 0 (`RUNE_BLOOD`) | 3 (`RUNE_DEATH`) |
| 2 | `SPELL_EFFECT_ENERGIZE` | 6 (`POWER_RUNIC_POWER`) | 0 |

Effect 0 asks for a death rune, so filtering on the current type only ever finds runes that are
already converted. A blood rune that is spent and still showing blood never matches. There is a
fallback loop below the main one that does look at `MiscValueB`, but it only fires when both runes
of the pair are spent and it `break`s as soon as one isn't, which is why the reporter sees it work
only with two death runes and one of them empty. On top of that it pairs slots by walking one at a
time, so it forms (1,2) and (3,4), and those cross rune types (slots are 0-1 blood, 2-3 unholy,
4-5 frost), and it reads `runes[6]` when the index reaches 5. `MAX_RUNES` is 6 and the accessors in
`Player.h` index `m_runes->runes[index]` with no bounds check.

Effect 1 is broken independently. It walks the slots from index 0 and converts the first blood rune
that isn't on cooldown, which has nothing to do with the rune effect 0 acted on. When effect 0
refreshes nothing, that's the rune the player already had up, which is the "it overwrites my
available rune" part of the report.

Both effects now live in a spell/aura script pair, the way TrinityCore handles this on their 3.3.5
branch. Nothing else changes about how the aura works: it is still the DBC's own
`SPELL_AURA_CONVERT_RUNE`, just aimed at the right slot.

The spell script takes effect 0. It selects by the slot's base rune type, taken from `MiscValueB` so
nothing about which slots are blood is hardcoded; `Player::IsBaseRuneSlotsOnCooldown` already walks
the slots the same way. It skips slots that are already up, so their grace period survives
(`SetGracePeriod` rides along with every `SetRuneCooldown(x, 0)`), and refreshes the one with the
lowest remaining cooldown. It honours the effect's value, which is 1 for Blood Tap today. Then it
hands that slot to the aura script.

The aura script takes effect 1 and converts exactly that slot, passing its own `AuraEffect` along.
That is what keeps the revert selective: `RemoveRunesByAuraEffect` only restores slots whose
`ConvertAura` matches, so when Blood Tap's 20 seconds are up it reverts its own conversion and
nothing else.

It converts unconditionally, which is worth spelling out because the common case looks like it
shouldn't. Reaping converts a blood rune the moment it is **spent**, so the rune Blood Tap brings
back is usually already a death rune owned by that talent, and Blood Tap takes that ownership over.
That is deliberate, and it is what upstream does. `RestoreBaseRune` turns a rune back to blood as
soon as it is spent when the owning aura is passive; the death rune talents are passive and Blood
Tap is not. Leave the talent the slot and Blood Tap's death rune dies on first use with its buff
still showing, which is not what the spell promises. The cost of taking it is the other direction: a
rune the player never spends reverts at Blood Tap's 20 seconds even if the talent had time left.
Since the talent resets its 30 second timer when the rune goes on cooldown, and a rune's cooldown is
10 seconds, the talent always has at least 20 seconds left at that point, so what is lost is only
the surplus.

`Spell::SetRuneState` is new. `SMSG_SPELL_GO` reports the rune mask from before the cast, and a
script taking over `SPELL_EFFECT_ACTIVATE_RUNE` has to record it itself.

Taking Blood Tap out of `Spell::EffectActivateRune` means its branch there is gone, and the fallback
loop with it. Empower Rune Weapon and every other spell reaching that function keep the generic loop
untouched, and its remaining spell id is now a named constant instead of a bare literal.

TrinityCore also fixed the effect 0 half separately on 3.3.5 in
[868dcb0](https://github.com/TrinityCore/TrinityCore/commit/868dcb0): `GetCurrentRune` to
`GetBaseRune` plus a bound on the loop. That keeps the "both runes spent" requirement, so on its own
it wouldn't cover the case in the issue.

Supersedes #27076, which I closed myself.

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code with Claude Opus 5, for both the code change and this
     description. It ran a fixed pipeline of agent skills, one per phase, each leaving a document
     behind: `fetch-ticket` for the issue, `azerothcore-research` for the research below,
     `refine-ticket` for the requirements, `create-implementation-plan` for the plan, then the plan
     executed step by step, `generate-pr-description` for this text, and `self-review` before
     publishing, which put the commit through a fresh-context reviewer and produced the report
     below. Every piece of game data quoted here came from azerothMCP v2, a local MCP server that
     reads this server's own DBC files, world DB and source tree, so the spell values are what the
     server actually runs and not a wiki transcription.
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #27073
- Escalated from [chromiecraft#9995](https://github.com/chromiecraft/chromiecraft/issues/9995)

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

- The script pair comes from TrinityCore [`d1dc0e2dc1`](https://github.com/TrinityCore/TrinityCore/commit/d1dc0e2dc1) ("Scripts/DK: correctly handle Blood Tap") by ccrs, credited with a `Co-authored-by` trailer on the follow-up commit. The rune selection is rewritten against AC.
- The spell's own `Spell.dbc` row (the effect table above), which is where the tooltip text comes
  from: "Instantly activates a blood rune and converts it into a death rune for the next 20 sec."
- [TrinityCore 868dcb0](https://github.com/TrinityCore/TrinityCore/commit/868dcb0), [PR 17132](https://github.com/TrinityCore/TrinityCore/pull/17132), the
  equivalent fix on their 3.3.5 branch.
- The video in the issue.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Tested in game on a level 80 Death Knight, all confirmed working:

- The scenario in the issue: two Blood Strikes, wait for one rune to come back, Blood Tap. It
  activates the rune that was still spent, and that same rune is the one that turns into a death
  rune.
- Both blood runes up: nothing is reset, one turns into a death rune, and it goes back to blood
  when the 20 seconds are up.
- With Reaping at 100%: spend a blood rune so the talent converts it, Blood Tap it back, then spend
  it before the aura expires. The rune stays a death rune while spent and comes back as one, which
  is the case that needs Blood Tap to own the conversion rather than the talent.
- All six runes spent: Blood Tap brings back one blood rune, nothing else moves.
- Regression, Empower Rune Weapon: still restores all six runes, with and without runes spent
  across types.
- Selection order: with both blood runes spent at different times, it picks the one closest to
  coming back, not the one with the lower index. Checked both ways round.

A rune that is already up keeping its grace period is not observable in game: the loop skips slots
with no cooldown before touching anything, so `SetGracePeriod` never runs on them.

worldserver builds clean and both `codestyle-cpp.py` and `codestyle-sql.py` pass.

## Self-review

**Outcome** 5 findings — 5 fixed — final round clean

**Reviewed** `573068b35` (`fix/dk-blood-tap-base-rune` vs `master`, merge-base diff — 4 files, +126 −24)

**By** Claude Code (Claude Agent SDK), claude-opus-5 — self-review v0.5, 2026-08-11

`codestyle-cpp.py` and `codestyle-sql.py` pass, worldserver builds clean, three rounds by a
fresh-context reviewer.

<details>
<summary>Review details (3 rounds)</summary>

**Intent** Blood Tap (spell 45529) should instantly activate one spent blood rune and convert that
same rune into a death rune for 20 s. It failed to recognise a spent blood rune that had not been
converted yet, and its aura converted whichever blood rune happened to be available rather than the
one the spell acted on.

**Project rules** `.agents/docs/self-review-rules.md` found and applied

## Round 1 — 4 findings

1. Taking the effect over dropped the `CastSpell(47804)` the core handler ran at the end, which
   exists only to push the rune list to the client → **fixed**: cast from the script, same position.
2. `AddRuneByAuraEffect` rebinds the slot's `ConvertAura` unconditionally, so Blood Tap took over a
   slot Reaping owned → **fixed**, then revised in round 2.
3. `SPELL_DK_BLOOD_TAP` was added to the enum and never used → **fixed**: removed, and
   `SPELL_DK_BLOOD_TAP_VISUAL = 47804` took its place.
4. The SQL file used a date-prefixed name instead of the `rev_<timestamp>.sql` that `create_sql.sh`
   generates → **fixed**: renamed.

## Round 2 — 1 finding

5. The fix for finding 2 overshot. `RestoreBaseRune` reverts a rune to blood as soon as it is spent
   when the owning aura is passive, and the death rune talents are passive while Blood Tap is not,
   so leaving the talent the slot meant Blood Tap's death rune died on first use with its buff still
   showing → **fixed**: the guard was removed and the aura converts unconditionally, as upstream
   does. Accepted cost: a rune the player never spends reverts at Blood Tap's 20 s even if the
   talent had time left.

## Round 3 — clean

No findings. The reviewer separately confirmed that Blood Tap's aura cannot be force-removed by a
rune restore, that the talents' own revert paths are gated on spell icons Blood Tap does not match,
and that no `AuraEffect` pointer can dangle across the conversion.

</details>

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

Level 80 Death Knight with Reaping (`.learn all my class`), hitting a dummy. Watch the rune bar
after each step.

1. Cast Blood Strike twice, wait for one blood rune to come back and convert to a death rune, then
   cast Blood Tap. Both runes should end up available.
2. With one blood slot up and the other spent, Blood Tap should refresh the spent one. Try it with
   slot 0 up and with slot 1 up.
3. With both blood slots spent on different cooldowns, it should refresh the one closest to coming
   back.
4. With both blood slots already up, Blood Tap should not reset anything, and the next rune you
   spend from those slots should still come back in its normal time.
5. With all six runes spent, Blood Tap should refresh a blood one.
6. With Reaping talented, spend a blood rune so the talent converts it, then Blood Tap it back and
   wait out the 20 seconds. The rune should stay a death rune: Blood Tap must not revert a
   conversion that belongs to the talent.
7. Cast Blood Tap on a blood rune that is not converted, wait out the 20 seconds, and the rune
   should go back to blood.
8. Regression: Empower Rune Weapon should still hand back every frost and death rune.
9. Regression: the client rune bar should match the server right after the cast, and the refreshed
   rune should be spendable straight away.

<details>
<summary>Research notes: spell data, rune system and prior art</summary>

### Spell 45529, from `Spell.dbc`

| Field | Value |
| --- | --- |
| Tooltip | "Instantly activates a blood rune and converts it into a death rune for the next 20 sec. This rune counts as a blood, frost or unholy rune." |
| RecoveryTime | 60000 ms |
| DurationIndex | 18, which is 20000 ms in `SpellDuration.dbc` |
| PowerType | -2, runes |
| SpellFamily | 15 DEATHKNIGHT, flags `[8, 0, 0]` |
| Cast | instant, self, no cost |

`damage` for effect 0 is `BasePoints + DieSides` = 1, so `count` starts at 1. One rune.

### The rune system, the part that matters

Six fixed slots, `MAX_RUNES` 6, base type wired in `runeSlotTypes` (`Player.cpp`): slots 0-1 blood,
2-3 unholy, 4-5 frost. Each slot carries `BaseRune`, which is permanent and survives every
conversion, `CurrentRune`, which is what it shows now, `Cooldown`, where 0 means up, and
`ConvertAura`, the aura that converted it so it can be reverted.

So a blood rune converted to death still has `BaseRune == RUNE_BLOOD`. Filtering on
`GetCurrentRune` loses those, `GetBaseRune` doesn't.

Reaping and Blood of the North are what turn blood into death, through `SPELL_AURA_CONVERT_RUNE`.
`spell_dk_death_rune::HandleProc` converts the rune the moment it goes on cooldown, one per proc,
and each conversion is owned by that talent's own `AuraEffect` on a 30 second timer. That ownership
is why the aura script has to leave an already-converted slot alone.

### The bug chain

1. The main loop requires `GetCurrentRune(j) == MiscValue`, and `MiscValue` is `RUNE_DEATH`. A spent
   blood rune that hasn't been converted yet never matches.
2. The fallback loop, the one that does look at `MiscValueB`, needs both runes of the pair spent and
   `break`s otherwise. Hence the report: it only activates an empty rune when you have two death
   runes and one of them is empty.
3. With nothing activated, effect 1 walks the slots from index 0 and converts the first one not on
   cooldown, which is the rune the player already had up.

Three more defects live in that same fallback loop, and all three go away with it: it reads
`runes[6]` when the index reaches 5 and the accessors don't bounds check, it pairs (1,2) and (3,4)
which cross rune types, and it can reset a slot that is already up, which throws away its grace
period since `SetGracePeriod` rides with every `SetRuneCooldown(x, 0)`.

### Prior art

[TrinityCore 868dcb0](https://github.com/TrinityCore/TrinityCore/commit/868dcb0), [PR 17132](https://github.com/TrinityCore/TrinityCore/pull/17132),
2016-05-15, on their 3.3.5 branch: `GetCurrentRune` to `GetBaseRune`, plus `l + 1 < MAX_RUNES` on
the loop. AzerothCore never ported it. That fix keeps the "both runes of the pair spent"
requirement, so on its own it wouldn't cover the case in this issue.

### Patch history

| When | What |
| --- | --- |
| 3.3.5a | Blood Tap as the DBC has it, activate a blood rune and convert it to death. This is the target. |
| Cataclysm on | Redesigned into charges and the rune system changed. Not applicable here. |
| 2016-05-15 | TrinityCore fixes the selection on their 3.3.5 branch. |
| Today | AzerothCore master still filters on `GetCurrentRune` with the unbounded loop. |

</details>

## Known Issues and TODO List:

- [ ] Unrelated to this PR, but found while working on it and worth writing down somewhere:
      `Player::ResyncRunes` sends `uint8(255 - (GetRuneCooldown(i) * 51))`, a 0-5 scale formula fed
      milliseconds, so every rune still on cooldown would get a garbage byte. The call is commented
      out in master, so nothing triggers it today. The correct formula is already at
      `Spell.cpp:4903`. Worth noting for whoever picks this up: TrinityCore calls `ResyncRunes` from
      `Player::SetRuneCooldown`, so every rune state change carries it, which is why they never
      needed a loose call in `EffectActivateRune`.

## How to Test AzerothCore PRs

When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.

