### PR TITLE
fix(DB/Loot): split Algalon 25-man gear into three loot pools

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1786824615627624500.sql
+++ b/data/sql/updates/pending_db_world/rev_1786824615627624500.sql
@@ -6,7 +6,7 @@
 
 -- Gift of the Observer 25-man (3 pools: 5+6+5)
 UPDATE `gameobject_loot_template` SET `MinCount`=1, `MaxCount`=1
-  WHERE `Entry`=26974 AND `Item`=1 AND `Reference`=12023;
+    WHERE `Entry`=26974 AND `Item`=1 AND `Reference`=12023;
 
 -- Pool A (5 items)
 UPDATE `reference_loot_template` SET `GroupId`=1 WHERE `Entry`=12023 AND `Item`=45570; -- Skyforge Crossbow

--- a/data/sql/updates/pending_db_world/rev_1786824615627624500.sql
+++ b/data/sql/updates/pending_db_world/rev_1786824615627624500.sql
@@ -1,0 +1,31 @@
+--
+-- Algalon the Observer (Ulduar 25-man) loot pool structure
+-- Splits the single 16-item gear pool into the three pools evidenced by recorded retail kills,
+-- so each kill yields exactly one item from each pool instead of three draws from one pool.
+-- Issue: azerothcore/azerothcore-wotlk#26353
+
+-- Gift of the Observer 25-man (3 pools: 5+6+5)
+UPDATE `gameobject_loot_template` SET `MinCount`=1, `MaxCount`=1
+  WHERE `Entry`=26974 AND `Item`=1 AND `Reference`=12023;
+
+-- Pool A (5 items)
+UPDATE `reference_loot_template` SET `GroupId`=1 WHERE `Entry`=12023 AND `Item`=45570; -- Skyforge Crossbow
+UPDATE `reference_loot_template` SET `GroupId`=1 WHERE `Entry`=12023 AND `Item`=45587; -- Bulwark of Algalon
+UPDATE `reference_loot_template` SET `GroupId`=1 WHERE `Entry`=12023 AND `Item`=45594; -- Legplates of the Endless Void
+UPDATE `reference_loot_template` SET `GroupId`=1 WHERE `Entry`=12023 AND `Item`=45599; -- Sabatons of Lifeless Night
+UPDATE `reference_loot_template` SET `GroupId`=1 WHERE `Entry`=12023 AND `Item`=45607; -- Fang of Oblivion
+
+-- Pool B (6 items)
+UPDATE `reference_loot_template` SET `GroupId`=2 WHERE `Entry`=12023 AND `Item`=45609; -- Comet's Trail
+UPDATE `reference_loot_template` SET `GroupId`=2 WHERE `Entry`=12023 AND `Item`=45610; -- Boundless Gaze
+UPDATE `reference_loot_template` SET `GroupId`=2 WHERE `Entry`=12023 AND `Item`=45611; -- Solar Bindings
+UPDATE `reference_loot_template` SET `GroupId`=2 WHERE `Entry`=12023 AND `Item`=45617; -- Cosmos
+UPDATE `reference_loot_template` SET `GroupId`=2 WHERE `Entry`=12023 AND `Item`=45619; -- Starwatcher's Binding
+UPDATE `reference_loot_template` SET `GroupId`=2 WHERE `Entry`=12023 AND `Item`=45620; -- Starshard Edge
+
+-- Pool C (5 items)
+UPDATE `reference_loot_template` SET `GroupId`=3 WHERE `Entry`=12023 AND `Item`=45612; -- Constellus
+UPDATE `reference_loot_template` SET `GroupId`=3 WHERE `Entry`=12023 AND `Item`=45613; -- Dreambinder
+UPDATE `reference_loot_template` SET `GroupId`=3 WHERE `Entry`=12023 AND `Item`=45615; -- Planewalker Treads
+UPDATE `reference_loot_template` SET `GroupId`=3 WHERE `Entry`=12023 AND `Item`=45616; -- Star-beaded Clutch
+UPDATE `reference_loot_template` SET `GroupId`=3 WHERE `Entry`=12023 AND `Item`=45665; -- Pharos Gloves


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Algalon's 25-man chest (Gift of the Observer, gameobject 194822) rolls a single 16-item gear reference three times, so one kill can hand out two or three items that retail treats as mutually exclusive, skip a pool entirely, or even repeat the same item. The recorded kills in the issue always show exactly one item from each of three pools.

