### PR TITLE
fix(Scripts/World): don't let air force guards attack non-hostile players

### DIFF
--- a/src/server/scripts/World/npcs_special.cpp
+++ b/src/server/scripts/World/npcs_special.cpp
@@ -21,6 +21,7 @@
 #include "CombatAI.h"
 #include "CreatureScript.h"
 #include "CreatureTextMgr.h"
+#include "DBCStores.h"
 #include "GameEventMgr.h"
 #include "GameTime.h"
 #include "GridNotifiers.h"
@@ -452,6 +453,7 @@ public:
         {
             SpawnAssoc = nullptr;
             SpawnedGUID.Clear();
+            SpawnedFactionTemplate = nullptr;
 
             // find the correct spawnhandling
             static uint32 entryCount = sizeof(spawnAssociations) / sizeof(SpawnAssociation);
@@ -477,11 +479,16 @@ public:
                     SpawnAssoc = nullptr;
                     return;
                 }
+
+                // guard posts and trip wires are of the neutral Ambient faction, so the reaction
+                // towards players is judged by the faction of the guard they summon
+                SpawnedFactionTemplate = sFactionTemplateStore.LookupEntry(spawnedTemplate->faction);
             }
         }
 
         SpawnAssociation* SpawnAssoc;
         ObjectGuid SpawnedGUID;
+        FactionTemplateEntry const* SpawnedFactionTemplate;
 
         void Reset() override {}
 
@@ -522,6 +529,12 @@ public:
 
                 // airforce guards only spawn for players
                 if (!playerTarget)
+                    return;
+
+                // only mark and attack players the summoned guard is hostile to, e.g. players
+                // merely Unfriendly with Sporeggar are attackable but must not be aggroed
+                if (SpawnedFactionTemplate && !playerTarget->IsHostileTo(me)
+                        && me->GetFactionReactionTo(SpawnedFactionTemplate, playerTarget) > REP_HOSTILE)
                     return;
 
                 Creature* lastSpawnedGuard = !SpawnedGUID ? nullptr : GetSummonedGuard();


### PR DESCRIPTION
## Changes Proposed:

The anti-air defense script `npc_air_force_bots` (alarm bots, guard posts and trip wires over towns like Sporeggar, Area 52 or the Shattrath tiers) picked its targets with `IsValidAttackTarget()` alone, which only answers whether attacking is legal, not whether the guard has a reason to attack. Any attackable player triggered it: a player merely Unfriendly with Sporeggar got Guard's Mark and was force-attacked by a summoned Sporebat about 25 seconds later (why the attacks looked random in the issue), and the town then piled on through the assist logic once the player was in combat with the faction-970 Sporebat.

This PR adds a hostility gate that judges the reaction by the faction of the guard the bot summons. The trigger NPCs themselves can't be used for that: all guard posts and trip wires are the neutral Ambient faction 190 (which is also why TrinityCore's variant of this gate, checking the trigger's own faction, would turn those triggers off entirely; Toshley's Station only has a guard post). The summoned guard's faction covers every case:

- rep towns (Sporeggar, Cenarion, Consortium, Aldor, Scryers): attack only at Hated/Hostile rank
- Horde/Alliance towns: attack the opposite faction via city reputation
- contested guards (Area 52 Death Machine, faction template flag 0x1000): attack PvP-flagged players

Intentional side effect worth reviewing: the Ambient-faction guard posts and trip wires used to attack every player, including own-faction players standing on rooftops (`IsValidAttackTarget` falls through to true for them because the Ambient faction has no reputation entry). They now follow the same rules as their town's alarm bots. For Area 52 that means Death Machines only engage contested-PvP players, matching documented retail behavior (they punish roof campers who attack someone: https://wowpedia.fandom.com/wiki/Area_52_Death_Machine).

A DB-only fix isn't possible: even with a real faction on the trigger NPCs, `IsValidAttackTarget()` still passes for Unfriendly players.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Claude Fable 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #26953

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)

FactionTemplate.dbc data (templates 1837/1857/190 and the guard templates), Wowpedia on the Area 52 Death Machine, and TrinityCore's rewrite of the same script for the hostility-gate approach.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Tested in-game on Windows: Sporeggar leaves you alone at Unfriendly and still attacks at Hostile and Hated; a Horde character gets marked at an Alliance guard post; Area 52 ignores unflagged players; and the contested case was verified with an Alliance and a Horde character fighting near Area 52: the contested player gets Guard's Mark and, once the mark's attack window fires, the summoned Death Machine engages and chases them (confirmed with temporary server-side logging: AttackStart sets the guard's victim). Duels were not tested; per code they never set the contested-PvP flag (`Unit::SetContestedPvP` excludes the duel opponent).

Two pre-existing quirks observed while testing, unchanged by this PR: (1) the mark's delayed attack only triggers on a movement event of the marked player during the last 5 seconds of the 30-second mark, so a stationary player is re-marked in a perfect 30-second loop and never engaged, while a moving player is attacked correctly; that mechanic is untouched here and behaved the same before (TrinityCore later rewrote the script to engage immediately, a possible follow-up). (2) The Stormspire (22069) and Scryer (22071) alarm bots carry the goblin "Friendly" trigger faction 1806, so those two specific alarm bots never engage rep-hated players before or after this PR; their towns' guard posts and trip wires do enforce the rep gate.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. `.go creature id 17924`, then `.modify reputation 970 -2000` (Unfriendly), leave GM mode
2. Walk and fly around Sporeggar for a minute: no Guard's Mark, no Sporebat attack, town NPCs stay passive
3. `.modify reputation 970 -4000` (Hostile) or `-36001` (Hated): summoned Sporebats mark you and attack about 25 seconds later (keep moving near the bots; the forced attack triggers on movement while the mark is about to expire)
4. Fly a Horde character over an Alliance air-defended outpost (e.g. Toshley's Station): still marked and attacked

## Known Issues and TODO List:

- [ ] none
