### PR TITLE
fix(DB/Loot): split Algalon 10-man chest loot into three pools

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1786808171734129200.sql
+++ b/data/sql/updates/pending_db_world/rev_1786808171734129200.sql
@@ -1,0 +1,28 @@
+-- Algalon the Observer (Ulduar 10-man) loot pool structure fix
+-- Splits the single 15-item pool of reference 34134 into 3 pools of 5, one item drawn from each,
+-- and lowers the referring row to 1x so the chest yields 3 gear items per kill instead of 2.
+-- Source: azerothcore/azerothcore-wotlk#26314, chromiecraft/chromiecraft#9757 (22 recorded kills)
+
+-- Gift of the Observer 10-man chest: process reference 34134 once (3 pools x 1 = 3 items)
+UPDATE `gameobject_loot_template` SET `MinCount`=1, `MaxCount`=1 WHERE `Entry`=27030 AND `Item`=1 AND `Reference`=34134;
+
+-- Pool A (5 items)
+UPDATE `reference_loot_template` SET `GroupId`=1 WHERE `Entry`=34134 AND `Item`=46037; -- Shoulderplates of the Celestial Watch
+UPDATE `reference_loot_template` SET `GroupId`=1 WHERE `Entry`=34134 AND `Item`=46038; -- Dark Matter
+UPDATE `reference_loot_template` SET `GroupId`=1 WHERE `Entry`=34134 AND `Item`=46039; -- Breastplate of the Timeless
+UPDATE `reference_loot_template` SET `GroupId`=1 WHERE `Entry`=34134 AND `Item`=46040; -- Strength of the Heavens
+UPDATE `reference_loot_template` SET `GroupId`=1 WHERE `Entry`=34134 AND `Item`=46041; -- Starfall Girdle
+
+-- Pool B (5 items)
+UPDATE `reference_loot_template` SET `GroupId`=2 WHERE `Entry`=34134 AND `Item`=46042; -- Drape of the Messenger
+UPDATE `reference_loot_template` SET `GroupId`=2 WHERE `Entry`=34134 AND `Item`=46043; -- Gloves of the Endless Dark
+UPDATE `reference_loot_template` SET `GroupId`=2 WHERE `Entry`=34134 AND `Item`=46044; -- Observer's Mantle
+UPDATE `reference_loot_template` SET `GroupId`=2 WHERE `Entry`=34134 AND `Item`=46045; -- Pulsar Gloves
+UPDATE `reference_loot_template` SET `GroupId`=2 WHERE `Entry`=34134 AND `Item`=46046; -- Nebula Band
+
+-- Pool C (5 items)
+UPDATE `reference_loot_template` SET `GroupId`=3 WHERE `Entry`=34134 AND `Item`=46047; -- Pendant of the Somber Witness
+UPDATE `reference_loot_template` SET `GroupId`=3 WHERE `Entry`=34134 AND `Item`=46048; -- Band of Lights
+UPDATE `reference_loot_template` SET `GroupId`=3 WHERE `Entry`=34134 AND `Item`=46049; -- Zodiac Leggings
+UPDATE `reference_loot_template` SET `GroupId`=3 WHERE `Entry`=34134 AND `Item`=46050; -- Starlight Treads
+UPDATE `reference_loot_template` SET `GroupId`=3 WHERE `Entry`=34134 AND `Item`=46051; -- Meteorite Crystal


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [X] Database (SAI, creatures, etc).

Algalon's 10-man chest draws 2 items from a single flat 15-item pool today, so items that should be mutually exclusive can drop together and every item sits at the wrong rate. This splits reference 34134 into 3 groups of 5 and lowers the referring row on loot 27030 from 2x to 1x, so each kill draws one item from each group.

Group membership is itemid order in blocks of 5 (46037-46041, 46042-46046, 46047-46051). That's what the 22 kill videos in the issue show, with zero conflicts across all of them, and it matches the "itemid = pool order" pattern noted in the related CC issues.

Two things worth flagging:

The item count was wrong too, not only the grouping. The chest gives 2 gear items today and every video shows 3. That's why `MaxCount` on the reference row goes down to 1: three groups times one pass gives three items. Leaving it at 2 would give six.

Reply-Code Alpha (the issue's "Pool D") needs no data change. It's already a 100% row on 27030 and a quest starter (`startquest` 13631), so the loot engine gates it per player, which is exactly the "drops unless you already did the quest" behaviour in the videos. The Emblem of Triumph row stays as is too, 100% matches Ignis and Auriaya in this DB.

The 25-man chest (loot 26974 / reference 12023) has the same flat pool but no kill evidence in this issue, so it's untouched.

### AI-assisted Pull Requests

- [X] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Opus 5)
- [X] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:

- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/26314

## SOURCE:

The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [X] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

22 recorded kills are linked in the issue. Every one of them contains exactly one item from each of the three pools above.

The same defect class was fixed for 9 Naxxramas 25-man bosses in https://github.com/azerothcore/azerothcore-wotlk/pull/25276, and this migration follows the shape of that one.

## Tests Performed:

This PR has been:
- [X] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Applied locally on Windows and the worldserver picked it up on restart with no loot errors at load time.

Killed Algalon in Ulduar 10 and the chest held Strength of the Heavens, Drape of the Messenger and Starlight Treads, one per pool, plus Emblem of Triumph and Reply-Code Alpha.

`.debug loot gameobject 27030 100` gives each pool summing to exactly 100 drops over 100 rolls, which is what one draw per pool per roll looks like, and every item lands near 20% where it used to be 13.3%.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [X] This pull request requires further testing. Provide steps to test your changes.

1. `.debug loot gameobject 27030` a few times. Each roll should hold exactly 3 items from 46037-46051, never two from the same block of 5, plus the Emblem and (if you're eligible for quest 13631) Reply-Code Alpha.
2. `.debug loot gameobject 27030 100` and check the percentages inside each block of 5 sum to 100.
3. Kill Algalon in Ulduar 10-man and loot the Gift of the Observer.

## Known Issues and TODO List:

- [ ] 25-man Algalon (loot 26974 / reference 12023) has the same flat pool and would need its own kill evidence before being changed.
