### PR TITLE
fix(Scripts/Ulduar): only subsequent Freya spawns can speed up next wave

### DIFF
--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_freya.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_freya.cpp
@@ -213,6 +213,8 @@ enum Misc
     ACTION_REMOVE_2_STACK                       = 2,
     ACTION_TRIO_MEMBER_DOWN                     = 1,
     ACTION_ATTUNED_TO_NATURE_REMOVED            = 3,
+    ACTION_TRIO_MEMBER_DOWN_CURRENT             = 5,
+    ACTION_TRIO_MEMBER_REVIVED_CURRENT          = 6,
     ACTION_LUMBERJACKED                         = -1,
     ACTION_ADD_DIED                             = -2,
     ACTION_TRIO_MEMBER_REVIVED                  = -3,
@@ -223,6 +225,7 @@ enum Misc
     DATA_GET_ELDER_COUNT                        = 1,
     DATA_BACK_TO_NATURE                         = 2,
     DATA_TRIO_DOWN                              = 3,
+    DATA_CURRENT_SET_ID                         = 7,
 
     CRITERIA_LUMBERJACKED                       = 21686,
 
@@ -253,6 +256,9 @@ struct boss_freya : public BossAI
     bool _backToNature;
     uint8 _deforestation;
     uint8 _aliveAddsCount;
+    uint8 _currentSetId;
+    uint8 _currentTrioDown;
+    uint8 _trioWaveEndSetId;
 
     ObjectGuid _elderGUID[3];
 
@@ -279,6 +285,9 @@ struct boss_freya : public BossAI
         _backToNature = true;
         _deforestation = 0;
         _aliveAddsCount = 0;
+        _currentSetId = 0;
+        _currentTrioDown = 0;
+        _trioWaveEndSetId = 0;
     }
 
     void KilledUnit(Unit* victim) override
@@ -356,6 +365,8 @@ struct boss_freya : public BossAI
 
     void SpawnWave()
     {
+        ++_currentSetId;
+        _currentTrioDown = 0;
         Talk(EMOTE_ALLIES_OF_NATURE);
 
         static constexpr uint8 permTable[6][3] = {
@@ -372,19 +383,20 @@ struct boss_freya : public BossAI
             case GROUP_TRIO:
                 Talk(SAY_SUMMON_TRIO);
                 DoCast(SPELL_SUMMON_WAVE_3);
+                _aliveAddsCount = 0;
                 _trioDown = 0;
                 break;
             case GROUP_CONSERVATOR:
                 Talk(SAY_SUMMON_CONSERVATOR);
                 DoCast(SPELL_SUMMON_WAVE_1);
-                _aliveAddsCount += 1;
+                _aliveAddsCount = 1;
                 break;
             case GROUP_LASHERS:
                 Talk(SAY_SUMMON_LASHERS);
                 for (uint8 i = 0; i < 10; ++i)
                     DoCast(SPELL_SUMMON_WAVE_10);
 
-                _aliveAddsCount += 10;
+                _aliveAddsCount = 10;
                 break;
         }
     }
@@ -411,17 +423,29 @@ struct boss_freya : public BossAI
 
         if (param == ACTION_TRIO_MEMBER_DOWN)
         {
-            // Once the whole trio is down none of them can come back, so the wave
-            // is decided here and only waits out the last member's revive window
+            // A full wipe must reset Deforestation even if the set is stale;
+            // only the wave acceleration is gated to the current set below.
             if (++_trioDown >= 3)
                 events.RescheduleEvent(EVENT_FREYA_TRIO_WAVE_END, 11s);
+            return;
+        }
 
+        if (param == ACTION_TRIO_MEMBER_DOWN_CURRENT)
+        {
+            if (++_currentTrioDown >= 3)
+                _trioWaveEndSetId = _currentSetId;
             return;
         }
 
         if (param == ACTION_TRIO_MEMBER_REVIVED)
         {
             --_trioDown;
+            return;
+        }
+
+        if (param == ACTION_TRIO_MEMBER_REVIVED_CURRENT)
+        {
+            --_currentTrioDown;
             return;
         }
 
