### PR TITLE
fix(DB/Loot): split Sartharion 25-man base gear into two loot pools

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1787183891069090300.sql
+++ b/data/sql/updates/pending_db_world/rev_1787183891069090300.sql
@@ -7,7 +7,7 @@
 
 -- Sartharion 25-man (2 pools: 5+5)
 UPDATE `creature_loot_template` SET `MinCount`=1, `MaxCount`=1
-  WHERE `Entry`=31311 AND `Item`=1 AND `Reference`=34166;
+    WHERE `Entry`=31311 AND `Item`=1 AND `Reference`=34166;
 
 -- Pool A (5 items)
 UPDATE `reference_loot_template` SET `GroupId`=1 WHERE `Entry`=34166 AND `Item`=40431; -- Fury of the Five Flights

--- a/data/sql/updates/pending_db_world/rev_1787183891069090300.sql
+++ b/data/sql/updates/pending_db_world/rev_1787183891069090300.sql
@@ -1,0 +1,24 @@
+--
+-- Sartharion (Obsidian Sanctum 25-man) base gear loot pool structure
+-- Splits the single 10-item ilvl 213 gear pool of reference 34166 into the two pools
+-- evidenced by recorded retail kills (21 kills), so each kill yields exactly one item
+-- from each pool instead of two draws from one pool.
+-- Issue: azerothcore/azerothcore-wotlk#26276
+
+-- Sartharion 25-man (2 pools: 5+5)
+UPDATE `creature_loot_template` SET `MinCount`=1, `MaxCount`=1
+  WHERE `Entry`=31311 AND `Item`=1 AND `Reference`=34166;
+
+-- Pool A (5 items)
+UPDATE `reference_loot_template` SET `GroupId`=1 WHERE `Entry`=34166 AND `Item`=40431; -- Fury of the Five Flights
+UPDATE `reference_loot_template` SET `GroupId`=1 WHERE `Entry`=34166 AND `Item`=40437; -- Concealment Shoulderpads
+UPDATE `reference_loot_template` SET `GroupId`=1 WHERE `Entry`=34166 AND `Item`=40446; -- Dragon Brood Legguards
+UPDATE `reference_loot_template` SET `GroupId`=1 WHERE `Entry`=34166 AND `Item`=40451; -- Hyaline Helm of the Sniper
+UPDATE `reference_loot_template` SET `GroupId`=1 WHERE `Entry`=34166 AND `Item`=40453; -- Chestplate of the Great Aspects
+
+-- Pool B (5 items)
+UPDATE `reference_loot_template` SET `GroupId`=2 WHERE `Entry`=34166 AND `Item`=40432; -- Illustration of the Dragon Soul
+UPDATE `reference_loot_template` SET `GroupId`=2 WHERE `Entry`=34166 AND `Item`=40433; -- Wyrmrest Band
+UPDATE `reference_loot_template` SET `GroupId`=2 WHERE `Entry`=34166 AND `Item`=40438; -- Council Chamber Epaulets
+UPDATE `reference_loot_template` SET `GroupId`=2 WHERE `Entry`=34166 AND `Item`=40439; -- Mantle of the Eternal Sentinel
+UPDATE `reference_loot_template` SET `GroupId`=2 WHERE `Entry`=34166 AND `Item`=40455; -- Staff of Restraint


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Sartharion 25-man (creature 31311) draws its 10-item ilvl 213 gear reference (34166) twice from one undivided group, so a kill can hand out two items from the same armour pool and skip the other entirely. The 21 recorded retail kills in the issue always show exactly one item from each of two mutually exclusive pools of five.

This splits reference 34166 into `GroupId` 1 and 2 and sets the boss's reference row to `MinCount`/`MaxCount` 1. The loot engine rolls every group of a referenced template once per pass, each group yielding one item, so one pass now gives exactly two items, one per pool. That's also why the count goes down instead of staying at 2: two passes over two groups would mean 4 items.

Pool membership doesn't follow item ids: 40437 (Concealment Shoulderpads) is pool A while the adjacent 40438 (Council Chamber Epaulets) is pool B. The kill matrix backs this: one kill drops Concealment together with Mantle of the Eternal Sentinel (40439), another drops Council Chamber together with Dragon Brood Legguards (40446), which forces exactly this assignment.

Nothing else changes: the drake bonus pools (LootMode 2/4/8) already have proper groups, the tier tokens keep their 2x roll with duplicates allowed (retail-correct, tokens aren't equippable so the engine doesn't dedupe them), and the bags, emblem and mount rows are untouched. The 10-man version doesn't have this bug either, it already draws each of its pools from a separate reference (35086 to 35090) once. Same approach as the Naxxramas 25-man fix (#25276), the Algalon splits (#26353, #26314) and the Malygos split (#26272).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Claude Fable 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #26276

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

The issue contains a matrix of 21 recorded retail kills (linked kill videos). No recorded kill has two items from the same proposed pool, and the complete recordings all show one item from each of the two pools.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Tested on Windows 11 (RelWithDebInfo build). `.debug loot creature 31311 100` run twice before and after: before the fix the two pools summed to 103/97 and 90/110 drops per 100 kills, after the fix both pools total exactly 100 in every run. Also killed Sartharion live in OS 25-man with 0, 1 (twice), 2 and 3 drakes alive: every kill dropped exactly one pool A item, one pool B item, two tier tokens and both bags, plus one item per active drake bonus pool, the right emblem count (1 to 4) and the mount only with all three drakes up.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. As a level 80 GM with raid difficulty set to 25, `.tele obsid`, kill the drakes you don't want up, then pull Sartharion (he must be engaged, the drake bonus loot modes are armed on pull) and kill him.
2. His corpse should hold exactly one item from each of the two base pools (listed in the SQL file's comments), two tier tokens and both bags, plus per drake alive one bonus pool item and one extra emblem, and the mount with all three up.
3. Quicker statistical check: `.debug loot creature 31311 100` and sum the drops per pool of five; each pool must total exactly 100.

## Known Issues and TODO List:

- None.


## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
