### PR TITLE
fix(Core/Spells): sync Raise Dead cooldown with the client

### DIFF
--- a/src/server/game/Entities/Pet/Pet.cpp
+++ b/src/server/game/Entities/Pet/Pet.cpp
@@ -392,14 +392,24 @@ bool Pet::LoadPetFromDB(Player* owner, uint32 petEntry, uint32 petnumber, bool c
     /// @todo pets should be summoned from real cast instead of just faking it?
     if (petInfo->CreatedBySpellId && spellInfo && (spellInfo->CategoryRecoveryTime > 0 || spellInfo->RecoveryTime > 0))
     {
+        // The death knight ghoul is summoned by a spell the client never learns, its spellbook entry is another one
+        uint32 castSpellId = petInfo->CreatedBySpellId;
+        uint32 spellbookSpellId = owner->GetSpellbookSpellForCooldown(spellInfo);
+        if (spellbookSpellId)
+            castSpellId = spellbookSpellId;
+
         WorldPacket data(SMSG_SPELL_GO, (8 + 8 + 4 + 4 + 2));
         data << owner->GetPackGUID();
         data << owner->GetPackGUID();
         data << uint8(0);
-        data << uint32(petInfo->CreatedBySpellId);
+        data << uint32(castSpellId);
         data << uint32(256); // CAST_FLAG_UNKNOWN3
         data << uint32(0);
-        owner->SendMessageToSet(&data, true);
+        // The translated id is a real spell for every client, so bystanders would see a cast that never happened
+        if (spellbookSpellId)
+            owner->SendDirectMessage(&data);
+        else
+            owner->SendMessageToSet(&data, true);
     }
 
     owner->SetMinion(this, true);

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -9293,6 +9293,9 @@ void Player::RemovePet(Pet* pet, PetSaveMode mode, bool returnreagent)
             return;
     }
 