This splits reference `12023` into three groups (5 + 6 + 5) and sets the chest's reference row to `MinCount`/`MaxCount` 1 so it's processed once instead of three times. Each group is guaranteed and equal chanced, so a chest still gives 3 gear items, now one per pool. Data only, no core change: the loot engine already does per-group exclusivity.

A few things worth knowing:

- Pool membership follows the kill table in the issue, not item ID order. 45612, 45613, 45615 and 45616 are Pool C while the higher numbered 45617, 45619 and 45620 are Pool B, so the "item ID order matches pool order" shortcut doesn't apply here.
- The issue lists a "Pool D" holding only Reply-Code Alpha. I didn't create it. 46053 is already a standalone 100% row on entry `26974`, so a fourth group would behave identically while rewiring a quest starter for nothing.
- The issue's screenshot shows `Chance` 6.25 on all 16 rows. The actual data has 0, and 6.25 is just 100/16, the equal share the reporter's DB viewer computes. Kept at 0 so every group stays guaranteed and evenly weighted.
- The five Pool A statements are no-ops, since all 16 rows are already `GroupId` 1. They're in anyway so the file states the final grouping for all 16 rows rather than only the delta, same as the merged Naxxramas file `2026_04_28_03.sql`.
- The 10-man chest (`27030` / reference `34134`) is deliberately untouched, that one is #27171.

For review: it's one 31 line SQL file. The line that actually changes behaviour is the `gameobject_loot_template` update, which is what turns three passes into one. The 16 `GroupId` updates are mechanical.

### AI-assisted Pull Requests

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Opus 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:

- Closes #26353

## SOURCE:

The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

The 20 recorded kills in #26353 back the split: no kill anywhere in that table shows two items from the same pool, and 15 of 20 show exactly one item from each of the three. Of the rest, 4 carry the table's own "Missing: 1 item" note. Same fix as #25276, which did this for nine Naxxramas 25-man bosses.

## Tests Performed:

- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Before the change, three chests in a row each drew two items from one pool and missed another: (C, C, A), (B, B, A), (C, C, A).

After, three chests each gave one item per pool, plus Reply-Code Alpha and Emblem of Triumph x2 as before, with patterns showing up occasionally.

Also did a full Algalon 25 kill so the encounter-spawned chest is covered too, not just `.gobject add`. Loot: Fang of Oblivion (pool A), Starshard Edge (pool B), Constellus (pool C), plus Reply-Code Alpha, Emblem of Triumph x2 and a Fragment of Val'anyr. One item per pool, everything else intact.

Then 100 simulated openings of each, with `.debug loot gameobject 26974 100` and `.debug loot reference 12023 100`. Since those counts are per iteration presence, a pool summing to exactly 100 over 100 runs means exactly one item from it every single time. All six pool sums (three pools, two runs) landed on 100 exactly. Fragment of Val'anyr came out at 19% against its 20% row and the pattern reference at 11% against 10%.

Individual items wander a fair bit at n=100 (45594 at 26% against an expected 20%), which is just binomial noise. The equal-chance guarantee is in the pool sums, and those are exact.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. `.gobject add 194822` and loot it, a few times over.
2. Each chest should have exactly 3 gear items: one of 45570 / 45587 / 45594 / 45599 / 45607, one of 45609 / 45610 / 45611 / 45617 / 45619 / 45620, and one of 45612 / 45613 / 45615 / 45616 / 45665. Never two from the same set, never a duplicate.
3. Reply-Code Alpha and Emblem of Triumph x2 should still be in every chest, with Fragment of Val'anyr and crafting patterns turning up now and then.
4. Faster: `.debug loot reference 12023 100` and check each pool's drop counts sum to 100.

## Known Issues and TODO List:

- [ ] One of the 20 kills in the issue (`https://youtu.be/VAdJZ7uPzlE`) lists only two gear items with no "missing" note. I read it as an incomplete transcription rather than counter-evidence, since no kill in the table ever shows two items from one pool.
- [ ] The crafting pattern reference (`34154`, 10%), the Val'anyr fragment chance and the emblem count are left as they are. The issue calls them assumed correct.