@@ -463,6 +487,9 @@ struct boss_freya : public BossAI
 
         if (param == DATA_TRIO_DOWN)
             return _trioDown;
+
+        if (param == DATA_CURRENT_SET_ID)
+            return _currentSetId;
 
         return 0;
     }
@@ -609,6 +636,10 @@ struct boss_freya : public BossAI
                 // _trioDown stays set so a member resolving on this same tick
                 // still sees the trio as wiped and does not come back
                 _deforestation = 0;
+                // The 1-min fallback may have moved the set on during the 11s revive
+                // window; only the current set's trio wipe may accelerate the next wave
+                if (_trioWaveEndSetId != _currentSetId)
+                    break;
                 events.RescheduleEvent(EVENT_FREYA_ADDS_SPAM, 5s, 0, EVENT_PHASE_ADDS);
                 break;
             case EVENT_FREYA_NATURE_BOMB:
@@ -1040,11 +1071,22 @@ struct boss_freya_summons : public ScriptedAI
     {
         _isTrio = me->GetEntry() == NPC_ANCIENT_WATER_SPIRIT || me->GetEntry() == NPC_STORM_LASHER || me->GetEntry() == NPC_SNAPLASHER;
         _hasDied = false;
+        _setId = 0;
     }
 
     EventMap events;
     bool _hasDied;
     bool _isTrio;
+    uint8 _setId;
+
+    void IsSummonedBy(WorldObject* summoner) override
+    {
+        if (Creature* freya = summoner->ToCreature())
+        {
+            if (freya->GetEntry() == NPC_FREYA)
+                _setId = freya->AI()->GetData(DATA_CURRENT_SET_ID);
+        }
+    }
 
     void Reset() override
     {
@@ -1082,6 +1124,8 @@ struct boss_freya_summons : public ScriptedAI
         {
             if (Creature* freya = instance->GetCreature(BOSS_FREYA))
             {
+                bool const isCurrentSet = _setId == freya->AI()->GetData(DATA_CURRENT_SET_ID);
+
                 if (!_hasDied)
                 {
                     uint32 doseSpell = 0;
@@ -1111,6 +1155,8 @@ struct boss_freya_summons : public ScriptedAI
                 if (_isTrio)
                 {
                     freya->AI()->DoAction(ACTION_TRIO_MEMBER_DOWN);
+                    if (isCurrentSet)
+                        freya->AI()->DoAction(ACTION_TRIO_MEMBER_DOWN_CURRENT);
                     _hasDied = true;
                     Talk(EMOTE_TRIO_WITHERS);
 
@@ -1121,7 +1167,7 @@ struct boss_freya_summons : public ScriptedAI
                         ReviveWithAllies();
                     }, 11s);
                 }
-                else
+                else if (isCurrentSet)
                     freya->AI()->DoAction(ACTION_ADD_DIED);
             }
         }
@@ -1147,6 +1193,8 @@ struct boss_freya_summons : public ScriptedAI
         me->setDeathState(DeathState::JustRespawned);
         Reset();
         freya->AI()->DoAction(ACTION_TRIO_MEMBER_REVIVED);
+        if (_setId == freya->AI()->GetData(DATA_CURRENT_SET_ID))
+            freya->AI()->DoAction(ACTION_TRIO_MEMBER_REVIVED_CURRENT);
     }
 
     void JustEngagedWith(Unit*) override
@@ -1212,7 +1260,14 @@ struct boss_freya_summons : public ScriptedAI
                 if (Unit* target = SelectTargetFromPlayerList(80))
                     AttackStart(target);
                 else
+                {
+                    // Despawning still counts the add as cleared so the set's wave can accelerate
+                    if (InstanceScript* instance = me->GetInstanceScript())
+                        if (Creature* freya = instance->GetCreature(BOSS_FREYA))
+                            if (_setId == freya->AI()->GetData(DATA_CURRENT_SET_ID))
+                                freya->AI()->DoAction(ACTION_ADD_DIED);
                     me->DespawnOrUnsummon(1ms);
+                }
                 events.Repeat(10s);
                 break;
         }


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Finishing off a previous add wave caused the new wave spawner to speed up. Now, only finishing off the current wave 
speeds up the timer.

