### PR TITLE
fix(DB/Spell): Savage Combat now procs off Wound Poison

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1786506332786520900.sql
+++ b/data/sql/updates/pending_db_world/rev_1786506332786520900.sql
@@ -1,0 +1,5 @@
+-- Savage Combat (51682, all ranks) never procced off Wound Poison, issue #26885. Its
+-- SpellTypeMask only accepted PROC_SPELL_TYPE_NO_DMG_HEAL, and Wound Poison is the one
+-- debuff-poison that also deals direct damage, so the proc system classified it as
+-- PROC_SPELL_TYPE_DAMAGE instead.
+UPDATE `spell_proc` SET `SpellTypeMask` = `SpellTypeMask`|1 WHERE `SpellId` = -51682;

--- a/data/sql/updates/pending_db_world/rev_1786506332786520900.sql
+++ b/data/sql/updates/pending_db_world/rev_1786506332786520900.sql
@@ -1,5 +1,2 @@
--- Savage Combat (51682, all ranks) never procced off Wound Poison, issue #26885. Its
--- SpellTypeMask only accepted PROC_SPELL_TYPE_NO_DMG_HEAL, and Wound Poison is the one
--- debuff-poison that also deals direct damage, so the proc system classified it as
--- PROC_SPELL_TYPE_DAMAGE instead.
+-- Savage Combat (all ranks)
 UPDATE `spell_proc` SET `SpellTypeMask` = `SpellTypeMask`|1 WHERE `SpellId` = -51682;


### PR DESCRIPTION
## Changes Proposed:

Savage Combat's +% physical damage debuff never lands when the only poison on the target is Wound Poison. Every other debuff-poison applies it fine.

The talent's `spell_proc` row (`SpellId = -51682`, all ranks) has `SpellTypeMask = 4`, which is `PROC_SPELL_TYPE_NO_DMG_HEAL`: only spells that deal no damage and do no healing.

That mask is exclusive in practice. `Unit::ProcDamageAndSpell` (`src/server/game/Entities/Unit/Unit.cpp`) classifies each event with an if/else chain, so a spell that deals damage gets `PROC_SPELL_TYPE_DAMAGE` and only that bit, never both. Wound Poison is the one debuff-poison that also deals direct damage: all seven target-side ranks (13218, 13222, 13223, 13224, 27189, 57974, 57975) carry a `SPELL_EFFECT_SCHOOL_DAMAGE` alongside their auras. So it comes in as `DAMAGE`, `0x1 & 0x4` is 0, and `CanSpellTriggerProcOnEvent` drops it. Deadly (2818), Crippling (3409) and Mind-numbing (5760) are aura-only, which is why nobody noticed the mask was too narrow.

Widens it with `SpellTypeMask|1` so `DAMAGE` is accepted too. `HEAL` is deliberately left out, no poison heals.

`SpellFamilyMask1 = 524288` is already correct and untouched. Worth spelling out because it's the obvious follow-up question: this does **not** start proccing off Instant Poison. Instant Poison has `SpellFamilyFlags[1] = 0` (checked ranks 1, 6 and 9: 8680, 11337, 57965), so it never matched that mask and still doesn't, which is right since it leaves no debuff on the target. Same for Anesthetic Poison (26785, `SpellFamilyFlags[1] = 0x10`).

