### PR TITLE
fix(Scripts/Spells): Glyph of Lightwell not increasing Lightwell healing

### DIFF
--- a/src/server/scripts/Spells/spell_priest.cpp
+++ b/src/server/scripts/Spells/spell_priest.cpp
@@ -359,6 +359,22 @@ class spell_pri_hymn_of_hope : public SpellScript
     }
 };
 
+static bool IsLightwellEntry(uint32 entry)
+{
+    switch (entry)
+    {
+        case PRIEST_LIGHTWELL_NPC_1:
+        case PRIEST_LIGHTWELL_NPC_2:
+        case PRIEST_LIGHTWELL_NPC_3:
+        case PRIEST_LIGHTWELL_NPC_4:
+        case PRIEST_LIGHTWELL_NPC_5:
+        case PRIEST_LIGHTWELL_NPC_6:
+            return true;
+        default:
+            return false;
+    }
+}
+
 // 60123 - Lightwell
 class spell_pri_lightwell : public SpellScript
 {
@@ -389,7 +405,8 @@ class spell_pri_lightwell : public SpellScript
         // proc a spellcast
         if (Aura* chargesAura = caster->GetAura(SPELL_PRIEST_LIGHTWELL_CHARGES))
         {
-            caster->CastSpell(GetHitUnit(), lightwellRenew, caster->ToTempSummon()->GetSummonerGUID());
+            caster->CastSpell(GetHitUnit(), lightwellRenew, true, nullptr, nullptr,
+                caster->ToTempSummon()->GetSummonerGUID());
             if (chargesAura->ModCharges(-1))
                 caster->ToTempSummon()->UnSummon();
         }
@@ -439,16 +456,26 @@ class spell_pri_lightwell_renew : public AuraScript
 
     void HandleUpdateSpellclick(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
     {
-        if (Unit* caster = GetCaster())
+        Player* player = GetTarget()->ToPlayer();
+        if (!player)
+            return;
+
+        Unit* caster = GetCaster();
+        if (!caster)
+            return;
+
+        // The renew is cast by the priest, so resend the well's own fields instead: the spellclick
+        // condition that hides the click while the renew is up is evaluated on them, per player.
+        for (Unit* controlled : caster->m_Controlled)
         {
-            if (Player* player = GetTarget()->ToPlayer())
-            {
-                UpdateData data;
-                WorldPacket packet;
-                caster->BuildValuesUpdateBlockForPlayer(&data, player);
-                data.BuildPacket(packet);
-                player->SendDirectMessage(&packet);
-            }
+            if (!IsLightwellEntry(controlled->GetEntry()))
+                continue;
+
+            UpdateData data;
+            WorldPacket packet;
+            controlled->BuildValuesUpdateBlockForPlayer(&data, player);
+            data.BuildPacket(packet);
+            player->SendDirectMessage(&packet);
         }
     }
 


### PR DESCRIPTION
## Changes Proposed:

The Lightwell Renew was cast without an original caster, so the priest was not the owner of the heal. The call in `spell_pri_lightwell::HandleScriptEffect` was

```cpp
caster->CastSpell(GetHitUnit(), lightwellRenew, caster->ToTempSummon()->GetSummonerGUID());
```

AzerothCore has no `CastSpell` overload taking an `ObjectGuid` in third position. `ObjectGuid` declares a non-explicit `operator bool()`, so the compiler picks the `bool triggered` overload, the guid becomes `true`, and `originalCaster` stays empty. It compiles clean, without a warning. The script was ported from TrinityCore, where the same line means "triggered, original caster = summoner" because their API takes a `CastSpellExtraArgs`, which does have an `ObjectGuid` constructor.

The renew aura therefore belonged to the Lightwell creature, which breaks three things at once:

- Glyph of Lightwell does nothing. `spell_pri_lightwell_renew::CalculateAmount` looks for aura 55673 on `GetCaster()`, and the well never has it.
- The priest's healing modifiers do not apply. The per tick `SPELL_AURA_MOD_HEALING_DONE_PERCENT` multiplier is read off `GetCaster()`, which is the well, so it is always 1.0.
- The combat log credits the Lightwell instead of the priest.

Passing the guid as `originalCaster` fixes all three.

`HandleUpdateSpellclick` needed fixing on top of that. It resends the aura caster's field values to the target so the client can re-check the spellclick condition that hides the click while the renew is up, and that condition is evaluated on the well's `UNIT_NPC_FLAGS`, not the priest's. It now looks the well up among the priest's minions instead. Without this, the well would keep looking clickable client-side while the renew was running.

**Heads up on the numbers**: healing goes up by considerably more than the glyph's 20%, because the priest's healing modifiers come back with the fix. That is the blizzlike behaviour, but anyone testing should expect the jump.

### Evidence

All values read from this server's own DBC and world DB.

| Item | Id | Data |
| --- | --- | --- |
| Glyph of Lightwell (item) | 42403 | Major priest glyph, requires level 40, teaches spell 56169 |
| Glyph of Lightwell (aura) | 55673 | EFFECT_0 = `SPELL_AURA_DUMMY`, `CalcValue()` = 20, Attributes `0xc0` (passive + hidden). Not a pct modifier, so a script has to read it |
| Lightwell (spellclick) | 60123 | EFFECT_0 = `SPELL_EFFECT_SCRIPT_EFFECT`, drives `spell_pri_lightwell` |
| Lightwell Charges | 59907 | 10 charges, cast on itself by `npc_pet_pri_lightwell` |

Lightwell Renew, all six ranks. `SPELL_AURA_PERIODIC_HEAL`, `Amplitude` 2000 (tick every 2s), 3 ticks, `ProcCharges` 1, family 6, `SpellFamilyFlags [0,0,16384]`:

| Rank | Spell id | Level | Base heal per tick | Well entry |
| --- | --- | --- | --- | --- |
| 1 | 7001 | 40 | 267 | 31897 |
| 2 | 27873 | 50 | 388 | 31896 |
| 3 | 27874 | 60 | 533 | 31895 |
| 4 | 28276 | 70 | 787 | 31894 |
| 5 | 48084 | 75 | 1305 | 31893 |
| 6 | 48085 | 80 | 1540 | 31883 |

Why the spellclick handler needs the well and not the priest:

| Fact | Where |
| --- | --- |
| Spellclick is gated by a negative aura condition, one per rank (source type 18, `SourceGroup` = well entry, `SourceEntry` = 60123, forbidden aura = that rank's renew) | world DB `conditions` |
| `UNIT_NPC_FLAG_SPELLCLICK` is stripped per player when building a **creature's** values | `Unit::PatchValuesUpdate`, `Unit.cpp:16949-16951` |
| `Aura` stores a single caster guid, so the aura keeps no trace of the well once the priest owns it | `SpellAuras.h:258` |
| The well is not in `m_SummonSlot`: its `SummonProperties` (1141, from spell 724 effect 28 `MiscValueB`) has `Slot = 0`, and `TempSummon::InitStats` only assigns a slot when it is non-zero | `TemporarySummon.cpp:234-244` |
| The well **is** in the priest's `m_Controlled`: `SummonProperties.Type` 11 maps to `UNIT_MASK_TOTEM`, a `Totem` derives from `Minion`, and `Minion::InitStats` calls `owner->SetMinion(this, true)` | `Object.cpp:2268-2270`, `TemporarySummon.cpp:375`, `Unit.cpp:7861` |

The six well entries are matched one by one rather than relying on `IsTotem()`. A Lightwell is the only totem a priest can own today, but nothing in the core guarantees that.

A search across all of `src/` for `CastSpell` calls passing a `…GUID()` in third position found this one and no others, so the same mistake is not sitting in another script.

### Measured in-game

Level 80 priest, per tick, same gear throughout:

| Rank | Well entry | DBC base | No glyph | With glyph | Ratio |
| --- | --- | --- | --- | --- | --- |
| 1 (7001) | 31897 | 267 | 310 | 372 | ×1.20 |
| 6 (48085) | 31883 | 1540 | 1693 | 2032 | ×1.20 |

The glyph lands exactly 20% on both ranks. The heal also comes out above the flat DBC base (1540 → 1693 on rank 6), and that surplus is the priest's healing modifiers, which the tick now reads off the priest instead of the well.

On master the tick is the flat DBC base, 1540 on rank 6, with or without the glyph: the aura belongs to the creature, so the glyph lookup finds nothing and the healing modifiers are read off the well. The missing 20% is what #27111 reports. The missing modifiers have never been reported separately, and fall out of the same broken line.

So on this gear a glyphed rank 6 Lightwell goes from 1540 to 2032 per tick, roughly +32%, not the +20% the glyph alone suggests.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code, model Opus 5. The agent produced both the code changes and this description. It ran the phase pipeline from `.agents/docs/agentic-workflow.md`: `/fetch-ticket` for the issue, the `azerothcore-research` skill for the research document, `/refine-ticket` for the requirements, `/create-implementation-plan` for the plan, then execution, then a self-review following `.agents/docs/self-review-rules.md` and `.agents/docs/code-review.md` (the `/self-review` skill itself is not installed in this checkout), then `/generate-pr-description`. Every spell, DBC, condition and creature value above came from the AzerothCore MCP querying this server's own `acore_world` DB and DBC files, not from a wiki transcription. All in-game testing was done by the author.
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #27111

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

- [Glyph of Lightwell (item 42403)](https://www.wowhead.com/wotlk/item=42403/glyph-of-lightwell) — the +20% tooltip, and a comment reporting 3 ticks of 3000 in levelling blues, a figure only reachable with the priest's spell power scaling applied.
- [Glyph of Lightwell (spell 55673)](https://www.wowhead.com/wotlk/spell=55673/glyph-of-lightwell) — confirms `Apply Aura: Dummy`, value 20, marked "Server-side script", and lists the six affected Lightwell Renew ranks.
- [TrinityCore 3.3.5 `spell_priest.cpp`](https://github.com/TrinityCore/TrinityCore/blob/3.3.5/src/server/scripts/Spells/spell_priest.cpp) and [`SpellDefines.h`](https://github.com/TrinityCore/TrinityCore/blob/3.3.5/src/server/game/Spells/SpellDefines.h) — the same line with the API that makes it mean what it looks like.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Builds clean on MSVC (Visual Studio 2026, RelWithDebInfo), no new errors or warnings.

Tested in-game on a level 80 priest:

- Glyph applies exactly +20% on rank 1 and rank 6 (numbers in the table above). Ranks 2 to 5 were not measured: they share the same script and code path, and an exact ×1.20 on two bases as far apart as 267 and 1540 covers the per-rank scaling.
- Removing the glyph and resummoning puts the numbers back to the unglyphed values exactly.
- The priest's healing modifiers apply to the tick, which they do not on master.
- The combat log credits the priest, not the Lightwell.
- The well is not clickable while the renew is up, and becomes clickable again as soon as it drops. This is the `HandleUpdateSpellclick` part of the change.
- Charges are unchanged: one per click, despawns on the tenth.
- With the priest dead, the well stays up, still takes clicks and still heals, no crash.

Not covered: cancelling the renew on 30% max health damage taken. That path lives in `CheckDropCharge` and `InitializeAmount`, which this change does not touch, and it does not depend on who owns the aura.

### Self-review

2 findings — 2 fixed — final round clean. One file, 37 insertions and 10 deletions.

Round 1, on the original one-line change:

- **`HandleUpdateSpellclick` stopped refreshing the well.** The handler pushed the aura caster's values to the player so the client could re-check the spellclick condition. Moving the aura's caster to the priest made it push the priest's values instead, which do nothing: the per-player `UNIT_NPC_FLAG_SPELLCLICK` stripping only runs for creatures. The well would have kept looking clickable while the renew was up. *Fixed* by resolving the well from the priest's minions, and confirmed in-game afterwards.

Round 2, on the code that fixed the above:

- **The lookup loop stopped at the first well.** With `SummonProperties.Slot = 0` there is no replacement logic, so a priest can end up with two live wells (cooldown reset, GM `.cast`), and the loop would refresh an arbitrary one. *Fixed* by dropping the `break` and refreshing every well found. Resending one extra is harmless.
- Everything else in round 2 came back clean: `GetTarget()` is valid in both `AfterEffectApply` and `AfterEffectRemove`, `ToPlayer()` and `GetCaster()` are null-checked, the loop does not mutate `m_Controlled`, `IsLightwellEntry` is used, no new line exceeds 120 columns, and `python apps/codestyle/codestyle-cpp.py` passes.

Also verified: the new call matches `CastSpell(Unit*, uint32, bool, Item*, AuraEffect const*, ObjectGuid)` exactly and keeps the `TRIGGERED_FULL_MASK` the broken call already produced, so nothing else about the cast changes. `caster->ToTempSummon()` cannot be null, since the handler returns early on `!caster->IsSummon()` and `ToTempSummon()` is guarded by that same check.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

Note: `npc_spellclick_spells` has `user_type = 2` (`SPELL_CLICK_USER_RAID`), so whoever clicks must be in the priest's group or raid. Testing solo works, a priest can use their own well.

1. On a level 80 priest with no glyph applied, summon the Lightwell, click it, and write down the three tick values. Check the well is entry 31883 with `.npc info`, so you are on rank 6.
2. Apply Glyph of Lightwell (item 42403), or `.aura 55673` to skip the Lexicon of Power, resummon the well and click it again. Each tick should heal exactly 20% more than in step 1.
3. Remove the glyph, resummon, click. The numbers should go back to the step 1 values exactly.
4. Check the target's combat log. The heal should be credited to the priest, not to the Lightwell.
5. While the renew is up, check the well is not clickable, and that it becomes clickable again once the renew drops. This is what the `HandleUpdateSpellclick` part of the change covers.
6. Click the well ten times across the group. It should still spend one charge per click and despawn on the tenth.
7. Take damage adding up to 30% of your max health while the renew is running. It should still cancel.
8. Kill the priest, then click the well with another character. It should stay alive, keep healing with the glyph applied, and not crash.

## Known Issues and TODO List:

- [ ] The renew cancelling on 30% max health damage was not re-tested. Untouched by this change.

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.

