### PR TITLE
fix(Scripts/Ulduar): exactly 8 Guardians to end Yogg-Saron phase 1

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1787262930222218000.sql
+++ b/data/sql/updates/pending_db_world/rev_1787262930222218000.sql
@@ -1,9 +1,7 @@
 -- Guardian of Yogg-Saron: the 25-man Shadow Nova (65209) entry-targeted effect must hit other
 -- Guardians (33136) like its 10-man variant (62714) does since 2026_08_03_03. Its condition still
 -- targeted Sara (33134), dealing her a second 25k per Guardian on top of the dedicated 65719 nova.
-DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 13) AND (`SourceGroup` = 2) AND (`SourceEntry` = 65209) AND (`SourceId` = 0);
-INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
-(13, 2, 65209, 0, 0, 31, 0, 3, 33136, 0, 0, 0, 0, '', 'Shadow Nova');
+UPDATE `conditions` SET `ConditionValue2` = 33136 WHERE (`SourceTypeOrReferenceId` = 13) AND (`SourceGroup` = 2) AND (`SourceEntry` = 65209) AND (`SourceId` = 0) AND (`ElseGroup` = 0) AND (`ConditionTypeOrReference` = 31) AND (`ConditionTarget` = 0) AND (`ConditionValue1` = 3) AND (`ConditionValue2` = 33134) AND (`ConditionValue3` = 0);
 
 -- Sara is friendly in phase 1 and thus never in combat, so out-of-combat regen undoes the
 -- Guardians' Shadow Nova damage. Disable health regen like Yogg-Saron (33288); the script

--- a/data/sql/updates/pending_db_world/rev_1787262930222218000.sql
+++ b/data/sql/updates/pending_db_world/rev_1787262930222218000.sql
@@ -1,0 +1,11 @@
+-- Guardian of Yogg-Saron: the 25-man Shadow Nova (65209) entry-targeted effect must hit other
+-- Guardians (33136) like its 10-man variant (62714) does since 2026_08_03_03. Its condition still
+-- targeted Sara (33134), dealing her a second 25k per Guardian on top of the dedicated 65719 nova.
+DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 13) AND (`SourceGroup` = 2) AND (`SourceEntry` = 65209) AND (`SourceId` = 0);
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(13, 2, 65209, 0, 0, 31, 0, 3, 33136, 0, 0, 0, 0, '', 'Shadow Nova');
+
+-- Sara is friendly in phase 1 and thus never in combat, so out-of-combat regen undoes the
+-- Guardians' Shadow Nova damage. Disable health regen like Yogg-Saron (33288); the script
+-- restores her to full health on reset and on the phase 2 transformation instead.
+UPDATE `creature_template` SET `RegenHealth` = 0 WHERE `entry` IN (33134, 34332);

--- a/src/server/game/Spells/SpellInfoCorrections.cpp
+++ b/src/server/game/Spells/SpellInfoCorrections.cpp
@@ -2045,6 +2045,13 @@ void SpellMgr::LoadSpellInfoCorrections()
         spellInfo->AttributesEx6 |= SPELL_ATTR6_IGNORE_PHASE_SHIFT;
     });
 
