### PR TITLE
fix(Scripts/Dragonblight): dismount the Wintergarde Gryphon outside the quest area

### DIFF
--- a/src/server/game/Maps/AreaDefines.h
+++ b/src/server/game/Maps/AreaDefines.h
@@ -142,6 +142,8 @@ enum AreaTableIDs : uint32
     AREA_NAXXANAR                                            = 4128,
     AREA_MAGISTERS_TERRACE                                   = 4131,
     AREA_WINTERGARDE_KEEP                                    = 4177,
+    AREA_WINTERGARDE_MINE                                    = 4178,
+    AREA_THE_CARRION_FIELDS                                  = 4188,
     AREA_WINTERGRASP                                         = 4197,
     AREA_THE_OCULUS                                          = 4228,
     AREA_ULDUAR                                              = 4273,

--- a/src/server/game/Maps/AreaDefines.h
+++ b/src/server/game/Maps/AreaDefines.h
@@ -142,8 +142,6 @@ enum AreaTableIDs : uint32
     AREA_NAXXANAR                                            = 4128,
     AREA_MAGISTERS_TERRACE                                   = 4131,
     AREA_WINTERGARDE_KEEP                                    = 4177,
-    AREA_WINTERGARDE_MINE                                    = 4178,
-    AREA_THE_CARRION_FIELDS                                  = 4188,
     AREA_WINTERGRASP                                         = 4197,
     AREA_THE_OCULUS                                          = 4228,
     AREA_ULDUAR                                              = 4273,

--- a/src/server/scripts/Northrend/zone_dragonblight.cpp
+++ b/src/server/scripts/Northrend/zone_dragonblight.cpp
@@ -648,6 +648,7 @@ enum WintergardeGryphon
     EVENT_VEHICLE_GET                           = 1,
     EVENT_TAKE_OFF                              = 2,
     EVENT_GET_VILLAGER                          = 3,
+    EVENT_CHECK_QUEST_AREA                      = 4,
 
     EVENT_PHASE_FEAR                            = 1,
     EVENT_PHASE_VEHICLE                         = 2,
@@ -655,9 +656,25 @@ enum WintergardeGryphon
     POINT_LAND                                  = 1,
     POINT_TAKE_OFF                              = 2,
 
+    SEAT_RIDER                                  = 0,
+    SEAT_VILLAGER                               = 1,
+
     QUEST_FLIGHT_OF_THE_WINTERGARDE_DEFENDER    = 12237,
     GO_TEMP_GRYPHON_STATION                     = 188679
 };
+
+static bool IsInWintergardeQuestZone(WorldObject const* object)
+{
+    switch (object->GetAreaId())
+    {
+        case AREA_WINTERGARDE_KEEP:
+        case AREA_WINTERGARDE_MINE:
+        case AREA_THE_CARRION_FIELDS:
+            return true;
+        default:
+            return false;
+    }
+}
 
 class npc_wintergarde_gryphon : public VehicleAI
 {
@@ -677,6 +694,21 @@ public:
         me->SetFacingToObject(summoner);
         Position pos = summoner->GetPosition();
         me->GetMotionMaster()->MovePoint(POINT_LAND, pos);
+        events.ScheduleEvent(EVENT_CHECK_QUEST_AREA, 1s);
+    }
+
+    // Vehicle::RemovePassenger grants Parachute, so unseating the rider mid-air is safe
+    void DespawnOutOfQuestZone()
+    {
+        if (Vehicle* gryphon = me->GetVehicleKit())
+            if (Unit* villager = gryphon->GetPassenger(SEAT_VILLAGER))
+                if (Creature* seat = villager->ToCreature())
+                {
+                    seat->ExitVehicle();
+                    seat->DespawnOrUnsummon();
+                }
+
+        me->DespawnOrUnsummon();
     }
 
     void MovementInform(uint32 type, uint32 id) override
