### PR TITLE
fix(Scripts/Ulduar): randomize Yogg-Saron's Lunatic Gaze interval in phase 3

### DIFF
--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
@@ -1308,7 +1308,7 @@ struct boss_yoggsaron : public ScriptedAI
             case EVENT_YS_LUNATIC_GAZE:
                 me->PlayDirectSound(YS_P3_LUNATIC_GAZE);
                 me->CastSpell(me, SPELL_LUNATIC_GAZE_YS, true);
-                events.Repeat(12s);
+                events.Repeat(13s, 22s);
                 break;
             case EVENT_YS_DEAFENING_ROAR:
                 Talk(SAY_YOGG_SARON_DEAFENING_ROAR);


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Yogg-Saron's phase 3 Lunatic Gaze was on a flat 12s repeat, which players experience as a static 8s gap between the 4s channels. A sniff shows the interval is randomized: consecutive casts landed 13.4, 13.4, 20.7, 21.9, 18.3, 18.3, 20.7 and 13.4 seconds apart (start to start). The video in the linked issue agrees once you measure the same way: its 10-18s gaps are channel end to next cast, so 14-22s start to start. The repeat is now `events.Repeat(13s, 22s)`, the union of both sources.

The issue also suggests Shadow Beacon should never overlap Lunatic Gaze. The sniff contradicts that: both fired together at phase 3 start and one beacon landed mid-channel, so no exclusion logic was added.

TC has the same flat 12s timer, so there was nothing to cherry-pick.

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Fable 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #27187

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [x] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. Reach Yogg-Saron phase 3 (brain defeated).
2. Time the Lunatic Gaze casts.
3. Intervals should vary between roughly 13 and 22 seconds start to start instead of a fixed 12.

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
