### PR TITLE
fix(DB/Loot): split Malygos 25-man gear into four loot pools

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1787181172594703800.sql
+++ b/data/sql/updates/pending_db_world/rev_1787181172594703800.sql
@@ -1,0 +1,38 @@
+--
+-- Malygos (Eye of Eternity 25-man) loot pool structure
+-- Splits the single 20-item gear pool of reference 34175 into the four pools evidenced by
+-- recorded retail kills (23 kills), so each kill yields exactly one item from each pool
+-- instead of four draws from one pool.
+-- Issue: azerothcore/azerothcore-wotlk#26272
+
+-- Alexstrasza's Gift 25-man (4 pools: 5+5+5+5)
+UPDATE `gameobject_loot_template` SET `MinCount`=1, `MaxCount`=1
+  WHERE `Entry`=26097 AND `Item`=1 AND `Reference`=34175;
+
+-- Pool A (5 items)
+UPDATE `reference_loot_template` SET `GroupId`=1 WHERE `Entry`=34175 AND `Item`=40531; -- Mark of Norgannon
+UPDATE `reference_loot_template` SET `GroupId`=1 WHERE `Entry`=34175 AND `Item`=40539; -- Chestguard of the Recluse
+UPDATE `reference_loot_template` SET `GroupId`=1 WHERE `Entry`=34175 AND `Item`=40541; -- Frosted Adroit Handguards
+UPDATE `reference_loot_template` SET `GroupId`=1 WHERE `Entry`=34175 AND `Item`=40543; -- Blue Aspect Helm
+UPDATE `reference_loot_template` SET `GroupId`=1 WHERE `Entry`=34175 AND `Item`=40549; -- Boots of the Renewed Flight
+
+-- Pool B (5 items)
+UPDATE `reference_loot_template` SET `GroupId`=2 WHERE `Entry`=34175 AND `Item`=40194; -- Blanketing Robes of Snow
+UPDATE `reference_loot_template` SET `GroupId`=2 WHERE `Entry`=34175 AND `Item`=40555; -- Mantle of Dissemination
+UPDATE `reference_loot_template` SET `GroupId`=2 WHERE `Entry`=34175 AND `Item`=40558; -- Arcanic Tramplers
+UPDATE `reference_loot_template` SET `GroupId`=2 WHERE `Entry`=34175 AND `Item`=40560; -- Leggings of the Wanton Spellcaster
+UPDATE `reference_loot_template` SET `GroupId`=2 WHERE `Entry`=34175 AND `Item`=40561; -- Leash of Heedless Magic
+
+-- Pool C (5 items)
+UPDATE `reference_loot_template` SET `GroupId`=3 WHERE `Entry`=34175 AND `Item`=40532; -- Living Ice Crystals
+UPDATE `reference_loot_template` SET `GroupId`=3 WHERE `Entry`=34175 AND `Item`=40562; -- Hood of Rationality
+UPDATE `reference_loot_template` SET `GroupId`=3 WHERE `Entry`=34175 AND `Item`=40564; -- Winter Spectacle Gloves
+UPDATE `reference_loot_template` SET `GroupId`=3 WHERE `Entry`=34175 AND `Item`=40566; -- Unravelling Strands of Sanity
+UPDATE `reference_loot_template` SET `GroupId`=3 WHERE `Entry`=34175 AND `Item`=40588; -- Tunic of the Artifact Guardian
+
+-- Pool D (5 items)
+UPDATE `reference_loot_template` SET `GroupId`=4 WHERE `Entry`=34175 AND `Item`=40589; -- Legplates of Sovereignty
+UPDATE `reference_loot_template` SET `GroupId`=4 WHERE `Entry`=34175 AND `Item`=40590; -- Elevated Lair Pauldrons
+UPDATE `reference_loot_template` SET `GroupId`=4 WHERE `Entry`=34175 AND `Item`=40591; -- Melancholy Sabatons
+UPDATE `reference_loot_template` SET `GroupId`=4 WHERE `Entry`=34175 AND `Item`=40592; -- Boots of Healing Energies
+UPDATE `reference_loot_template` SET `GroupId`=4 WHERE `Entry`=34175 AND `Item`=40594; -- Spaulders of Catatonia


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

The 25-man Alexstrasza's Gift chest (gameobject 193967, loot entry 26097) draws its 20-item gear reference (34175) four times from one undivided group, so a kill can hand out several items from the same armour pool and skip another entirely. The 23 recorded retail kills in the issue always show exactly one item from each of four mutually exclusive pools of five.

This splits reference 34175 into `GroupId` 1 to 4 and sets the chest's reference row to `MinCount`/`MaxCount` 1. The loot engine rolls every group of a referenced template once per pass, each group yielding one item, so one pass now gives exactly four items, one per pool. That's also why the count goes down instead of staying at 4: four passes over four groups would mean 16 items.

Two assignments look off but are intentional, backed by the kill matrix in the issue: 40194 (Blanketing Robes of Snow) belongs to pool B despite its low id, and 40532 (Living Ice Crystals) is pool C while the adjacent 40531 is pool A.

Nothing else changes: all 20 items keep `Chance` 0 (equal 1 in 5 within a pool), the mount row stays at 1% and the emblem row at 2x 100%. Same approach as the Naxxramas 25-man fix (#25276) and the Algalon splits (#26353, #26314).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Claude Fable 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #26272

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

The issue contains a matrix of 23 recorded retail kills (linked kill videos). No recorded kill has two items from the same proposed pool, and the complete recordings all show one item from each of the four pools.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Tested on Windows 11 (RelWithDebInfo build). `.debug loot gameobject 26097 100` run twice: every pool now sums to exactly 100 drops per 100 rolls (before the fix they ranged from 85 to 115), items stay around 20% each, emblem 100% x2, mount around 1%. Also killed Malygos in a live EoE 25-man run: the chest held one item from each of the four pools plus two Emblem of Triumph.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. As a level 80 GM with raid difficulty set to 25, `.tele eyeofe`, `.additem 44581`, insert the key and kill Malygos.
2. Alexstrasza's Gift should contain exactly four gear items, one from each pool (pools listed in the issue and in the SQL file's comments).
3. Quicker statistical check: `.debug loot gameobject 26097 100` and sum the drops per pool of five; each pool must total exactly 100.

## Known Issues and TODO List:

- [ ] The 10-man chest (loot entry 26094, reference 34174) has the same single-pool shape but is left untouched here on purpose: this issue only has evidence for 25-man. Needs its own issue and kill evidence, like the Algalon 10-man split (#26314).

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
