### PR TITLE
fix(Scripts/Ulduar): correct Yogg-Saron's Shadow Beacon timer in phase 3

### DIFF
--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
@@ -1251,7 +1251,7 @@ struct boss_yoggsaron : public ScriptedAI
             me->RemoveAura(SPELL_SHADOW_BARRIER);
 
             events.ScheduleEvent(EVENT_YS_LUNATIC_GAZE, 7s);
-            events.ScheduleEvent(EVENT_YS_SHADOW_BEACON, 20s);
+            events.ScheduleEvent(EVENT_YS_SHADOW_BEACON, 45s);
             events.ScheduleEvent(EVENT_YS_SUMMON_GUARDIAN, 0ms);
             _thirdPhase = true;
 
@@ -1263,7 +1263,7 @@ struct boss_yoggsaron : public ScriptedAI
         }
         else if (param == ACTION_YOGG_SARON_SHADOW_BEACON)
         {
-            events.RescheduleEvent(EVENT_YS_SHADOW_BEACON, 40s);
+            events.RescheduleEvent(EVENT_YS_SHADOW_BEACON, 45s);
         }
         else if (param == ACTION_REMOVE_STUN)
         {


### PR DESCRIPTION
## Changes Proposed:

Adjusts Yogg-Saron's Shadow Beacon timer in phase 3. Sniff data shows Shadow Beacon on a strict 45 second cycle from the moment phase 3 starts, with the first effective cast landing at 45 seconds (there's an additional cast right at the transition, but it hits no targets). We currently cast the first one at 20 seconds and repeat every 40 seconds.

Empowering Shadows follows each beacon by 10 seconds through the aura duration, so it needs no changes and lines up once the beacon is fixed. Deafening Roar (30s first, 60s repeat) already matches the sniff (30.9s, then every 61s).

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/27186

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [x] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. Engage Yogg-Saron and push into phase 3.
2. Time the abilities from the phase 3 transition: Shadow Beacon should first mark Immortal Guardians around 45s, then every 45s, with Empowering Shadows 10s after each beacon.

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
