### PR TITLE
fix(DB/Creature): give Ulduar Clockwork Sappers invisibility and stealth detection

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1787266581.sql
+++ b/data/sql/updates/pending_db_world/rev_1787266581.sql
@@ -1,0 +1,7 @@
+-- Ulduar: Clockwork Sappers see through invisibility and stealth (retail 3.1 hotfix behavior)
+UPDATE `creature_addon` SET `auras` = '18950' WHERE `guid` IN (136586, 136587, 136588, 136589, 136591, 136592);
+
+DELETE FROM `creature_template_addon` WHERE `entry` IN (34193, 34220);
+INSERT INTO `creature_template_addon` (`entry`, `path_id`, `mount`, `bytes1`, `bytes2`, `emote`, `visibilityDistanceType`, `auras`) VALUES
+(34193, 0, 0, 0, 1, 0, 0, '18950'),
+(34220, 0, 0, 0, 1, 0, 0, '18950');


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Clockwork Sappers (34193) in Ulduar's corridor toward Mimiron's tram can currently be walked past with an Invisibility Potion. On retail they detect invisible players (visible at 0:19 in the video linked in the issue), and since a patch 3.1 hotfix they detect stealth as well, which is why rogues back then needed vanish plus rocket boots to get a skip past them instead of just sneaking through.

This gives them the standard detection aura 18950 (Invisibility and Stealth Detection, both effects at value 100000, permanent). It's the same aura roughly 90 creature templates and 400 spawns already carry for exactly this purpose.

Two placement details worth knowing. All six Sapper spawns already have `creature_addon` rows (sheath state, and the tinkering emote on four of them), and the core uses a per-spawn row wholesale when one exists, so the aura has to go into those six rows or it would be masked. The two new `creature_template_addon` rows (34193 and its 25-man clone 34220) cover any Sapper spawned without a guid row, e.g. GM-spawned ones.

Aggro behavior stays normal otherwise: the aura makes hidden players visible but doesn't enlarge the pull radius, so the movement and speed based corridor skips that retail allowed still work. Stealthed and invisible players are simply treated like visible ones.

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Claude Fable 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #27249

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Invisibility detection: the WotLK Classic skip guide video linked in the issue (https://youtu.be/Pi1DmAahFcs?&t=19) shows the Sappers pulling invisible players. Stealth detection: June 2009 OwnedCore thread on the Mimiron trash skip (https://www.ownedcore.com/forums/world-of-warcraft/world-of-warcraft-exploits/240832-skip-mimirons-trash.html), "You used to be able to bypass it all. Now they have stealth detection", with replies describing vanish plus rocket boots as the remaining workaround.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Tested on Windows 11 (RelWithDebInfo build): with the SQL applied and GM mode off, drinking an Invisibility Potion and walking up to a Sapper now gets you pulled at normal aggro range, in both 10-man and 25-man Ulduar. A stealthed rogue gets pulled the same way (tested in 10-man). The per-spawn emotes survive the change (plain column update, verified in the DB after applying twice, the file is idempotent).

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. `.additem 9172 5`, `.go creature id 34193`, step back a bit, `.gm off`, drink the potion and walk toward the Sapper. It should pull you like a visible player.
2. Same walk on a stealthed rogue or prowling druid: also pulled, at roughly the same distance as unstealthed, not farther.
3. The four Sappers with the tinkering emote should still play it, and Energy Sap should still be cast in combat.

## Known Issues and TODO List:

- None.
