### PR TITLE
fix(CI/Windows): restore the Boost download

### DIFF
--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -60,11 +60,30 @@ jobs:
           # (VS detection failures and slproweb removing old OpenSSL installers).
 
           # --- Boost 1.87.0 (msvc-14.3, 64-bit) prebuilt binaries -> C:\local\boost_1_87_0 (BOOST_ROOT) ---
-          # Use the direct-download host; the plain /download URL serves an HTML interstitial.
+          # Go through downloads.sourceforge.net, which hands out an https mirror. The
+          # master.dl host redirects to a plain-http URL that PowerShell 7.5+ refuses to
+          # follow, and an installer we then execute shouldn't travel in the clear anyway.
+          # The plain sourceforge.net /download page serves an HTML interstitial instead.
           if (-not (Test-Path 'C:\local\boost_1_87_0\boost'))
           {
               $boostExe = Join-Path $env:RUNNER_TEMP 'boost.exe'
-              Invoke-WebRequest -Uri 'https://master.dl.sourceforge.net/project/boost/boost-binaries/1.87.0/boost_1_87_0-msvc-14.3-64.exe?viasf=1' -OutFile $boostExe
+              $boostUrl = 'https://downloads.sourceforge.net/project/boost/boost-binaries/' +
+                  '1.87.0/boost_1_87_0-msvc-14.3-64.exe'
+              # Mirrors drop connections often enough on a 200 MB file to be worth retrying.
+              for ($attempt = 1; $attempt -le 3; $attempt++)
+              {
+                  try
+                  {
+                      Invoke-WebRequest -Uri $boostUrl -OutFile $boostExe
+                      break
+                  }
+                  catch
+                  {
+                      Write-Host "Boost download attempt $attempt failed: $($_.Exception.Message)"
+                      if ($attempt -eq 3) { throw }
+                      Start-Sleep -Seconds 15
+                  }
+              }
               $boostMB = (Get-Item $boostExe).Length / 1MB
               Write-Host ("Downloaded Boost installer: {0:N1} MB" -f $boostMB)
               if ($boostMB -lt 50) { throw "Boost installer download looks wrong ($([int]$boostMB) MB) - likely an HTML page." }

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -63,7 +63,9 @@ jobs:
           # Go through downloads.sourceforge.net, which hands out an https mirror. The
           # master.dl host redirects to a plain-http URL that PowerShell 7.5+ refuses to
           # follow, and an installer we then execute shouldn't travel in the clear anyway.
-          # The plain sourceforge.net /download page serves an HTML interstitial instead.
+          # SourceForge sniffs the user agent: anything starting with Mozilla gets the HTML
+          # download page instead of the file, so send a non-browser one. Note this is the
+          # opposite of what the MySQL archives CDN below wants.
           if (-not (Test-Path 'C:\local\boost_1_87_0\boost'))
           {
               $boostExe = Join-Path $env:RUNNER_TEMP 'boost.exe'
@@ -74,7 +76,7 @@ jobs:
               {
                   try
                   {
-                      Invoke-WebRequest -Uri $boostUrl -OutFile $boostExe
+                      Invoke-WebRequest -Uri $boostUrl -OutFile $boostExe -UserAgent 'azerothcore-ci'
                       break
                   }
                   catch

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -72,11 +72,9 @@ jobs:
               $boostUrl = 'https://downloads.sourceforge.net/project/boost/boost-binaries/' +
                   '1.87.0/boost_1_87_0-msvc-14.3-64.exe'
               # Mirrors drop connections often enough on a 200 MB file to be worth retrying.
-              # Both timeouts default to infinite and bound different phases: Connection covers
-              # the wait for response headers, Operation the gap between reads once the body is
-              # flowing. Only the latter catches a mirror that goes quiet mid-transfer, which
-              # would otherwise hang the job until the 6h runner limit instead of retrying. Don't
-              # collapse these into a whole-transfer budget, slow mirrors can need 15+ minutes.
+              # OperationTimeoutSeconds is the one that catches a mirror going quiet mid-transfer,
+              # which would otherwise hang the job until the 6h runner limit. Don't collapse the
+              # two into a whole-transfer budget, slow mirrors can need 15+ minutes.
               $boostRequest = @{
                   Uri                      = $boostUrl
                   OutFile                  = $boostExe

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -90,6 +90,11 @@ jobs:
                   try
                   {
                       Invoke-WebRequest @boostRequest
+                      # A mirror can answer 200 with an error page, which doesn't throw. Size-check
+                      # inside the loop so a bad payload retries onto a different mirror instead of
+                      # failing the job outright. Each attempt re-rolls the mirror.
+                      $boostMB = (Get-Item $boostExe).Length / 1MB
+                      if ($boostMB -lt 50) { throw "got $([int]$boostMB) MB, likely an HTML page." }
                       break
                   }
                   catch
@@ -99,9 +104,7 @@ jobs:
                       Start-Sleep -Seconds 15
                   }
               }
-              $boostMB = (Get-Item $boostExe).Length / 1MB
               Write-Host ("Downloaded Boost installer: {0:N1} MB" -f $boostMB)
-              if ($boostMB -lt 50) { throw "Boost installer download looks wrong ($([int]$boostMB) MB) - likely an HTML page." }
               $boostProc = Start-Process -FilePath $boostExe -ArgumentList '/VERYSILENT','/SUPPRESSMSGBOXES','/NORESTART','/DIR=C:\local\boost_1_87_0' -Wait -PassThru
               if ($boostProc.ExitCode -ne 0) { throw "Boost installer failed with exit code $($boostProc.ExitCode)." }
               # Fail fast if the installer "succeeded" but didn't lay down the expected tree,

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -61,7 +61,7 @@ jobs:
 
           # --- Boost 1.87.0 (msvc-14.3, 64-bit) prebuilt binaries -> C:\local\boost_1_87_0 (BOOST_ROOT) ---
           # Go through downloads.sourceforge.net, which hands out an https mirror. The
-          # master.dl host redirects to a plain-http URL that PowerShell 7.5+ refuses to
+          # master.dl host redirects to a plain-http URL that PowerShell 7.4+ refuses to
           # follow, and an installer we then execute shouldn't travel in the clear anyway.
           # SourceForge sniffs the user agent: anything starting with Mozilla gets the HTML
           # download page instead of the file, so send a non-browser one. Note this is the

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -72,14 +72,24 @@ jobs:
               $boostUrl = 'https://downloads.sourceforge.net/project/boost/boost-binaries/' +
                   '1.87.0/boost_1_87_0-msvc-14.3-64.exe'
               # Mirrors drop connections often enough on a 200 MB file to be worth retrying.
-              # -TimeoutSec matters: it defaults to infinite, so a mirror that stalls mid-transfer
-              # would hang the job until the 6h runner limit instead of failing into a retry.
+              # Both timeouts default to infinite and bound different phases: Connection covers
+              # the wait for response headers, Operation the gap between reads once the body is
+              # flowing. Only the latter catches a mirror that goes quiet mid-transfer, which
+              # would otherwise hang the job until the 6h runner limit instead of retrying. Don't
+              # collapse these into a whole-transfer budget, slow mirrors can need 15+ minutes.
+              $boostRequest = @{
+                  Uri                      = $boostUrl
+                  OutFile                  = $boostExe
+                  UserAgent                = 'azerothcore-ci'
+                  ConnectionTimeoutSeconds = 60
+                  OperationTimeoutSeconds  = 60
+              }
               $boostAttempts = 3
               for ($attempt = 1; $attempt -le $boostAttempts; $attempt++)
               {
                   try
                   {
-                      Invoke-WebRequest -Uri $boostUrl -OutFile $boostExe -UserAgent 'azerothcore-ci' -TimeoutSec 600
+                      Invoke-WebRequest @boostRequest
                       break
                   }
                   catch

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -72,17 +72,20 @@ jobs:
               $boostUrl = 'https://downloads.sourceforge.net/project/boost/boost-binaries/' +
                   '1.87.0/boost_1_87_0-msvc-14.3-64.exe'
               # Mirrors drop connections often enough on a 200 MB file to be worth retrying.
-              for ($attempt = 1; $attempt -le 3; $attempt++)
+              # -TimeoutSec matters: it defaults to infinite, so a mirror that stalls mid-transfer
+              # would hang the job until the 6h runner limit instead of failing into a retry.
+              $boostAttempts = 3
+              for ($attempt = 1; $attempt -le $boostAttempts; $attempt++)
               {
                   try
                   {
-                      Invoke-WebRequest -Uri $boostUrl -OutFile $boostExe -UserAgent 'azerothcore-ci'
+                      Invoke-WebRequest -Uri $boostUrl -OutFile $boostExe -UserAgent 'azerothcore-ci' -TimeoutSec 600
                       break
                   }
                   catch
                   {
                       Write-Host "Boost download attempt $attempt failed: $($_.Exception.Message)"
-                      if ($attempt -eq 3) { throw }
+                      if ($attempt -eq $boostAttempts) { throw }
                       Start-Sleep -Seconds 15
                   }
               }


### PR DESCRIPTION
## Changes Proposed:

`windows-build` has been red on master since #27197. It never reached the build,
it died in `Configure OS` while provisioning Boost. Two separate SourceForge
behaviours had to be worked around, and the second only showed up once the first
was fixed.

**1. The download redirected to plain http.** `master.dl.sourceforge.net/...?viasf=1`
now 301s to an `http://` URL, and PowerShell 7.4+ refuses to follow an https -> http
redirect:

```
Invoke-WebRequest: Cannot follow an insecure redirection by default.
Reissue the command specifying the -AllowInsecureRedirect switch.
```

Requesting `downloads.sourceforge.net` directly, without `?viasf=1`, keeps every hop
on https. I did not use `-AllowInsecureRedirect`, since we execute this installer and
it shouldn't arrive over cleartext.

**2. SourceForge then served an HTML page instead of the file.** It sniffs the user
agent: anything starting with `Mozilla` gets the download landing page, which is what
PowerShell's default UA gets. The job downloaded 138 KB of HTML and the existing size
guard rejected it. Sending a non-browser UA gets the real 205 MB installer. Note this
is the exact inverse of the MySQL archives CDN below it, which needs a browser UA or
Oracle serves an error page, so the two can't be unified.

Also hardened the fetch while in there, since a 205 MB pull off a rotating mirror is a
standing flake risk: three attempts, plus a connection timeout and a per-read timeout.
Both default to infinite, and only the per-read one (`-OperationTimeoutSeconds`) catches
a mirror that goes quiet mid-transfer; `-TimeoutSec` is an alias of
`-ConnectionTimeoutSeconds` and would not. They're deliberately not collapsed into one
whole-transfer budget: mirror throughput has been seen anywhere from 250 KB/s to 5.9 MB/s,
so any total cap either kills healthy downloads or is too loose to help.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

CI only.

### AI-assisted Pull Requests

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Opus 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Redirect chains and UA behaviour traced with `curl`. Timeout semantics per the
[Invoke-WebRequest docs](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/invoke-webrequest):
`ConnectionTimeoutSeconds` "replaced the TimeoutSec parameter in PowerShell 7.4",
`OperationTimeoutSeconds` "applies to data reads within a stream, not to the stream time
as a whole". The runner is PowerShell 7.6.4.

## Tests Performed:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

`windows-build` on this PR: `Configure OS` and `Build` both green. Run
[32475468373](https://github.com/azerothcore/azerothcore-wotlk/actions/runs/32475468373)
exercised the real download on a cache miss (`Downloaded Boost installer: 205.2 MB`,
about 7 s) and built in 15m50s.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes.

1. `windows-build` needs the `run-build` label to run on a PR.
2. `Configure OS` should log `Downloaded Boost installer: 205.2 MB` on a cache miss, or skip
   the block on a cache hit.
3. The `Build` step should complete.

## Known Issues and TODO List:

- [ ] Both provisioning downloads still depend on third-party hosts changing their
      behaviour under us. This is the third such break; a mirror we control would end it.
