### PR TITLE
fix(Core/Spells): Glyph of Hurricane no longer cuts Hurricane's damage

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -103,6 +103,11 @@
 //  see: https://github.com/azerothcore/azerothcore-wotlk/issues/9766
 #include "GridNotifiersImpl.h"
 
+enum DruidSpells
+{
+    SPELL_DRUID_GLYPH_OF_HURRICANE  = 54831
+};
+
 enum CharacterFlags
 {
     CHARACTER_FLAG_NONE                 = 0x00000000,
@@ -9989,6 +9994,13 @@ bool Player::IsAffectedBySpellmod(SpellInfo const* spellInfo, SpellModifier* mod
 
     // +duration to infinite duration spells making them limited
     if (mod->op == SPELLMOD_DURATION && spellInfo->GetDuration() == -1)
+        return false;
+
+    // The glyph's flat -20 is meant for the dormant slow sitting in the channelled spell's first
+    // effect. Hurricane's triggered damage spells share its family mask and hold direct damage at
+    // that same index, so keep the mod away from them.
+    if (mod->spellId == SPELL_DRUID_GLYPH_OF_HURRICANE && mod->op == SPELLMOD_EFFECT1 &&
+        !spellInfo->Effects[EFFECT_0].IsAura())
         return false;
 
     return spellInfo->IsAffectedBySpellMod(mod);


### PR DESCRIPTION
## Changes Proposed:

Closes #26877. With the Glyph of Hurricane equipped, every Hurricane tick hits for less.

The glyph's effect 0 is a flat `-20` (`ADD_FLAT_MODIFIER`, `MiscValue 3` = `SPELLMOD_EFFECT1`) on druid family mask `0x400000`. That mask is Hurricane, and the channelled ranks keep a dormant slow in their first effect: `MOD_DECREASE_SPEED` at base `-1 / DieSides 1`, so 0 until something moves it. The glyph is what moves it, which is why Hurricane's own tooltip spells the slow out conditionally: `$?s54831[reduces movement speed by $54831s1%][]`.

The catch is that the spells carrying Hurricane's periodic damage share that mask exactly, and their first effect is `SCHOOL_DAMAGE`. `SPELLMOD_EFFECT1` means effect index 0 either way, so the same `-20` came off the damage.

Note it is a flat `-20`, not a percentage. It only looks like 20% at rank 1, where the damage spell's base is 100. At rank 5 the base is 451, so the loss is about 4.4%, which is why this is easy to miss when testing at level 80.

The guard sits next to the existing infinite-duration one in `Player::IsAffectedBySpellmod` and skips the modifier when the spell being evaluated has no aura in its first effect. It is tied to `SPELLMOD_EFFECT1` so the glyph's second modifier, the `+30%` `SPELLMOD_DOT` for Insect Swarm on mask `0x200000`, is left alone.

### Evidence

All values read from this server's `Spell.dbc` through the AzerothCore MCP.

| Spell | Effect 0 | `IsAura()` | Mod applies |
| --- | --- | --- | --- |
| 54831 Glyph of Hurricane | `ADD_FLAT_MODIFIER`, `MiscValue 3` (`SPELLMOD_EFFECT1`), base `-21` + `DieSides 1` = `-20`, mask `0x400000` | n/a | source of the mod |
| 54831 effect 1 | `ADD_PCT_MODIFIER`, `MiscValue 22` (`SPELLMOD_DOT`), `+30`, mask `0x200000` (Insect Swarm) | n/a | untouched by the guard |
| 16914 Hurricane r1 | `PERSISTENT_AREA_AURA`, aura 33 `MOD_DECREASE_SPEED`, base `-1` + `DieSides 1` = 0 | true | yes, slow turns on |
| 17401 / 17402 / 27012 r2-r4 | same shape | true | yes |
| 48467 Hurricane r5 | same shape, effect 1 `MOD_MELEE_HASTE` base `-21` = `-20` | true | yes |
| 42231 damage r1 | `SCHOOL_DAMAGE`, `ApplyAuraName 0` | false | no, this is the fix |
| 42232 / 42233 / 42230 damage r2-r4 | same shape | false | no |
| 48466 damage r5 | same shape | false | no |

Neither 42231 nor 48466 carries `SPELL_ATTR3_IGNORE_CASTER_MODIFIERS`, so nothing was already blocking the leak.

Alternatives dropped, each for a reason worth recording:

- **Clearing the family mask on the damage spells** breaks Gale Winds (48488), which raises that same damage by 15% through the very same mask.
- **A general rule that effect-index modifiers never touch direct damage** breaks legitimate cases: 17 spells in the DBC do exactly that on purpose, among them the Claw and Maul damage bonuses.
- **A new `SPELL_ATTR0_CU_` flag** would work, but the 32-bit mask is already full up to `0x80000000`.

Supersedes #27066, which I closed myself while clearing out my open PRs, not on its merits. That version lacked the `SPELLMOD_EFFECT1` condition and had not been tested in game. Both are addressed here.

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (VS Code extension, Claude Agent SDK), claude-opus-5. It produced the code change and this description. The phase pipeline from the repo's `.agents/docs/agentic-workflow.md` was followed: `azerothcore-research` for the research document, `refine-ticket` for the requirements, `create-implementation-plan` for the plan, then execution, `code-review` for the self-review and `generate-pr-description` for this text. Every game value quoted here was read from this server's own `Spell.dbc` and DB through the AzerothCore MCP, not transcribed from a wiki. In-game testing was done by me on a Windows build.
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

### Self-review

Outcome: 2 findings, 0 fixed, 2 dismissed, final round clean on correctness.
Reviewed `cd0898421` against `origin/master`, 1 file, +12 −0. Claude Code (claude-opus-5), 2026-08-14.

Verified clean:

- `SPELLMOD_EFFECT1` maps to effect index 0 in `Unit::ApplyEffectModifiers`, so `Effects[EFFECT_0]` is the right slot to inspect.
- `IsAura()` is true for `PERSISTENT_AREA_AURA` with a non-zero `ApplyAuraName`, so the slow keeps its `-20` on all five channelled ranks.
- Blast radius: the guard keys on `mod->spellId`, and `Player::IsAffectedBySpellmod` has exactly one caller, `Player::ApplySpellMod`, where a false simply continues. The glyph aura is passive and chargeless, so no charge bookkeeping is skipped.
- The `SpellAuraEffects.cpp` recalc path that bypasses `IsAffectedBySpellmod` only schedules `RecalculateAmount`, which re-enters `ApplySpellMod` and hits the guard anyway.
- Other spells matching family mask `0x400000` (Putrid Cloud 32087/32134, Thrall Calls Thunder 34378, Violent Hurricane 50105, 27530, 32717, 40090, 55881) are creature spells a glyphed player never casts.
- `apps/codestyle/codestyle-cpp.py` passes all nine checks. `.editorconfig` respected.

Findings:

1. `Player.cpp:106` — `enum DruidSpells` shares its name with the one in `spell_druid.cpp:32`, with a different enumerator list. **Dismissed**: master already does exactly this with `enum DeathKnightSpells`, which lives in both `spell_dk.cpp:34` and `SpellEffects.cpp`. `Player.cpp` builds into the `game` target and `spell_druid.cpp` into `scripts`, so they never share a translation unit.
2. `Player.cpp:9999` — a single-glyph hardcode in a generic spell-mod path. A data-only fix exists: OR a spare `SpellFamilyFlags[1]` bit into the five channelled ranks and repoint the glyph's `SpellClassMask` at it through `SpellInfoCorrections`, the same technique used for Death's Embrace. **Dismissed for this PR**, but flagged in the TODO list below: it is a fair call for a maintainer to make, and I would rather have the decision on the record than silently pick one.

## Issues Addressed:
- Closes #26877

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

`Spell.dbc` itself, quoted above, plus the tooltip screenshots in the linked issue.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Built on Windows with MSVC and tested in game on a level 80 druid with a full talent tree, so Gale Winds was active throughout. Combat log numbers, non-crit ticks, same gear and no buffs between the two columns:

| Check | Without glyph | With glyph |
| --- | --- | --- |
| Hurricane rank 1 tick | 149 | 149 |
| Hurricane rank 5 tick | 658 | 658 |
| Insect Swarm tick | 247 | 321 (`+30%`, as the glyph's second modifier intends) |

Aura amounts read on the target with `.list auras id 48467` while channelling, on a creature and on a player:

| Aura effect | Without glyph | With glyph |
| --- | --- | --- |
| effect 0, `MOD_DECREASE_SPEED` | 0 | `-20` |
| effect 1, `MOD_MELEE_HASTE` | `-20` | `-20` |

So the damage is untouched at both ends of the rank range, the slow only exists with the glyph on, and the attack speed penalty and the Insect Swarm bonus are unchanged.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes.

1. Level 80 druid. Cast Hurricane rank 5 on a dummy and note a non-crit tick from the combat log.
2. Apply the glyph with `.aura 54831` (or equip item 40920) and cast again. The tick must be the same number. Repeat at rank 1, where the old loss was much more visible.
3. While channelling with the glyph on, select the target and run `.list auras id 48467`. Effect 0 must read `-20`. Remove the glyph with `.unaura 54831`, channel again, and it must read 0 or be absent.
4. Cast Insect Swarm with and without the glyph. The glyphed tick must be 30% higher.

Testing the damage at rank 5 alone is not enough to tell the bug from the fix by eye: the loss there is about 4.4%. Compare the numbers.

## Known Issues and TODO List:

- [ ] The client tooltip still shows the reduced damage figure with the glyph equipped. `Player::AddSpellMod` broadcasts `SMSG_SET_FLAT_SPELL_MODIFIER` per mask bit when the aura is applied, without filtering by spell, so no guard inside `IsAffectedBySpellmod` can prevent it. Blizzard's server sent the same packet, so retail behaved the same way. The combat log is what reflects the fix.
- [ ] Only this glyph is addressed. If another glyph turns out to share the shape, it wants the same treatment rather than this growing into a general rule, for the reasons above.
- [ ] Open question for reviewers: this could be done as a data fix instead, by giving the channelled ranks a spare `SpellFamilyFlags[1]` bit and repointing the glyph's `SpellClassMask` at it in `SpellInfoCorrections`, which would drop the core branch entirely. Happy to redo it that way if you prefer, it just needs the in-game verification repeating.

## How to Test AzerothCore PRs

When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