+    // Captured here because the reagent block below clears m_temporaryUnsummonedPetNumber
+    bool removedWhileTemporarilyUnsummoned = !pet && m_temporaryUnsummonedPetNumber;
+
     if (returnreagent && (pet || (m_temporaryUnsummonedPetNumber && (!m_session || !m_session->PlayerLogout()))) && !InBattleground())
     {
         //returning of reagents only for players, so best done here
@@ -9321,6 +9324,16 @@ void Player::RemovePet(Pet* pet, PetSaveMode mode, bool returnreagent)
 
     if (!pet)
     {
+        // The "pet is out" block is an infinity cooldown and those are never written to the DB, so it has
+        // to become the real one once the pet is gone for good or the session ends while it is away
+        SpellInfo const* petSpellInfo = nullptr;
+        if (removedWhileTemporarilyUnsummoned)
+        {
+            petSpellInfo = sSpellMgr->GetSpellInfo(m_oldpetspell);
+            if (petSpellInfo && !petSpellInfo->IsCooldownStartedOnEvent())
+                petSpellInfo = nullptr;
+        }
+
         if (mode == PET_SAVE_NOT_IN_SLOT && m_petStable && m_petStable->CurrentPet)
         {
             // Handle removing pet while it is in "temporarily unsummoned" state, for example on mount
@@ -9332,6 +9345,18 @@ void Player::RemovePet(Pet* pet, PetSaveMode mode, bool returnreagent)
 
             m_petStable->UnslottedPets.push_back(std::move(*m_petStable->CurrentPet));
             m_petStable->CurrentPet.reset();
+
+            if (petSpellInfo)
+            {
+                SendCooldownEvent(petSpellInfo);
+                // Nothing left to resummon, the pet is out of the slot now
+                m_temporaryUnsummonedPetNumber = 0;
+            }
+        }
+        else if (petSpellInfo && m_session && m_session->PlayerLogout())
+        {
+            // Runs before SaveToDB, so the cooldown reaches character_spell_cooldown
+            SendCooldownEvent(petSpellInfo);
         }
 
         return;
@@ -11277,11 +11302,65 @@ void Player::ModifySpellCooldown(uint32 spellId, int32 cooldown)
     SendDirectMessage(&data);
 }
 
+uint32 Player::GetSpellbookSpellForCooldown(SpellInfo const* spellInfo) const
+{
+    if (!spellInfo)
+        return 0;
+
+    // The spell itself is in the spellbook, so there is nothing to translate
+    if (HasActiveSpell(spellInfo->Id))
+        return 0;
+
+    uint32 category = spellInfo->GetCategory();
+    if (!category)
+        return 0;
+
+    SpellCategoryStore::const_iterator i_scstore = sSpellsByCategoryStore.find(category);
+    if (i_scstore == sSpellsByCategoryStore.end())
+        return 0;
+
+    for (auto i_scset = i_scstore->second.begin(); i_scset != i_scstore->second.end(); ++i_scset)
+    {
+        // Item categories share their ids with spell ones, they are not siblings
+        if (i_scset->first)
+            continue;
+
+        SpellInfo const* categorySpellInfo = sSpellMgr->GetSpellInfo(i_scset->second);
+        if (!categorySpellInfo || categorySpellInfo->SpellFamilyName != spellInfo->SpellFamilyName)
+            continue;
+
+        if (HasActiveSpell(i_scset->second))
+            return i_scset->second;
+    }
+
+    return 0;
+}
+
 void Player::SendCooldownEvent(SpellInfo const* spellInfo, uint32 itemId /*= 0*/, Spell* spell /*= nullptr*/, bool setCooldown /*= true*/)
 {
     // start cooldowns at server side, if any
     if (setCooldown)
         AddSpellAndCategoryCooldowns(spellInfo, itemId, spell);
+
+    // The spell triggering the event may not be in the client's spellbook (the death knight ghoul is
+    // summoned by one of those), so the client also needs the event for the spell it does know
+    if (!itemId && spellInfo->IsCooldownStartedOnEvent())
+    {
+        if (uint32 spellbookSpellId = GetSpellbookSpellForCooldown(spellInfo))
+        {
+            SpellCooldowns::iterator itr = m_spellCooldowns.find(spellbookSpellId);
+            if (itr != m_spellCooldowns.end())
+            {
+                // Otherwise SendInitialSpells skips it and the cooldown is lost on relog
+                itr->second.needSendToClient = true;
+            }
+
+            WorldPacket spellbookData(SMSG_COOLDOWN_EVENT, 4 + 8);
+            spellbookData << uint32(spellbookSpellId);
+            spellbookData << GetGUID();
+            SendDirectMessage(&spellbookData);
+        }
+    }
 
     // Send activate cooldown timer (possible 0) at client side
     WorldPacket data(SMSG_COOLDOWN_EVENT, 4 + 8);

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -1820,6 +1820,7 @@ public:
     [[nodiscard]] bool HasSpellCooldown(uint32 spell_id) const override;
     [[nodiscard]] bool HasSpellItemCooldown(uint32 spell_id, uint32 itemid) const override;
     [[nodiscard]] uint32 GetSpellCooldownDelay(uint32 spell_id) const;
+    [[nodiscard]] uint32 GetSpellbookSpellForCooldown(SpellInfo const* spellInfo) const;
     void AddSpellAndCategoryCooldowns(SpellInfo const* spellInfo, uint32 itemId, Spell* spell = nullptr, bool infinityCooldown = false);
     void AddSpellCooldown(uint32 spell_id, uint32 itemid, uint32 end_time, bool needSendToClient = false, bool forceSendToSpectator = false) override;
     void _AddSpellCooldown(uint32 spell_id, uint16 categoryId, uint32 itemid, uint32 end_time, bool needSendToClient = false, bool forceSendToSpectator = false);

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -7945,7 +7945,21 @@ void Unit::SetMinion(Minion* minion, bool apply)
             SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(minion->GetUInt32Value(UNIT_CREATED_BY_SPELL));
             // Remove infinity cooldown
             if (spellInfo && spellInfo->IsCooldownStartedOnEvent())
-                ToPlayer()->SendCooldownEvent(spellInfo);
+            {
+                // A pet put away for a while comes back untouched, so its cooldown must not start yet: the
+                // infinity cooldown stays and Pet::LoadPetFromDB restores the client side block on resummon
+                bool temporarilyUnsummoned = false;
+                if (Pet* pet = minion->ToPet())
+                {
+                    CharmInfo* charmInfo = pet->GetCharmInfo();
+                    bool hasCooldown = spellInfo->CategoryRecoveryTime > 0 || spellInfo->RecoveryTime > 0;
+                    temporarilyUnsummoned = charmInfo && hasCooldown
+                        && ToPlayer()->GetTemporaryUnsummonedPetNumber() == charmInfo->GetPetNumber();
+                }
+
+                if (!temporarilyUnsummoned)
+                    ToPlayer()->SendCooldownEvent(spellInfo);
+            }
 
             // xinef: clear spell book
             if (m_Controlled.empty())

--- a/src/server/scripts/Spells/spell_dk.cpp
+++ b/src/server/scripts/Spells/spell_dk.cpp
@@ -2174,7 +2174,6 @@ class spell_dk_raise_dead : public SpellScript
         targets.SetDst(*GetHitUnit());
 
         GetCaster()->CastSpell(targets, spellInfo, nullptr, TRIGGERED_FULL_MASK, nullptr, nullptr, GetCaster()->GetGUID());
-        GetCaster()->ToPlayer()->RemoveSpellCooldown(GetSpellInfo()->Id, true);
     }
 
     void Register() override


### PR DESCRIPTION
## Changes Proposed:

A Death Knight's Raise Dead (46584) ends up out of sync between client and server: the icon looks ready, but casting answers *"Spell is not ready yet"*. It clears up on relog, which is why it reads as random.

The ghoul is summoned by a triggered spell, 46585 without Master of Ghouls or 52150 with it. Neither is in the client's spellbook. When the ghoul dies, `Unit::RemoveMinion` calls `Player::SendCooldownEvent` with that triggered spell, so the `SMSG_COOLDOWN_EVENT` goes out with an id the client has never seen and gets dropped. Server side the 3 minute cooldown does land on 46584, through the category sibling loop in `AddSpellAndCategoryCooldowns`, with `needSendToClient = false`. Server blocked, client unaware.

The link the core was missing is the spell category. AzerothCore has no category cooldown map (TrinityCore resolves this through `SpellHistory::_categoryCooldowns`), so this adds a small helper that walks `sSpellsByCategoryStore` and answers "which spell in this category does the player actually have in the spellbook". `SendCooldownEvent` then sends a second event for that spell and flags its cooldown entry so it survives a relog. Everything else about the function is untouched.

Three more things fell out of that:

- `spell_dk_raise_dead` called `RemoveSpellCooldown(46584, true)` right after summoning. Server side that was a no-op, the only entry there was the infinity "pet is out" block, and the `SMSG_CLEAR_COOLDOWN` it sent desynced the client further. It also happened to be the only thing stopping a second guardian from being summoned. Gone.
- A pet that is only parked for a while (mounting, zoning, vehicles) no longer starts the real cooldown. The infinity block stays and the pet comes back to it, which is what retail does: the spell is blocked because the ghoul is out, not because it is recharging.
- The fake `SMSG_SPELL_GO` that `Pet::LoadPetFromDB` sends to restore the client-side block now carries the spellbook id when the create spell isn't in the book. Since that id is a real spell every client knows, on this path it goes to the owner alone instead of the whole visibility set, otherwise bystanders would see a Raise Dead cast that never happened. Every other class keeps master's broadcast.

Nothing else is affected. Every entry point is closed by filters that only Raise Dead crosses in 3.3.5a data:

| Guard | Where | What it rules out |
| --- | --- | --- |
| `HasActiveSpell(spellInfo->Id)` returns early | `Player::GetSpellbookSpellForCooldown` | every summon whose spell is already in the spellbook (warlock, hunter, mage, totems, summoned items) |
| `!itemId` | `Player::SendCooldownEvent` | potions and item-triggered spells, which always arrive with an item id |
| `IsCooldownStartedOnEvent()` | `SendCooldownEvent`, `RemoveMinion`, `RemovePet` | Summon Imp (688), Call Pet (883), Summon Water Elemental (31687), none of which carry the attribute |
| `ToPet()` non-null plus a recovery time plus a matching parked pet number | `Unit::RemoveMinion` | guardians, totems, minipets, and any pet summon without a DBC cooldown |
| same `SpellFamilyName` | `Player::GetSpellbookSpellForCooldown` | any other class sharing a category id |

### Evidence

Read from this server's DBC files through the AzerothCore MCP, not transcribed from a wiki:

| Id | Spell | Category | RecoveryTime | CategoryRecoveryTime | Family | FamilyFlags[0] | Attributes | `COOLDOWN_ON_EVENT` (0x02000000) |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| 46584 | Raise Dead (spellbook) | 1245 | 0 | 180000 | 15 | 0x1000 | 0x82000000 | yes |
| 46585 | Raise Dead (guardian, 60s) | 1245 | 0 | 180000 | 15 | 0x1000 | 0x02010000 | yes |
| 52150 | Raise Dead (pet, Master of Ghouls) | 1245 | 0 | 180000 | 15 | 0x1000 | 0x0A810000 | yes (plus Attr7 0x4000) |
| 688 | Summon Imp | 0 | 0 | 0 | 5 | — | — | no |
| 883 | Call Pet | 0 | 0 | 0 | 0 | — | — | no |
| 31687 | Summon Water Elemental | 0 | 0 | 0 | 3 | — | — | no |

`SpellCategory.dbc` row 1245 has `flags = 0`, so the "cooldown starts on event" behaviour comes from the spell attribute, not the category. The DBC data is correct and untouched.

Related data that had to line up: Night of the Dead (55620 / 55623) applies `SPELLMOD_COOLDOWN` of -45s / -90s over ClassMask 0x1000, which covers 46584, 46585 and 52150 alike, so client and server compute the same number. Glyph of Raise Dead (60200) only applies `SPELL_AURA_NO_REAGENT_USE` and never touches cooldowns.

Before and after, per case:

| Case | master | this PR |
| --- | --- | --- |
| Ghoul dies (killed, Death Pact, guardian expiring, player death) | server starts 180s on 46584, client gets an event for 46585/52150 and drops it | both sides show the same 180s |
| Ghoul alive | server has nothing, the script wiped the block; a second guardian could be summoned | the "pet is out" block holds on both sides |
| Mount, zone, vehicle | real 180s starts even though the pet comes right back | the block is kept, no cooldown starts |
| Pet reloaded from DB | fake cast sent with 52150, which the client ignores | sent with 46584, to the owner only |
| Logout while the pet is parked | infinity block is never persisted, so Raise Dead came back free | the real cooldown starts before the save, so it is there on relog |

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Claude Agent SDK) running Opus 5 (`claude-opus-5`), for the code, this description, and the review below. It ran the phase pipeline from the AC agentic workflow: `azerothcore-research` for the research notes, `/refine-ticket` for the requirements, `/create-implementation-plan` for the plan, then implementation, then `/self-review` (which drives `fresh-eyes-review` in a separate context) and `/generate-pr-description`. All game data came from the AzerothCore MCP reading this server's own DBC files and source tree, so the values above are what the server actually runs.
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #27081

