### PR TITLE
fix(Scripts/ICC): Restore Svalna's spear kill on the Argent captains

### DIFF
--- a/src/server/scripts/Northrend/IcecrownCitadel/icecrown_citadel.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/icecrown_citadel.cpp
@@ -406,7 +406,9 @@ public:
 
         if (CreatureData const* data = creature->GetCreatureData())
             creature->SetPosition(data->posX, data->posY, data->posZ, data->orientation);
-        creature->DespawnOrUnsummon();
+        // Force the respawn timer: creatures already dead (captains speared by Svalna) keep the
+        // m_respawnTime their long corpse delay set, which ForcedDespawn recomputes only when forced.
+        creature->DespawnOrUnsummon(0ms, 2s);
 
         creature->SetCorpseDelay(corpseDelay);
         creature->SetRespawnDelay(respawnDelay);

--- a/src/server/scripts/Northrend/IcecrownCitadel/icecrown_citadel.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/icecrown_citadel.cpp
@@ -408,6 +408,8 @@ public:
             creature->SetPosition(data->posX, data->posY, data->posZ, data->orientation);
         // Force the respawn timer: creatures already dead (captains speared by Svalna) keep the
         // m_respawnTime their long corpse delay set, which ForcedDespawn recomputes only when forced.
+        // Under the default dynamic respawn mode RemoveCorpse keeps that stale time (it only ever
+        // pushes it further out), so without the timer they would not come back for a full day.
         creature->DespawnOrUnsummon(0ms, 2s);
 
         creature->SetCorpseDelay(corpseDelay);

--- a/src/server/scripts/Northrend/IcecrownCitadel/icecrown_citadel.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/icecrown_citadel.cpp
@@ -1340,7 +1340,11 @@ public:
 
         me->GetMotionMaster()->Clear(false);
         if (Creature* crok = ObjectAccessor::GetCreature(*me, instance->GetGuidData(DATA_CROK_SCOURGEBANE)))
+        {
+            // MoveFollow never clears the evade state _EnterEvadeMode sets, unlike MoveTargetedHome
+            me->ClearUnitState(UNIT_STATE_EVADE);
             me->GetMotionMaster()->MoveFollow(crok, FollowDist, FollowAngle, MOTION_SLOT_IDLE);
+        }
         else
             me->GetMotionMaster()->MoveTargetedHome();
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->
Sister Svalna has two separate spear mechanics. During Crok Scourgebane's escort she spears one of the four Argent Crusade captains dead, and during the boss fight she pins a random raid member on a spear. Issue [#15902](https://github.com/azerothcore/azerothcore-wotlk/issues/15902) reports the second one as a bug, but that one is correct and blizzlike, and this PR leaves it alone.

The escort one was genuinely broken: the spear never fired, and all four captains walked into Svalna's chamber alive. The combat log showed Caress of Death being evaded by every captain.

CreatureAI::_EnterEvadeMode sets UNIT_STATE_EVADE up front as a recursion guard, and only HomeMovementGenerator clears it again. npc_argent_captainAI::EnterEvadeMode regroups the captains on Crok with MoveFollow instead of MoveTargetedHome, so nothing ever cleared the state. After their first evade in the gauntlet the captains stayed flagged as evading, and every spell aimed at them missed with SPELL_MISS_EVADE. That also silenced their UpdateAI and regeneration for the rest of the run.

The eager assignment came in with the TrinityCore threat system port ([#24715](https://github.com/azerothcore/azerothcore-wotlk/issues/24715)). Before that, the state was only set on the MoveTargetedHome path, so this script's override used to be correct. [#25157](https://github.com/azerothcore/azerothcore-wotlk/issues/25157) fixed the same leak for pets and guardians but left script overrides alone.

Once the captains actually start dying again, a second problem shows up on gauntlet reset: FrostwingGauntletRespawner called DespawnOrUnsummon() with no forced timer, and Creature::ForcedDespawn only recomputes m_respawnTime when the creature was alive or a timer is passed. A dead captain kept the respawn time its day long corpse delay had set, and under the default dynamic respawn mode RemoveCorpse only ever pushes that further out. So the speared captains stayed missing. Passing a 2s forced timer fixes it, and changes nothing for the creatures that were still alive.

No SQL. The conditions rows restricting spell 70078 to the four captain entries and the spell_script_names binding were both checked in a live world DB and are fine. Players can't be hit by that cast.
<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Opus 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/15902

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

[Wowpedia on Sister Svalna](https://wowpedia.fandom.com/wiki/Sister_Svalna) describes both phases: the spear takes out the guards during the transition, then targets players during the fight itself. The video attached to the issue shows the boss-fight mechanic.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Tested in-game: the captain kill during the escort, a gauntlet reset bringing the speared captains back, and the Svalna boss fight itself.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Open the Combat Log, then run Crok's gauntlet the normal way, fighting the vrykul trash instead of pre-clearing it. The captains have to actually enter and leave combat, since the bug only appeared after their first evade.
2. Two captains should die to Svalna's spear during the escort, leaving two alive when the raid engages her, and no "Caress of Death was evaded by Captain ..." lines should appear.
3. Wipe mid-gauntlet and confirm the dead captains respawn with the rest of the event instead of staying missing.
4. Engage Svalna and confirm Impaling Spear still pins a random player, that the pinned player can be freed, and that Hurl Spear still breaks Aether Shield.
5. Confirm the surviving captains still fight normally and that Revive Champion still turns them into undead champions.

Quick check without a full run: select Svalna as a GM mid-escort and .cast self 70078. A captain should die instantly.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
