### PR TITLE
fix(DB/SAI): Thysta summons Enraged Wyverns instead of Alliance Gryphons

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1786828315751519800.sql
+++ b/data/sql/updates/pending_db_world/rev_1786828315751519800.sql
@@ -1,0 +1,6 @@
+--
+DELETE FROM `smart_scripts` WHERE (`entryorguid` = 1387) AND (`source_type` = 0);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(1387, 0, 0, 1, 4, 0, 100, 0, 0, 0, 0, 0, 0, 0, 12, 9297, 4, 30000, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Thysta - On Aggro - Summon Creature \'Enraged Wyvern\''),
+(1387, 0, 1, 2, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 12, 9297, 4, 30000, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Thysta - On Aggro - Summon Creature \'Enraged Wyvern\''),
+(1387, 0, 2, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Thysta - On Aggro - Say Line 0');


### PR DESCRIPTION
## Changes Proposed:

Attacking Thysta, the wind rider master in Grom'gol Base Camp, summons two Enraged Gryphons (9526). That's the Stormwind guard, so instead of defending her they kill her, the camp NPCs and any nearby Horde players. Her two SAI summon rows now point at the Horde guard Enraged Wyvern (9297), the same one every other Horde flight master summons (Gringer, Breyk, Devrak, etc.). The wrong entry ships in the base data, no update file ever touched it.

Only the summoned creature and the row comments change. The link chain, summon type, 30s despawn, two-guard count and the "Grunts! Attack!" yell stay as they are, and the block is rewritten in full (DELETE + INSERT of all three rows) per the SAI update convention. The guards being level 65 elite is correct for both factions, they're deliberately overleveled anti-griefing guards, so that part of the report isn't a bug.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Claude Fable 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #27122

## SOURCE:

The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Validated by consistency with the rest of the DB: every other Horde flight master with this guard script summons 9297 with the identical row shape, Thysta is the only faction-specific flight master whose guard doesn't match her faction. Verified in-game that the Booty Bay and Swamp of Sorrows flight masters (same script, correct entry) behave as expected.

## Tests Performed:

This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Applied the update to a local server and attacked Thysta: two level 65 elite Enraged Wyverns spawn, defend her, and despawn about 30s after combat ends.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. `.go creature id 1387`
2. Attack Thysta: two Enraged Wyverns (not Gryphons) spawn and attack you, not her or the town.
3. Leave combat and wait ~30s: the wyverns despawn.
4. Optional regression check: attack an Alliance flight master (e.g. Dungar Longdrink in Stormwind), Enraged Gryphons still spawn there.

## Known Issues and TODO List:

Nothing left after this, the fix is data-only.

<!-- Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