It should also cover [#25337](https://github.com/azerothcore/azerothcore-wotlk/issues/25337) (Glyph of Raise Dead showing no cooldown), [chromiecraft/chromiecraft#9997](https://github.com/chromiecraft/chromiecraft/issues/9997) and [chromiecraft/chromiecraft#9232](https://github.com/chromiecraft/chromiecraft/issues/9232), which are the same desync reported from different angles. [chromiecraft/chromiecraft#9858](https://github.com/chromiecraft/chromiecraft/issues/9858) (ghoul on permanent cooldown after a knockback) looks like a different bug and is not claimed here.

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

- [Wowhead WotLK 46584](https://www.wowhead.com/wotlk/spell=46584/raise-dead) for the tooltip and the confirmation that Raise Dead and Raise Ally do not share a cooldown.
- Video repro of the bug in [chromiecraft/chromiecraft#9997](https://github.com/chromiecraft/chromiecraft/issues/9997).
- A 2009 Blizzard support case on the same symptom, [bluetracker](https://www.bluetracker.gg/wow/topic/eu-en/9520844585-solved-raise-dead-spell-not-ready-yet/).
- TrinityCore 3.3.5 solved the same problem with the same idea, the spell category as the link: [`SpellHistory::SendCooldownEvent`](https://github.com/TrinityCore/TrinityCore/blob/3.3.5/src/server/game/Spells/SpellHistory.cpp) and `spell_dk_raise_dead::OverrideCooldown` in [`spell_dk.cpp`](https://github.com/TrinityCore/TrinityCore/blob/3.3.5/src/server/scripts/Spells/spell_dk.cpp). The code here is written for AzerothCore's own cooldown containers, not copied, so this is not a cherry-pick.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Builds clean on Windows with MSVC (RelWithDebInfo), no new warnings. `apps/codestyle/codestyle-cpp.py` passes.

Tested in-game on a level 80 Death Knight, with `.cheat cooldown off` so the server state is real:

- The reported repro: summon, `.die`, release, resurrect, zone into a dungeon, cast Raise Dead. The icon shows the real cooldown and the *"Spell is not ready yet"* mismatch is gone.
- Ghoul killed with `.damage 99999`: cooldown starts on both sides, and the resummon works when it expires, with no relog.
- Death Pact on the ghoul: same, 3 minutes.
- Guardian without Master of Ghouls, left to expire on its own after 60s: cooldown starts.
- Mount and dismount with Master of Ghouls: the ghoul is parked and comes back, the icon stays blocked and no 3 minute countdown appears. Pressing Raise Dead with the ghoul back is refused and no second ghoul appears.
- Zoning into a dungeon and out, and entering and leaving a vehicle: same as mounting.
- Respec out of Master of Ghouls while mounted: the pet does not come back and Raise Dead gets a normal cooldown that expires, not a permanent block.
- Logout mounted with the ghoul parked, then relog: the cooldown is there and running, no free ghoul.
- Relog with the cooldown partway through: the remaining time matches what it was.

Not tested yet: the non-DK regression pass on the shared functions (warlock and hunter across mount, zone, death and a battleground death while mounted, a shaman totem, a potion), Night of the Dead's reduced cooldown, and the Glyph of Raise Dead case.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Level 80 Death Knight with Master of Ghouls (52143) and some Corpse Dust (`.additem 37201 20`). Turn cheats off with `.cheat cooldown off`, otherwise none of this measures anything.
2. Summon the ghoul, `.die`, release, resurrect, walk into a dungeon and press Raise Dead. The icon must show the real remaining cooldown, and once it expires the summon must work.
3. Summon again, kill the ghoul with `.damage 99999`. The cooldown must start immediately on the icon and the resummon must work when it runs out, without relogging.
4. With the ghoul alive, press Raise Dead again. It must be refused, with no second ghoul, both with and without Master of Ghouls.
5. Mount with the ghoul out. It gets parked, and the icon must stay blocked with no 3 minute countdown. Dismount and the same ghoul comes back.
6. Repeat step 5, and while still mounted log out to the character screen and back in. The cooldown must be running when you return, and you must not be able to summon a second ghoul.
7. Regression, since these functions are shared: warlock and hunter pets across mounting, zoning, dying and a battleground death while mounted; a shaman totem expiring; a potion with a category cooldown.

## Known Issues and TODO List:

- [ ] The non-DK regression pass listed above still needs eyes, ideally from someone other than me.
- [ ] Two pre-existing bugs were found while reviewing and are deliberately **not** fixed here, to keep this PR to one concern. `Player::SendInitialSpells` announces `m_spellCooldowns.size()` and then skips every entry with `needSendToClient == false`, so `SMSG_INITIAL_SPELLS` carries a count higher than the number of entries written whenever anyone holds a category cooldown. In practice the client copes, relogging with a Raise Dead cooldown shows the right time left, but the count is still wrong. And `Aura::_UnapplyForTarget` runs the same `SendCooldownEvent` twice for a player caster, two identical blocks a few lines apart, so `AddSpellAndCategoryCooldowns` also runs twice on every aura unapply. Happy to open follow-ups for both.
- [ ] `SPELL_ATTR7_RECAST_ON_RESUMMON` (0x4000) is set on 52150, is defined in `SharedDefines.h` and is still unused. It was not used here because its documented meaning is "recast on resummon", not "do not start the cooldown", but it may be the cleaner gate if a maintainer prefers it.

## Self-review

A fresh-context agent reviewed the change as a maintainer would, three rounds, each on the commit produced by the previous one.

**3 findings, 3 fixed. Rounds stopped at the 3 round cap, so the round 3 fix was not re-reviewed; it is covered by in-game testing instead (the logout case above).**

Reviewed at `4770a05f0` against `origin/master` `7d9027d73`, 5 files, +107 −4. Reviewer: Claude Code, Opus 5, 2026-08-14. The rounds ran on the wider version of the change; the three cross-class edits they cleared were taken back out afterwards to keep this PR to the Death Knight, which is why two of them appear under Known Issues above.

**Round 1** — 1 finding.

1. `Pet::LoadPetFromDB` sends the fake `SMSG_SPELL_GO` to the whole visibility set. With the id translation it now carries 46584, a real spell for every client, so bystanders would see a Raise Dead cast that never happened every time a DK's ghoul is restored. **Fixed**: sent to the owner alone on the translated path, every other class keeps the broadcast.

**Round 2** — 1 finding.

2. `Player::RemovePet` cleared `m_temporaryUnsummonedPetNumber` for every class. A warlock or hunter dying mounted inside a battleground skips the reagent block that used to clear it, so the pet stopped coming back on dismount and a soul shard was wasted. **Fixed**: the clear only runs when a cooldown was actually converted, which is the ghoul's case alone.

**Round 3** — 1 finding.

3. Logging out mounted with the ghoul parked left Raise Dead with no cooldown at all: the new guard keeps the infinity block, `LogoutPlayer` calls `RemovePet(nullptr, PET_SAVE_AS_CURRENT)` which missed the conversion, and infinity cooldowns are never persisted. On relog the icon was free and a new ghoul cost nothing. **Fixed**: the logout path starts the real cooldown, and it runs before `SaveToDB` so it reaches `character_spell_cooldown`. Verified in-game afterwards.

Both reviewers covered every changed file, verified the DBC claims themselves rather than taking them from the description, and checked every caller of the touched functions. Neither reviewer had access to the planning documents.

## Research notes

**How "cooldown on event" works here.** `Player::m_spellCooldowns` maps spell id to `{ end, category, itemid, maxduration, needSendToClient, sendToSpectator }`. There is no per-category map, so category blocking is emulated by writing one entry per sibling spell in `AddSpellAndCategoryCooldowns`, and `HasSpellCooldown` is a plain `find(spellId)`. Siblings get `needSendToClient = false` when the cast spell is `IsCooldownStartedOnEvent()`, which is exactly our case, and `SendInitialSpells` skips those on login.

**The chain, with Master of Ghouls.** The DK casts 46584. `Spell::SendSpellCooldown` returns early because of the attribute, so no server cooldown, and the client blocks the icon on its own. The script summons 52150 and then wipes 46584's entry, sending `SMSG_CLEAR_COOLDOWN` to a client that was correctly blocked. The player dies, `Player::setDeathState` reaches `Unit::RemoveMinion`, which calls `SendCooldownEvent(52150)`: the 180s lands on 52150 and on 46584 through the sibling loop, and the packet goes out with 52150, which the client drops. The player resurrects, presses the button, and `Spell::CheckCast` finds the entry on 46584 and answers `SPELL_FAILED_NOT_READY`. Relogging resyncs both sides, hence the "sometimes it fixes itself".

**Prior art.** TrinityCore hit this in [TrinityCore/TrinityCore#15862](https://github.com/TrinityCore/TrinityCore/issues/15862) and fixed it with the same insight, the category as the link between the triggered spell and the spellbook one. TC starts an on-hold cooldown on 46584 at cast time and resolves the category in `SpellHistory::SendCooldownEvent`. AzerothCore already gets the on-hold half for free through `Unit::SetMinion`, which applies the infinity cooldown, so what was missing was only the lookup. VMaNGOS predates the mechanic and has nothing comparable.

**Patch history.**

| Patch | Change | Applies to 3.3.5a |
| --- | --- | --- |
| 3.0.2 | Raise Dead added: one ghoul, 1 minute, 3 minute cooldown, humanoid corpse or Corpse Dust | yes |
| 3.0.2 | Master of Ghouls (52143) makes the ghoul a permanent controllable pet (52150) | yes |
| 3.0.8 | Raise Ally added, and it does not share a cooldown with Raise Dead | yes |
| 3.1.0 | Ghoul scaling and ability adjustments | yes |
| 3.2.x | Night of the Dead reduces Raise Dead and Army of the Dead by the values now in 55620 / 55623 | yes, and it matches this server's DBC |
| 4.x Cataclysm | Reagent dropped, ghoul permanent for Unholy without the talent, cooldown changed | no, do not apply |

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.