Supersedes #26945, a PR of mine that I closed myself while clearing out a backlog.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code with Claude Opus 5, for both the SQL change and this
     description. It ran a fixed pipeline of agent skills, one per phase, each leaving a document
     behind: `fetch-ticket` for the issue, `azerothcore-research` for the research notes below,
     `refine-ticket` for the requirements, `create-implementation-plan` for the plan, then the plan
     executed step by step, `generate-pr-description` for this text, and a self-review against the
     final commit before publishing, whose report is below. Every spell value quoted here came from
     azerothMCP, a local MCP server that reads this server's own DBC files, world DB and source
     tree, so the numbers are what the server actually runs and not a wiki transcription.
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #26885
- Same report on the ChromieCraft tracker: [chromiecraft/chromiecraft#9945](https://github.com/chromiecraft/chromiecraft/issues/9945)

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

The issue carries a video of the debuff never landing off Wound Poison.

[Savage Combat on Wowhead](https://www.wowhead.com/wotlk/spell=58413/savage-combat) describes the effect with no carve-out for any particular poison:

> Increases your total attack power by 4% and all physical damage caused to enemies you have poisoned is increased by 4%.

Spell data backing the above, from Spell.dbc and the world DB:

- `spell_proc` row `-51682`: `SpellFamilyName = 8`, `SpellFamilyMask1 = 524288`, `ProcFlags = 0`, `SpellTypeMask = 4`, `SpellPhaseMask = 2`.
- `ProcFlagsSpellType` in `src/server/game/Spells/SpellMgr.h`: `PROC_SPELL_TYPE_DAMAGE = 0x1`, `PROC_SPELL_TYPE_HEAL = 0x2`, `PROC_SPELL_TYPE_NO_DMG_HEAL = 0x4`.
- All four debuff-poisons carry `SpellFamilyFlags[1] = 0x80000`, Wound Poison included, so the family mask was never the problem.
- The weapon-enchant halves (13219, 2823, ...) are `SPELL_EFFECT_ENCHANT_HELD_ITEM` and are not what reaches the proc engine.
- Savage Combat has two ranks, 51682 (triggers 58684) and 58413 (triggers 58683). 58414 is Filthy Tricks, unrelated.

The whole argument in one table. Target-side spells only, since the weapon-enchant halves never reach the proc engine:

| Poison | Target-side ids | `SpellFamilyFlags[1]` | Deals direct damage | Leaves a debuff | Before | After |
|---|---|---|---|---|---|---|
| **Wound** | 13218, 13222, 13223, 13224, 27189, 57974, 57975 | `0x80000` ✅ | **yes** | yes | ✗ | **✓** |
| Deadly | 2818 + ranks | `0x80000` ✅ | no (periodic only) | yes | ✓ | ✓ |
| Crippling | 3409 | `0x80000` ✅ | no | yes | ✓ | ✓ |
| Mind-numbing | 5760 | `0x80000` ✅ | no | yes | ✓ | ✓ |
| Instant | 8680 … 57965 | `0` ✗ | yes | no | ✗ | ✗ |
| Anesthetic | 26785 | `0x10` ✗ | yes | no | ✗ | ✗ |

Wound Poison is the only row where "deals direct damage" and "leaves a debuff" are both true, which is exactly the combination the old mask excluded.

Patch history, for the record: 3.0.2 introduced the talent at 1/2%, and 3.1.0 raised it to 2/4%. The DBC here already carries the post-3.1 values (58684 = +2%, 58683 = +4%), so nothing needs correcting on that front.

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

**Not yet tested in game for this PR.** Being upfront about it rather than ticking a box I have not earned.

What has been verified, at DB level, starting from a row reset to master's value: `SpellTypeMask` goes 4 to 5 on import, stays 5 on a second import, `SpellFamilyMask1` is untouched at 524288, and the `WHERE` matches exactly one row.

For context, the same one-line change was tested by @EricksOliveira on #26945, a PR of mine that I closed myself while clearing out a backlog: "Tested. PvE and PvP working perfectly." That was a different head which set the mask to 5 outright, so it lands on the same value from a base of 4. Recording it as context, not as a tick in the box above.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. Level 80 Combat rogue with Savage Combat, without Deadly Brew. Deadly Brew applies Crippling Poison underneath and the debuff shows up even when the bug is still there, which is what made the original report look wrong at first.
2. `.add 43235 20`, apply Wound Poison to both weapons
3. Hit a training dummy and watch the target's debuffs
4. The Savage Combat debuff should appear next to the Wound Poison one
5. Repeat with Deadly, Crippling and Mind-numbing poison to confirm nothing regressed
6. Repeat with Instant Poison, which should still not apply the debuff

## Known Issues and TODO List:

- [ ] In-game verification, see above.
- [ ] The migration that introduced this row, `data/sql/updates/db_world/2026_02_18_01.sql`, comments it as "Rogue Deadly Brew (all ranks)". `-51682` is Savage Combat, Deadly Brew is the separate `-51625` row. Not touched here since merged update files are immutable.

## Self-review

**Outcome** 3 findings — 1 fixed, 1 rejected with reason, 1 nothing-to-change — final round clean

Reviewed `d8a3c5b` (`fix/savage-combat-wound-poison-26885` vs `origin/master` — 1 file, +5 −0), per `.agents/docs/self-review-rules.md` and `.agents/docs/code-review.md`.

`codestyle-sql.py` and `codestyle-cpp.py` both pass on the branch. No C++ is touched.

### Round 1 — 3 findings

1. **An earlier draft of this description claimed Instant Poison has `SpellFamilyFlags[1] = 0` on every rank, while only two ranks had been checked** → fixed: verified ranks 1, 6 and 9 (8680, 11337, 57965), all `[8192, 0, 0]`, and the wording now names the ranks checked. Found along the way that 26784, which I had taken for Instant Poison VIII, is Arcanoweave Robe.
2. **CodeRabbit's inline comment on #26945 asked for two things** → the `create_sql.sh` filename is applied; the `version_db_world` header is **rejected**. The claim that `create_sql.sh` inserts one, and that without it the versioning system cannot track the file, does not hold: the script writes a single `--` line and nothing else, and no file in `pending_db_world/` carries that header. It is added when files move into `db_world/`.
3. **The SQL itself** → nothing to change. `WHERE SpellId = -51682` matches exactly one row, `SpellTypeMask|1` is idempotent on re-import, and with no `INSERT` the DELETE-before-INSERT rule does not apply.

### Round 2, against the final commit — clean

No findings. The commit adds one file, nothing outside `pending_db_world/`, no tabs, no trailing whitespace, trailing newline present, no line over 120 columns.

### Regression surface

The wider mask admits any rogue spell that matches family mask `0x80000` **and** `ProcFlags 0x11000` **and** deals damage. Master Poisoner's row (`-31226`) has carried the same family mask with `SpellTypeMask = 5` for a long time without incident, which suggests the set ends at the poisons, but Shiv and Envenom are worth a look when testing.

## Research notes: spell data, the proc system and prior art

### Savage Combat, from Spell.dbc

| Field | 51682 (rank 1) | 58413 (rank 2) |
|---|---|---|
| Triggers | 58684, +2% physical damage taken | 58683, +4% physical damage taken |
| `SpellFamilyName` | 8 `ROGUE` | 8 `ROGUE` |
| `ProcFlags` | `0x11000` | `0x11000` |
| `ProcChance` | 100 | 100 |
| `AttributesEx3` | `0x4000000` `CAN_PROC_FROM_PROCS` | same |
| Effect 0 | `APPLY_AURA`, `PROC_TRIGGER_SPELL` | same |
| Effect 1 | `MOD_ATTACK_POWER_PCT` +2% | +4% |

`ProcFlags 0x11000` is `DONE_SPELL_NONE_DMG_CLASS_NEG | DONE_SPELL_MAGIC_DMG_CLASS_NEG`. The poisons are `DmgClass = 1 MAGIC` and negative, so they satisfy it.

`58414` is **Filthy Tricks**, a Subtlety talent with nothing to do with this. It shows up as "Savage Combat rank 3" in a few write-ups of this bug, including the issue thread. The talent has two ranks, not three.

### How the proc gets classified

1. The weapon enchant procs and casts the target-side poison as a triggered spell.
2. `Unit::ProcDamageAndSpell` assigns `spellTypeMask` with an `if / else if` chain, so the value is **exclusive**: damage dealt means `PROC_SPELL_TYPE_DAMAGE` and only that bit, never `DAMAGE | NO_DMG_HEAL`.
3. `Aura::GetProcEffectMask` walks the aura's gates, then calls `SpellMgr::CanSpellTriggerProcOnEvent`.
4. That function rejects on `procEntry.SpellTypeMask && !(eventInfo.GetSpellTypeMask() & procEntry.SpellTypeMask)`.

Everything else Wound Poison needs, it already had: `CAN_PROC_FROM_PROCS` on the talent lets a triggered spell proc it, the `ProcFlags` match, `SpellPhaseMask = 2 HIT` matches, and `HitMask = 0` defaults to normal + crit + absorb.

### The bug chain

`SpellTypeMask = 4` accepts only `NO_DMG_HEAL` → Wound Poison arrives as `DAMAGE` because its target-side spells carry a `SPELL_EFFECT_SCHOOL_DAMAGE` next to the auras → `0x1 & 0x4` is 0 → the proc is dropped before the talent is ever consulted. The aura-only poisons arrive as `NO_DMG_HEAL` and pass, which is why the bug looked specific to Wound Poison.

### Prior art

No TrinityCore or VMaNGOS change to port: this is an AzerothCore data row. The closest reference is inside the same table. Master Poisoner's row `-31226` pairs the identical `SpellFamilyName = 8` and `SpellFamilyMask1 = 0x80000` with `SpellTypeMask = 5`, which is what this PR makes Savage Combat's row look like.

The row was introduced by `data/sql/updates/db_world/2026_02_18_01.sql:1302`, where its inline comment labels it "Rogue Deadly Brew (all ranks)". Deadly Brew is the separate `-51625` row. Not corrected here, since merged update files are immutable.

`spell_proc_event` still exists as a table and a base SQL file, and its row for this talent already carries the right family mask, but no file under `src/` reads that table any more. Anyone chasing this bug through `spell_proc_event` is reading dead data.

### Patch history

| When | What |
|---|---|
| 3.0.2 | Savage Combat introduced as a Combat tier 9 talent, 2 ranks, 1/2% physical damage |
| 3.1.0 | Raised to 2/4%. This is the 3.3.5a value, and the DBC here already carries it |
| Cataclysm on | Talent removed from the tree, replaced by an unrelated passive. Not applicable |

## How to Test AzerothCore PRs

When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