+    // Shadow Nova (Sara)
+    ApplySpellFix({ 65719 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->AttributesEx3 |= SPELL_ATTR3_ALWAYS_HIT;
+        spellInfo->AttributesEx4 |= SPELL_ATTR4_NO_CAST_LOG;
+    });
+
     // Cosmic Smash (Algalon the Observer)
     ApplySpellFix({ 62293 }, [](SpellInfo* spellInfo)
     {

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
@@ -511,6 +511,7 @@ struct boss_yoggsaron_sara : public ScriptedAI
         me->SetDisplayId(me->GetNativeDisplayId());
         me->SetDisableGravity(true);
         me->SetFaction(FACTION_FRIENDLY);
+        me->SetFullHealth();
         me->ClearUnitState(UNIT_STATE_EVADE);
         EnableSara(false);
 
@@ -778,7 +779,9 @@ struct boss_yoggsaron_sara : public ScriptedAI
             damage = 0;
 
             events.SetPhase(EVENT_PHASE_TWO);
-            me->SetHealth(me->GetMaxHealth());
+            // 1 health shows an empty bar through the transformation dialogue;
+            // SetHealth(0) would make the client treat her as dead
+            me->SetHealth(1);
             me->SetInCombatWithZone();
             me->SetFaction(FACTION_MONSTER_2);
 
@@ -993,6 +996,7 @@ struct boss_yoggsaron_sara : public ScriptedAI
                 }
             case EVENT_SARA_P2_SPAWN_START_TENTACLES:
                 {
+                    me->SetFullHealth();
                     me->SetOrientation(M_PI);
                     me->SetDisplayId(SARA_TRANSFORM_MODEL);
 

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
@@ -776,12 +776,10 @@ struct boss_yoggsaron_sara : public ScriptedAI
         if (me->GetHealth() <= damage)
         {
             _secondPhase = true;
-            damage = 0;
+            // leave her at 1 health through the transformation dialogue, the client treats 0 health as dead
+            damage = me->GetHealth() - 1;
 
             events.SetPhase(EVENT_PHASE_TWO);
-            // 1 health shows an empty bar through the transformation dialogue;
-            // SetHealth(0) would make the client treat her as dead
-            me->SetHealth(1);
             me->SetInCombatWithZone();
             me->SetFaction(FACTION_MONSTER_2);
 


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

In phase 1 each Guardian of Yogg-Saron dying near Sara should remove exactly 25000 health, so exactly 8 deaths push her into phase 2. Three independent bugs made the count vary between pulls:

1. Sara is friendly in phase 1 (retail-correct since #26632), so `SetInCombatWithZone()` never puts her in combat and out-of-combat regen healed her by a third of her health pool every 2 seconds.
2. Her dedicated Shadow Nova (65719) is DmgClass NONE with a single school damage effect, which AzerothCore routes through the magic hit roll, so it fully missed about 5% of the time (level 82 caster vs level 83 target) and got partially resisted about 7% of the time via the level difference resistance. Her max health is 199999 and 8 x 25000 is 200000, so a single lost point already forces a ninth Guardian.
3. In 25-man the player-facing Shadow Nova becomes 65209 through `spelldifficulty_dbc`. #26934 retargeted 62714's entry condition from Sara to the Guardians but left 65209's condition untouched, so its entry-targeted effect still hit Sara, roughly doubling her damage per Guardian (phase 2 after 4 or 5 deaths).

Fixes, in the same order:

1. `RegenHealth = 0` for Sara (33134, 34332), like Yogg-Saron (33288) already has. The script now restores her to full health in `Reset()` (covers spawn and wipe recovery, which relied on the regen) and at the phase 2 transformation.
2. `SpellInfoCorrections`: 65719 gets `SPELL_ATTR3_ALWAYS_HIT` and `SPELL_ATTR4_NO_CAST_LOG` so it can neither miss nor be partially resisted. Only Sara's nova is touched. The player-facing novas (62714/65209) stay missable and resistable on purpose, as decided in #26632.
3. Retarget 65209's entry condition from Sara (33134) to other Guardians (33136), mirroring what #26934 did for 62714.

One visible behavior change: the eighth nova now leaves Sara at an empty health bar through the transformation dialogue instead of instantly snapping back to full, and she refills when she actually transforms and the tentacles spawn. She is held at 1 health rather than 0 because the client treats a 0-health unit as dead (that is what C'thun's fake death relies on).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Claude Fable 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #27189

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Wowhead's WotLK Yogg-Saron strategy guide: the novas deal 25k shadow damage and exactly 8 explosions bring Sara to 0. Spell values (flat 25000 base points on 65719, the 65209 difficulty mapping, radius 15yd) read from the 3.3.5a client DBCs.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Tested on Windows 11 (RelWithDebInfo). Kill-tested the phase 1 to 2 transition: every Guardian death removed exactly 25000, no regen between deaths, exactly 8 Guardians ended the phase, Sara sat at an empty bar through the transformation yells and came back at full health when the tentacles spawned, phase 2 proceeded normally. The retargeted conditions row and `RegenHealth` values verified in the live DB after the updater ran.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Open the encounter as a level 80 GM (kill Flame Leviathan, XT-002 and Vezax via `.go c id` plus `.damage`), then `.tele Yogg` and pull Sara.
2. Kill Guardians within 15yd of her and watch her health: 25000 per death, no ticks back up, exactly 8 to phase, empty bar until the transformation completes.
3. In 25-man, also check the combat log: each player is still hit exactly once per Shadow Nova.
4. Regression: with Vezax alive, walk into an Ominous Cloud and kill the summoned Guardian next to Sara; she must take no damage.

## Known Issues and TODO List:

- None.