`/self-review` paste below. 
~~https://wowgaming.altervista.org/aowow/?achievement=2984

Related PR of Freya adds:
- https://github.com/azerothcore/azerothcore-wotlk/pull/26993

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: DeepSeek V4 Pro + AzerothMCP
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/27095
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/26318

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Tested incl. deforestation achi

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.


# Self-review — 4b1d5d5a435 → 051ee66c8d2

**Outcome** 3 findings — 2 fixed, 1 dismissed — no blockers

**Caveat** the in-game test has not been run yet (per project rules); the agreed steps are in the details — run them before merging

**Reviewed** `4b1d5d5a435` (`master` vs `upstream/master` `051ee66c8d2`, merge-base diff — 1 file, +60 −5)

**By** GitHub Copilot, DeepSeek V4 Pro — self-review v0.4, 2026-08-12

<details>
<summary>Review details (3 rounds)</summary>

**Intent** The change gates Freya's ~5s next-wave acceleration on the current add set: only deaths from the most recently spawned set — and the 11s trio-revive event they leave behind — may trigger it or reset the trio-wipe (deforestation) counter. Stale adds from an earlier, overlapping set must not. Each add records its set at summon time (`IsSummonedBy` → `DATA_CURRENT_SET_ID`) and compares on death/revive.

**Project rules** `.agents/docs/self-review-rules.md` found and applied (regression risk; in-game testing asked and recorded). `code-review.md`, `cpp-guidelines.md`, `cpp-scripts.md` run as a checklist. `apps/codestyle/codestyle-cpp.py` passes on the changed file (before and after the Round 2 fix); no SQL changed, so the SQL linter was not run. Only pre-existing IDE warning: unused `#include "CreatureScript.h"` (off-diff, untouched).

-----

## Round 1 — `d71f10a2879d`, 3 findings

1. `boss_freya::DoAction` — pre-existing `--_trioDown` (uint8) could underflow to 255 if a new trio wave reset it inside an 11s revive window → **dismissed**: unreachable — trio waves are two waves apart (permutation), minimum ~15s even under instant-wipe acceleration vs an 11s window, and every decrement pairs with a prior increment; code pre-dates this change
2. `EVENT_FREYA_TRIO_WAVE_END` — gating `_deforestation = 0` on the current set lets the Deforestation credit (spell 65015) fire earlier than before → **dismissed**: author instructed "Keep existing AC. Do not touch. Do not port TC changes" (TC implements Deforestation via a different binary-mask mechanism); verify Deforestation in-game, revisit if wrong
3. `SpawnWave` / `JustDied` → `ACTION_ADD_DIED` — per-set `_aliveAddsCount` (`=` vs `+=`) stalls a set's 5s acceleration if a current-set add despawns without `JustDied` → **fixed**: the lasher's no-target despawn path now sends `ACTION_ADD_DIED` (current-set guarded) before despawning; committed at `44004f0c4bce` and covered by Round 2 (not re-raised)

## Round 2 — `44004f0c4bce`, 1 finding

1. `EVENT_FREYA_TRIO_WAVE_END` (`boss_freya.cpp:640-641`) — re-raises Round 1 #2: `if (_trioWaveEndSetId != _currentSetId) break;` also skipped `_deforestation = 0`, and a stale set's third death (after the 1-min fallback advanced the set) never scheduled the event, so a full trio wipe no longer reset the Deforestation counter → **fixed**: `_deforestation = 0` now runs before the gate, and full-wipe scheduling is restored on the global `_trioDown >= 3` (`_trioWaveEndSetId` now only gates the wave acceleration); committed at `4b1d5d5a435`

## Round 3 — `4b1d5d5a435`, clean

**In-game test (author, not yet run)** — level 80, `.tele Freya`, `.cheat god`, engage, let Sets 1–2 spawn, `.damage 10000000` on Set 1, observe whether Set 3 spawns early (expected: it must NOT — a stale-set wipe must not trigger the acceleration); also verify wiping the CURRENT trio still accelerates the next wave to ~5s, and that Deforestation still fires — including after a full trio wipe completes while a later set is already up.

</details>