@@ -687,11 +719,11 @@ public:
 
     void PassengerBoarded(Unit* passenger, int8 seatId, bool apply) override
     {
-        if (!apply && seatId == 0)
+        if (!apply && seatId == SEAT_RIDER)
         {
             // left the vehicle with a passenger will result in despawn
             if (Vehicle* gryphon = me->GetVehicleKit())
-                if (Unit* villager = gryphon->GetPassenger(1))
+                if (Unit* villager = gryphon->GetPassenger(SEAT_VILLAGER))
                 {
                     if (!villager->IsCreature())
                         return;
@@ -744,6 +776,17 @@ public:
                     }
                     break;
                 }
+                case EVENT_CHECK_QUEST_AREA:
+                {
+                    if (!IsInWintergardeQuestZone(me))
+                    {
+                        DespawnOutOfQuestZone();
+                        return;
+                    }
+
+                    events.ScheduleEvent(EVENT_CHECK_QUEST_AREA, 1s);
+                    break;
+                }
             }
         }
     }
@@ -754,7 +797,7 @@ public:
             return;
 
         if (Vehicle* gryphon = me->GetVehicleKit())
-            if (Unit* villager = gryphon->GetPassenger(1))
+            if (Unit* villager = gryphon->GetPassenger(SEAT_VILLAGER))
             {
                 villager->ExitVehicle();
                 villager->GetMotionMaster()->Clear(false);
@@ -881,12 +924,17 @@ class spell_call_wintergarde_gryphon : public SpellScript
 
     SpellCastResult CheckRequirement()
     {
-        if (Player* playerCaster = GetCaster()->ToPlayer())
-        {
-            if (playerCaster->GetQuestStatus(QUEST_FLIGHT_OF_THE_WINTERGARDE_DEFENDER) == QUEST_STATUS_INCOMPLETE)
-                return SPELL_CAST_OK;
-        }
-        return SPELL_FAILED_DONT_REPORT;
+        Player* playerCaster = GetCaster()->ToPlayer();
+        if (!playerCaster)
+            return SPELL_FAILED_DONT_REPORT;
+
+        if (playerCaster->GetQuestStatus(QUEST_FLIGHT_OF_THE_WINTERGARDE_DEFENDER) != QUEST_STATUS_INCOMPLETE)
+            return SPELL_FAILED_DONT_REPORT;
+
+        if (!IsInWintergardeQuestZone(playerCaster))
+            return SPELL_FAILED_INCORRECT_AREA;
+
+        return SPELL_CAST_OK;
     }
 
     void Register() override

--- a/src/server/scripts/Northrend/zone_dragonblight.cpp
+++ b/src/server/scripts/Northrend/zone_dragonblight.cpp
@@ -648,7 +648,6 @@ enum WintergardeGryphon
     EVENT_VEHICLE_GET                           = 1,
     EVENT_TAKE_OFF                              = 2,
     EVENT_GET_VILLAGER                          = 3,
-    EVENT_CHECK_QUEST_AREA                      = 4,
 
     EVENT_PHASE_FEAR                            = 1,
     EVENT_PHASE_VEHICLE                         = 2,
@@ -656,25 +655,9 @@ enum WintergardeGryphon
     POINT_LAND                                  = 1,
     POINT_TAKE_OFF                              = 2,
 
-    SEAT_RIDER                                  = 0,
-    SEAT_VILLAGER                               = 1,
-
     QUEST_FLIGHT_OF_THE_WINTERGARDE_DEFENDER    = 12237,
     GO_TEMP_GRYPHON_STATION                     = 188679
 };
-
-static bool IsInWintergardeQuestZone(WorldObject const* object)
-{
-    switch (object->GetAreaId())
-    {
-        case AREA_WINTERGARDE_KEEP:
-        case AREA_WINTERGARDE_MINE:
-        case AREA_THE_CARRION_FIELDS:
-            return true;
-        default:
-            return false;
-    }
-}
 
 class npc_wintergarde_gryphon : public VehicleAI
 {
@@ -694,21 +677,6 @@ public:
         me->SetFacingToObject(summoner);
         Position pos = summoner->GetPosition();
         me->GetMotionMaster()->MovePoint(POINT_LAND, pos);
-        events.ScheduleEvent(EVENT_CHECK_QUEST_AREA, 1s);
-    }
-
-    // Vehicle::RemovePassenger grants Parachute, so unseating the rider mid-air is safe
-    void DespawnOutOfQuestZone()
-    {
-        if (Vehicle* gryphon = me->GetVehicleKit())
-            if (Unit* villager = gryphon->GetPassenger(SEAT_VILLAGER))
-                if (Creature* seat = villager->ToCreature())
-                {
-                    seat->ExitVehicle();
-                    seat->DespawnOrUnsummon();
-                }
-
-        me->DespawnOrUnsummon();
     }
 
     void MovementInform(uint32 type, uint32 id) override
