### PR TITLE
fix(DB/Conditions): Stop pet attacks from stacking Focus Anger on Yogg-Saron's Crusher Tentacles

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1786933721893803000.sql
+++ b/data/sql/updates/pending_db_world/rev_1786933721893803000.sql
@@ -1,0 +1,4 @@
+--
+DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 24) AND (`SourceEntry` = 57688);
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(24, 0, 57688, 0, 0, 31, 0, 4, 0, 0, 0, 0, 0, '', 'Focused Anger - proc only from player attacks');


### PR DESCRIPTION
## Changes Proposed:

Crusher Tentacles gained Focus Anger stacks from pet attacks.

The tentacle self-casts Focused Anger (57688) on spawn. That aura is a plain proc trigger whose behaviour comes entirely from DBC: proc flags `0x222A8`, which is every "taken" flag (melee auto attack, melee-class spell, ranged auto attack, ranged-class spell, negative none-class spell, negative magic-class spell), triggering Focus Anger (57689) at 100%. Nothing anywhere checks who dealt the damage, so a pet swing procs it exactly like a player hit.

A 2009-06-15 hotfix removed pet attacks as a source. This adds a `CONDITION_SOURCE_TYPE_SPELL_PROC` condition on 57688 requiring the proc actor to be a player. `Aura::IsProcTriggeredOnEvent` builds its `ConditionSourceInfo` from `eventInfo.GetActor()`, which for a victim-side proc is the unit that dealt the damage, so the pet is rejected while player melee, ranged and spell damage keep stacking it as before.

Data-only, no core change. Scope is one spell: 57688 has no `SpellDifficulty` entry, so 10 and 25 man share the id, and the Crusher Tentacle's 25 man difficulty entry (33967) intentionally carries no `ScriptName` because `Creature::InitEntry` keeps the base entry 33966 and only swaps stats. Same aura, same id, same script in both raid sizes.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Opus 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:

- Closes #27190

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

WotLK hotfix, 2009-06-15: "Focus Anger, on Yogg-Saron's Crusher tentacles, will no longer result from pet attacks." Recorded at https://warcraft.wiki.gg/wiki/Yogg-Saron_(tactics)

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Send a pet at a Crusher Tentacle and confirm it no longer gains Focus Anger stacks.
2. Attack the same tentacle yourself and confirm your melee, ranged and spell damage still stacks it.

## Known Issues and TODO List:

- [ ]
