### PR TITLE
fix(Scripts/ICC): make the Lady Deathwhisper elevator wait 7s at each…

### DIFF
--- a/src/server/scripts/Northrend/IcecrownCitadel/instance_icecrown_citadel.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/instance_icecrown_citadel.cpp
@@ -71,6 +71,9 @@ enum Say
     SAY_SOULS_LICH_KING_RAND_WHISPER = 5
 };
 
+// How long the Lady Deathwhisper elevator stays motionless at each end of its cycle before departing again.
+constexpr uint32 DARKWHISPER_ELEVATOR_DWELL_TIME = 7 * IN_MILLISECONDS;
+
 BossBoundaryData const boundaries =
 {
     { DATA_LORD_MARROWGAR, new CircleBoundary(Position(-428.0f,2211.0f), 95.0) },
@@ -212,7 +215,7 @@ public:
             PutricideEventProgress = 0;
             LichKingHeroicAvailable = true;
             LichKingRandomWhisperTimer = 120 * IN_MILLISECONDS;
-            DarkwhisperElevatorTimer = 3000;
+            DarkwhisperElevatorTimer = DARKWHISPER_ELEVATOR_DWELL_TIME;
 
             SetHeaders(DataHeader);
             SetBossNumber(MAX_ENCOUNTERS);
@@ -1664,21 +1667,28 @@ public:
             else
                 LichKingRandomWhisperTimer -= diff;
 
-            if (DarkwhisperElevatorTimer <= diff)
-            {
-                DarkwhisperElevatorTimer = 3000;
-                if (GetBossState(DATA_LADY_DEATHWHISPER) == DONE)
-                    if (GameObject* elevator = instance->GetGameObject(LadyDeathwisperElevatorGUID))
-                        if (StaticTransport* trans = elevator->ToStaticTransport())
+            if (GetBossState(DATA_LADY_DEATHWHISPER) == DONE)
+                if (GameObject* elevator = instance->GetGameObject(LadyDeathwisperElevatorGUID))
+                    if (StaticTransport* trans = elevator->ToStaticTransport())
+                    {
+                        // StaticTransport::Update clamps PathProgress to exactly 0 / GetPauseTime() and then freezes
+                        // there while GOState matches, so these two comparisons detect "parked at a stop" exactly.
+                        bool const atBottom = trans->GetGoState() == GO_STATE_READY && trans->GetPathProgress() == 0;
+                        bool const atTop = trans->GetGoState() == GO_STATE_ACTIVE &&
+                            trans->GetPathProgress() == trans->GetPauseTime();
+
+                        // Count the dwell down only while parked, so it always starts on arrival instead of on the
+                        // phase of a free-running tick. Flipping GOState sends the transport towards the other end.
+                        if (!atBottom && !atTop)
+                            DarkwhisperElevatorTimer = DARKWHISPER_ELEVATOR_DWELL_TIME;
+                        else if (DarkwhisperElevatorTimer <= diff)
                         {
-                            if (trans->GetGoState() == GO_STATE_READY && trans->GetPathProgress() == 0)
-                                trans->SetGoState(GO_STATE_ACTIVE);
-                            else if (trans->GetGoState() == GO_STATE_ACTIVE && trans->GetPathProgress() == trans->GetPauseTime())
-                                trans->SetGoState(GO_STATE_READY);
+                            DarkwhisperElevatorTimer = DARKWHISPER_ELEVATOR_DWELL_TIME;
+                            trans->SetGoState(atBottom ? GO_STATE_ACTIVE : GO_STATE_READY);
                         }
-            }
-            else
-                DarkwhisperElevatorTimer -= diff;
+                        else
+                            DarkwhisperElevatorTimer -= diff;
+                    }
 
             if (Events.Empty())
                 return;


### PR DESCRIPTION
… stop

The elevator was driven by a free running 3000 ms tick that had nothing to do with the moment it actually reached an end of its path, so the time it stood still was uniformly random in [0, 3000] ms and a raid often could not board it.

Count the dwell only while the transport is parked, so it always starts on arrival: rearm the timer while it is moving, and flip GOState once 7000 ms have passed at a stop. StaticTransport::Update clamps PathProgress to exactly 0 and GetPauseTime() and freezes there while GOState matches, so those comparisons detect "parked at a stop" exactly.

The ride itself is untouched. The client renders it from TransportAnimation.dbc, so pause time and path progress are left alone and no SQL is needed.

<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Opus5
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Progress #20324

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

https://www.youtube.com/watch?v=_z-_4-O6Fsg

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.

