### PR TITLE
fix(DB/SmartAI): 'Delicate Sound of Thunder' speed buff timing race

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1786648635519.sql
+++ b/data/sql/updates/pending_db_world/rev_1786648635519.sql
@@ -1,0 +1,25 @@
+-- [Howling Fjord] The Delicate Sound of Thunder (timing race):
+-- make the Rocket Jump speed buff (44626) atomic with the flight.
+DELETE FROM `spell_linked_spell` WHERE `spell_trigger` = 44608 AND `spell_effect` = 44626;
+
+DELETE FROM `smart_scripts` WHERE (`source_type` = 0 AND `entryorguid` = 24825);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(24825, 0, 0, 0, 54, 0, 100, 512, 0, 0, 0, 0, 0, 0, 75, 44643, 0, 0, 0, 0, 0, 23, 0, 0, 0, 0, 0, 0, 0, 0, 'Iron Rune Construct - On Just Summoned - Add Aura \'Reputation and Language\''),
+(24825, 0, 1, 0, 28, 0, 100, 512, 0, 0, 0, 0, 0, 0, 28, 44643, 0, 0, 0, 0, 0, 23, 0, 0, 0, 0, 0, 0, 0, 0, 'Iron Rune Construct - On Passenger Removed - Remove Aura \'Reputation and Language\''),
+(24825, 0, 2, 11, 72, 0, 100, 512, 1, 0, 0, 0, 0, 0, 11, 44626, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Iron Rune Construct - On Action Done - Cast Rocket Jump speed buff'),
+(24825, 0, 3, 12, 72, 0, 100, 512, 2, 0, 0, 0, 0, 0, 11, 44626, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Iron Rune Construct - On Action Done - Cast Rocket Jump speed buff'),
+(24825, 0, 4, 13, 72, 0, 100, 512, 3, 0, 0, 0, 0, 0, 11, 44626, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Iron Rune Construct - On Action Done - Cast Rocket Jump speed buff'),
+(24825, 0, 5, 14, 72, 0, 100, 512, 4, 0, 0, 0, 0, 0, 11, 44626, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Iron Rune Construct - On Action Done - Cast Rocket Jump speed buff'),
+(24825, 0, 6, 15, 72, 0, 100, 512, 5, 0, 0, 0, 0, 0, 11, 44626, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Iron Rune Construct - On Action Done - Cast Rocket Jump speed buff'),
+(24825, 0, 7, 16, 72, 0, 100, 512, 6, 0, 0, 0, 0, 0, 11, 44626, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Iron Rune Construct - On Action Done - Cast Rocket Jump speed buff'),
+(24825, 0, 8, 0, 58, 0, 100, 512, 0, 0, 0, 0, 0, 0, 28, 44626, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Iron Rune Construct - On Path 0 Finished - Remove Aura \'Rocket Jump\''),
+(24825, 0, 9, 0, 31, 0, 100, 512, 44609, 0, 3000, 3000, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Iron Rune Construct - On Target Spellhit \'Bluff\' - Say Line 0'),
+(24825, 0, 10, 0, 8, 0, 100, 512, 44626, 0, 5000, 5000, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Iron Rune Construct - On Spellhit \'Rocket Jump\' - Say Line 1'),
+(24825, 0, 11, 0, 61, 0, 100, 512, 0, 0, 0, 0, 0, 0, 53, 2, 24826, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Iron Rune Construct - Rocket Jump - Start flight path Level 1'),
+(24825, 0, 12, 0, 61, 0, 100, 512, 0, 0, 0, 0, 0, 0, 53, 2, 24827, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Iron Rune Construct - Rocket Jump - Start flight path Level 2'),
+(24825, 0, 13, 0, 61, 0, 100, 512, 0, 0, 0, 0, 0, 0, 53, 2, 24828, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Iron Rune Construct - Rocket Jump - Start flight path Ground Level'),
+(24825, 0, 14, 0, 61, 0, 100, 512, 0, 0, 0, 0, 0, 0, 53, 2, 24831, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Iron Rune Construct - Rocket Jump - Start flight path Level 1 Return'),
+(24825, 0, 15, 0, 61, 0, 100, 512, 0, 0, 0, 0, 0, 0, 53, 2, 24829, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Iron Rune Construct - Rocket Jump - Start flight path Ground Level Return'),
+(24825, 0, 16, 0, 61, 0, 100, 512, 0, 0, 0, 0, 0, 0, 53, 2, 24832, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Iron Rune Construct - Rocket Jump - Start flight path Level 2 Return'),
+(24825, 0, 17, 0, 57, 0, 100, 512, 0, 0, 0, 0, 0, 0, 28, 44626, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Iron Rune Construct - On Escort Stopped - Remove Aura Rocket Jump'),
+(24825, 0, 18, 0, 28, 0, 100, 512, 0, 0, 0, 0, 0, 0, 28, 44626, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Iron Rune Construct - On Passenger Removed - Remove Aura Rocket Jump');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: DeepSeek V4 Pro + AzerothMCP + Keira3
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/21570

A rare race can occur when using the jump pad
>  a mechanical creature there, then if you use the pad, use ability wrongly, then it will give you an insane speedboost that you can use to fly/travel around the map, however, you still are controlling an mechanoid, so nothing really that you can do with that I think.


## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Note: tough to reproduce

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ] "falling" animation during WP
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.

----

# Self-review — 21570-howling-fjord-rocket-jump (Part 2) → master

**Outcome** No findings — clean

**Reviewed** `rev_1786648635519.sql` (uncommitted working-tree file, new file — 26 lines, DB/SmartAI only)

**By** GitHub Copilot, DeepSeek V4 Pro — self-review v0.4, 2026-08-13

<details>
<summary>Review details (1 round)</summary>

**Intent** Quest 11495 ("The Delicate Sound of Thunder") Part 2: make the Iron Rune Construct's (24825) Rocket Jump speed buff (spell 44626) atomic with the flight — applied by the same SmartAI chain that starts the escort path, removed when the escort stops or the passenger leaves — instead of riding the launch spell for its full 60 s.

**Project rules** `.agents/docs/self-review-rules.md` present and applied (with `.agents/docs/code-review.md`, `sql-guidelines.md`, `cpp-scripts.md`)

## Round 1 — `rev_1786648635519.sql` (working tree), clean

No findings.

Notes (not findings):

1. `rev_1786649573107.sql` (Part 1) is a separate pending revision that `UPDATE`s `action_param1` to 3 (fly) on the same `SMART_ACTION_ESCORT_START` rows this file inserts with `action_param1` 2. It documents being applied on top of Part 2; timestamp order (…5519 < …3107) makes that true. Layering is correct, not a duplicate or conflict.
2. Whether the construct's synchronous self-cast of 44626 inside its own 44608 spellhit is ever rejected in-game is not determinable from source alone; author confirmed in-game that the buff no longer persists after an interrupted jump.

</details>

