### PR TITLE
fix(DB/Creature): Gortok Palehoof aggro sound missing

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1787336038579910700.sql
+++ b/data/sql/updates/pending_db_world/rev_1787336038579910700.sql
@@ -1,0 +1,7 @@
+-- Gortok Palehoof (Utgarde Pinnacle) aggro line plays no voice sound
+-- creature_text row (CreatureID 26687, GroupID 0, ID 0, SAY_AGGRO) has Sound=0.
+-- Verified against SoundEntries.dbc: ID 13464 = "A_UP_Gortok_Aggro" / UP_Gortok_Aggro.wav
+-- under Sound\Creature\GortokPalehoof, matching this creature and text.
+-- Source: azerothcore/azerothcore-wotlk#27231, chromiecraft/chromiecraft#10039
+
+UPDATE `creature_text` SET `Sound`=13464 WHERE `CreatureID`=26687 AND `GroupID`=0 AND `ID`=0;


### PR DESCRIPTION
Gortok Palehoof's aggro line printed its text but played no voice line, because the SAY_AGGRO row in creature_text had Sound=0.

Verified SoundEntries.dbc ID 13464 ("A_UP_Gortok_Aggro" / UP_Gortok_Aggro.wav, under Sound\Creature\GortokPalehoof) against a locally extracted client DBC before applying; it matches this creature and text. Tested in-game: the voice line now plays together with the text when Gortok unfreezes and aggros.

Source: chromiecraft/chromiecraft#10039, azerothcore/azerothcore-wotlk#27231

## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code, Sonnet 5
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/27231

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

I recorded a video demo of my local server after applying the SQL: https://www.dropbox.com/scl/fi/nfqzagi9806ajb8fvcrd1/GortokSoundFix.mp4?rlkey=sg87c68ssxxsrug81jmz52zhf&st=7nzfrxw8&dl=0

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Enter Utgarde Pinnacle.
2. Activate the orb for the Gortok Palehoof encounter.
3. Kill mini-bosses until Gortok Palehoof unfreezes and aggros.
4. Confirm his aggro line is both printed and voiced. **NOTE:** You must be standing near him to hear it, since he "says" it rather than "yells".

## Known Issues and TODO List:
- [ ] Gortok's SLAY lines (`GroupID 1`) also have `Sound = 0` in `creature_text`, and their linked `broadcast_text` rows have `SoundEntriesId = 0` as well. So they currently have no configured voice audio either. Out of scope for this PR (issue #27231 only covers the aggro line), but maybe worth a follow-up.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
