### PR TITLE
fix(Core/Unit): stop the swim animation after dismounting in mid air

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -10578,6 +10578,30 @@ void Unit::Dismount()
 
     if (Player* player = ToPlayer())
     {
+        // Dismounting mid flight leaves the client in the movement state the mount was carrying,
+        // so it keeps playing the swim animation while it falls. Give it a velocity it has to
+        // react to.
+        if (IsFlying())
+        {
+            // Flying forward when we let go of the mount, so carry some momentum into the fall
+            // instead of dropping straight down. The knockback pushes away from the point we pass
+            // it, so aim from behind us. MOVE_RUN still reads the mounted rate here, since the
+            // speed auras are torn down after this handler, and that is the speed we want: the
+            // mount's ground pace, well short of the flight speed that would fling the player.
+            // MOVEMENTFLAG_MASK_MOVING would be wrong: it counts descending as moving, and a
+            // player only losing height has no forward momentum to keep
+            if (m_movementInfo.HasMovementFlag(MOVEMENTFLAG_FORWARD))
+                KnockbackFrom(GetPositionX() - std::cos(GetOrientation()), GetPositionY() - std::sin(GetOrientation()),
+                    GetSpeed(MOVE_RUN), 0.5f);
+            else
+            {
+                // Nothing to carry, so the direction does not matter. Small enough not to be felt
+                float x, y;
+                GetPosition(x, y);
+                KnockbackFrom(x, y, 0.5f, 0.5f);
+            }
+        }
+
         WorldPacket data(SMSG_MOVE_SET_COLLISION_HGT, GetPackGUID().size() + 4 + 4);
         data << GetPackGUID();
         data << player->GetSession()->GetOrderCounter(); // movement counter


### PR DESCRIPTION
## Changes Proposed:

Dismounting a flying mount in the air leaves the 3.3.5a client playing the swim animation while the
character falls. Everyone around sees it, not just the player.

There's nothing wrong on the server side to correct, which is the first thing I went looking for.
`MOVEMENTFLAG_SWIMMING` is never set by the core for a player controlled unit: `Unit::SetSwim` is
only used on creatures and SmartAI, and for players the movement flags are client authoritative,
stored from whatever the client reports in `WorldSession::HandleMoverRelocation`. The client just
keeps the movement state the mount was carrying and never transitions into a fall.

So `Unit::Dismount` now sends a knockback when the unit was actually flying. A velocity is the one
thing the server can hand the client that it has to react to.

That velocity also decides how the fall looks, because it replaces whatever the client had. Dropping
straight down looked like the mount had been yanked from under you, so when the player was flying
forward the knockback goes forward instead, at `GetSpeed(MOVE_RUN)`. Worth knowing if you read that
line: `Dismount` clears `UNIT_FLAG_MOUNT` first, but `GetSpeed` returns the cached rate and that is
only recomputed when the mounted speed aura goes, in a later effect handler, so what comes back is
still the mount's ground pace. Which is the speed we want here, well short of flight speed. Any
other case keeps a nudge small enough not to be felt.

The condition is `MOVEMENTFLAG_FORWARD` and not `MOVEMENTFLAG_MASK_MOVING`, which I tried first: the
mask counts descending as moving, and logging the flags in game showed a player merely losing height
reports `0x3800000`, so they would have earned a forward shove with no forward momentum to keep.

The `IsFlying()` guard keeps dismounting on the ground, boarding a vehicle and landing off a taxi
untouched, since none of those carry the flying movement flags for a player.

Two cleaner routes were tried in game first, and I'd rather write down what they did than have
someone wonder why they aren't here.

Unsetting the flight before `SMSG_DISMOUNT` goes out. This one matters because the mount aura is
removed before the flight speed aura, so the client is told it's off the mount while still flagged
as able to fly. It does stop the swimming on its own, but then the character walks on air instead of
falling.

Handing gravity back on top of that, with `SMSG_MOVE_GRAVITY_ENABLE`. Still walks on air whenever
the mount was carrying momentum.

TrinityCore's 3.3.5 `Unit::Dismount` has nothing for this, so there was no upstream fix to port.

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code with Claude Opus 5, for both the code change and this
     description. It ran a fixed pipeline of agent skills, one per phase, each leaving a document
     behind: `fetch-ticket` for the issue, `azerothcore-research` for the research, `refine-ticket`
     for the requirements, then the alternatives above implemented and tested one at a time, and
     `self-review` before publishing, which put the commit through a fresh-context reviewer and
     produced the report below. Every movement flag and core symbol quoted here came from
     azerothMCP, a local MCP server that reads this server's own DBC files, world DB and source
     tree, so the values are what the server actually runs and not a wiki transcription.
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #25992
- Escalated from [chromiecraft#9584](https://github.com/chromiecraft/chromiecraft/issues/9584)
- Supersedes #26732, which I closed myself

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

The videos in the issue, and the reproduction steps its triage left there.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Tested in game, all confirmed working: dismounting a flying mount while flying forward, which is the
reported case, now falls forward with the animation it should have; hovering still and descending
without touching a direction key both drop straight; dismounting a ground mount while running,
boarding a vehicle and landing off a taxi are unchanged. The two alternatives above were each built
and tested the same way before being dropped, as were a version with no forward momentum and one
that used the mount's flight speed, which flung the player.

worldserver builds clean and `apps/codestyle/codestyle-cpp.py` passes.

## Self-review

**Outcome** 6 findings — 3 fixed, 3 dismissed — nothing blocking, two of them worth a maintainer's
opinion and listed under Known Issues below

**Reviewed** `1af711eb5` (`fix/dismount-swim-animation` vs `master`, merge-base diff — 1 file, +24)

**By** Claude Code (Claude Agent SDK), claude-opus-5 — self-review v0.5, 2026-08-12

<details>
<summary>Review details (2 rounds)</summary>

Both rounds ran in a fresh context that never saw the research or the earlier attempts, and were
told the workaround-versus-fix question was already settled, so they reported only concrete harm.

Round 1, on the version with the plain nudge:

1. `GetPosition(x, y, z)` declared a `z` nothing reads, where the two argument overload exists and
   is what `Spell::EffectKnockBack` uses at its own call site → **fixed**.
2. The comment claimed 0.5f sits above "the 0.1f that `EffectKnockBack` treats as a no-op". That
   guard is an AND, and it lives in a function this path never calls → **fixed**.
3. Knocking back from our own position makes `Position::GetSinCos` pick a random angle, so the
   horizontal direction differed every time → **dismissed**: a purely vertical variant was tried and
   the tested one kept. It now only applies where there is no momentum to carry.
4. The comment claimed the forward push uses run speed rather than the mount's. Half true and
   misleading, since `GetSpeed` returns the cached rate, still the mounted one at that point →
   **fixed**.

Round 2, on the version with the forward momentum:

5. The forward push also fires on dismounts the player did not ask for, and the client carries the
   horizontal speed for the whole fall with no decay, so a no-fly zone drop from Dalaran carries
   over 100 yards, more with the parachute those zones hand out → **dismissed**, see Known Issues.
6. Both the trigger and the direction come from client-reported movement flags, and
   `ReadMovementInfo` validates `MOVEMENTFLAG_FORWARD` only against `MOVEMENTFLAG_BACKWARD`, unlike
   `MOVEMENTFLAG_FLYING` which needs a real fly aura → **dismissed**, see Known Issues.

Traced through the code and clean: the `IsFlying()` guard does exclude ground mounts, vehicles and
taxi, and it is the check carrying that guard, since a taxi player does have
`MOVEMENTFLAG_FORWARD`; the `MotionMaster::MoveKnockbackFrom` branch documented as able to drop
players below the map is unreachable from here; the knockback adds no new anti-cheat exemption
class, since `SetCanKnockback` and `SetCanTeleport` are already set by every spell knockback; fall
damage is computed from height, so it is unchanged; and the source point of the knockback is a full
yard away, so the direction is exactly the facing one.

**After publishing** CodeRabbit raised a seventh finding on `Unit.cpp:10589`, that `KnockbackFrom`
reaches `MotionMaster::MoveKnockbackFrom`, which returns early for a client-controlled player, so
the call would do nothing for the reported case. It **withdrew** it once traced: that function is
only reached on the non-player branch, and a player gets `SMSG_MOVE_KNOCK_BACK` sent directly.
Thread resolved.

</details>

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

The triage steps from the issue:

1. Create an alliance character, `.levelup 79`, `.add 25527`, `.learn 34091`, `.tele nagrand`.
2. Learn the mount, fly, get some height and move forward.
3. Dismount without letting go of the movement key.

The character should fall normally. No swimming, and no walking on air either.

Worth a look as regressions: dismounting a ground mount while running, boarding a vehicle, and
landing off a taxi. None of those should feel any different.

<details>
<summary>Research notes: movement flags, who owns them and prior art</summary>

### The flags involved, from `UnitDefines.h`

| Flag | Value | Note in the header |
| --- | --- | --- |
| `MOVEMENTFLAG_FORWARD` | `0x00000001` | |
| `MOVEMENTFLAG_BACKWARD` | `0x00000002` | |
| `MOVEMENTFLAG_DISABLE_GRAVITY` | `0x00000400` | used when walking is not possible |
| `MOVEMENTFLAG_FALLING` | `0x00001000` | damage dealt on that type of falling |
| `MOVEMENTFLAG_SWIMMING` | `0x00200000` | "appears with fly flag also" |
| `MOVEMENTFLAG_ASCENDING` | `0x00400000` | press space when flying |
| `MOVEMENTFLAG_DESCENDING` | `0x00800000` | |
| `MOVEMENTFLAG_CAN_FLY` | `0x01000000` | appears when unit can fly and also walk |
| `MOVEMENTFLAG_FLYING` | `0x02000000` | unit is actually flying, players only |

The header's own comment on `MOVEMENTFLAG_SWIMMING`, "appears with fly flag also", is the shape of
this bug: swimming and flying coexist by design, so nothing downstream treats the pair as invalid.

The `0x3800000` quoted above for a player merely losing height decomposes exactly:
`FLYING 0x2000000 | CAN_FLY 0x1000000 | DESCENDING 0x800000`.

### Who owns a player's movement flags

For a player-controlled unit the flags are client authoritative. `WorldSession::HandleMoverRelocation`
stores whatever the client reports, and `Unit::SetSwim`, the only place the core sets
`MOVEMENTFLAG_SWIMMING`, is reached from creature code and SmartAI, never for a player. So there is
no server-side state saying "this player is swimming" to correct. The server can only hand the
client something it must react to, which is what a velocity is.

`MOVEMENTFLAG_MASK_MOVING` (same header) lists `DESCENDING` among the moving flags. That is why the
trigger is the bare `MOVEMENTFLAG_FORWARD` and not the mask: under the mask, a player who is only
losing height counts as moving and would earn a forward shove with no forward momentum to keep.

### The chain from cause to symptom

1. The player is flying, so the client is reporting `FLYING | CAN_FLY` plus whatever direction keys
   are down, and the mount's movement state includes swimming.
2. The mount aura is removed. The client is told it is off the mount while still flagged able to fly.
3. Nothing in that sequence forces a movement state transition, so the client keeps the state it
   had, swimming included, and never enters a fall.
4. Everyone in range sees it, because the flags travel in the movement packets rather than being a
   local display quirk.

### Why the knockback reaches the client at all

`Unit::KnockbackFrom` branches on whether the unit is client-controlled. Only the non-player branch
goes to `MotionMaster::MoveKnockbackFrom`, which returns early for players; the player branch sends
`SMSG_MOVE_KNOCK_BACK` straight to the client. That distinction is what makes this work, and it was
raised and then withdrawn by CodeRabbit in review after being traced.

### Prior art

None to port. TrinityCore's 3.3.5 `Unit::Dismount` carries nothing for this, and no equivalent fix
exists in VMaNGOS. Searched for a dismount or swim-animation fix in both before writing anything.

### Patch history

Not applicable in the usual sense: this is not a 3.3.5a value that drifted, it is a client-side
animation state the server never corrects. There is no earlier or later patch behaviour to match
against, only the observable retail behaviour that a dismount in mid air produces a fall.

</details>

## Known Issues and TODO List:

Both of these come from the forward momentum branch, and I would rather put them here than have
someone find them in review. Happy to drop that branch and keep only the small nudge if you would
prefer it: the nudge alone stops the swimming, it just makes the fall look like the mount was pulled
out from under the player.

- [ ] The client carries a knockback's horizontal speed for the whole fall with no decay, and this
      code also runs on dismounts the player did not ask for, the no-fly zone auras over Dalaran and
      Wintergrasp among them. A drop from Dalaran to Crystalsong is around nine seconds of airtime,
      so the forward carry lands past 100 yards, and further with the parachute those zones give.
- [ ] The branch triggers on `MOVEMENTFLAG_FORWARD` and aims at `GetOrientation()`, both reported by
      the client, and `ReadMovementInfo` validates `MOVEMENTFLAG_FORWARD` only against
      `MOVEMENTFLAG_BACKWARD`, unlike `MOVEMENTFLAG_FLYING` which requires a real fly aura. A
      modified client can therefore hover still, claim to be moving forward in any direction, and
      get a server-issued push out of a dismount.

## How to Test AzerothCore PRs

When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.