@@ -719,11 +687,11 @@ public:
 
     void PassengerBoarded(Unit* passenger, int8 seatId, bool apply) override
     {
-        if (!apply && seatId == SEAT_RIDER)
+        if (!apply && seatId == 0)
         {
             // left the vehicle with a passenger will result in despawn
             if (Vehicle* gryphon = me->GetVehicleKit())
-                if (Unit* villager = gryphon->GetPassenger(SEAT_VILLAGER))
+                if (Unit* villager = gryphon->GetPassenger(1))
                 {
                     if (!villager->IsCreature())
                         return;
@@ -744,6 +712,9 @@ public:
 
     void UpdateAI(uint32 diff) override
     {
+        // dismounts the player once the gryphon leaves the areas whitelisted in conditions
+        VehicleAI::UpdateAI(diff);
+
         events.Update(diff);
         while (uint32 eventId = events.ExecuteEvent())
         {
@@ -776,17 +747,6 @@ public:
                     }
                     break;
                 }
-                case EVENT_CHECK_QUEST_AREA:
-                {
-                    if (!IsInWintergardeQuestZone(me))
-                    {
-                        DespawnOutOfQuestZone();
-                        return;
-                    }
-
-                    events.ScheduleEvent(EVENT_CHECK_QUEST_AREA, 1s);
-                    break;
-                }
             }
         }
     }
@@ -797,7 +757,7 @@ public:
             return;
 
         if (Vehicle* gryphon = me->GetVehicleKit())
-            if (Unit* villager = gryphon->GetPassenger(SEAT_VILLAGER))
+            if (Unit* villager = gryphon->GetPassenger(1))
             {
                 villager->ExitVehicle();
                 villager->GetMotionMaster()->Clear(false);
@@ -924,17 +884,12 @@ class spell_call_wintergarde_gryphon : public SpellScript
 
     SpellCastResult CheckRequirement()
     {
-        Player* playerCaster = GetCaster()->ToPlayer();
-        if (!playerCaster)
-            return SPELL_FAILED_DONT_REPORT;
-
-        if (playerCaster->GetQuestStatus(QUEST_FLIGHT_OF_THE_WINTERGARDE_DEFENDER) != QUEST_STATUS_INCOMPLETE)
-            return SPELL_FAILED_DONT_REPORT;
-
-        if (!IsInWintergardeQuestZone(playerCaster))
-            return SPELL_FAILED_INCORRECT_AREA;
-
-        return SPELL_CAST_OK;
+        if (Player* playerCaster = GetCaster()->ToPlayer())
+        {
+            if (playerCaster->GetQuestStatus(QUEST_FLIGHT_OF_THE_WINTERGARDE_DEFENDER) == QUEST_STATUS_INCOMPLETE)
+                return SPELL_CAST_OK;
+        }
+        return SPELL_FAILED_DONT_REPORT;
     }
 
     void Register() override


### PR DESCRIPTION
The Wintergarde Gryphon from Flight of the Wintergarde Defender worked as a free flying mount: once you were on it you could fly anywhere in Northrend for the full 15 minutes, no dismount and no warning.

Turns out the world DB already handles this. There are three conditions rows for creature 27258 (source type 16) whitelisting Wintergarde Keep, Wintergarde Mine and The Carrion Fields, and VehicleAI::CheckConditions polls them every second and kicks the rider off when they no longer hold. They just never ran, because npc_wintergarde_gryphon overrides UpdateAI and never chains to VehicleAI::UpdateAI. So the fix is that one call.

Decisions worth knowing
The first version of this did the area check in C++ with its own area list and its own 1s timer. I dropped it: it would've duplicated the conditions rows and left them dead, so anyone editing them later would've seen no effect in game.

Chaining to the base also makes m_DoDismiss live for this creature for the first time. Its 5s timer now beats the script's existing EVENT_TAKE_OFF into DespawnOrUnsummon(4050ms), which landed around 6s, so the gryphon disappears about a second earlier after a normal dismount, part way through the take off arc. Cosmetic, but you'll see it.

<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Opus 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/27232

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
