### PR TITLE
fix(Core/Spells): Ritual of Refreshment table spawns on the portal

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1787374192228854600.sql
+++ b/data/sql/updates/pending_db_world/rev_1787374192228854600.sql
@@ -1,0 +1,9 @@
+-- The refreshment portal never played an animation when clicked: Data2 (animSpell) was 0 and the
+-- core fallback casts with TRIGGERED_CAST_DIRECTLY, which skips the visual. 32783 is the same
+-- generic ritual channel the summoning portals (36727 / 179944) already use.
+UPDATE `gameobject_template` SET `Data2` = 32783 WHERE `entry` IN (186811, 193062);
+
+DELETE FROM `spell_script_names` WHERE `spell_id` IN (43985, 58661);
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(43985, 'spell_mage_conjure_refreshment_table_r1'),
+(58661, 'spell_mage_conjure_refreshment_table_r2');

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -5392,9 +5392,23 @@ void Spell::EffectTransmitted(SpellEffIndex effIndex)
     }
 
     float fx, fy, fz;
+    float fo = m_caster->GetOrientation();
 
     if (m_targets.HasDst())
+    {
         destTarget->GetPosition(fx, fy, fz);
+
+        // only destinations derived from the caster's own position carry his facing, and they are
+        // the only ones a script can have deliberately turned. Destinations taken from a target,
+        // from a nearby object or from spell_target_position carry a facing of their own that must
+        // not rotate the gameobject
+        SpellImplicitTargetInfo const& targetInfo = m_spellInfo->Effects[effIndex].TargetA;
+        if (targetInfo.GetReferenceType() == TARGET_REFERENCE_TYPE_CASTER
+            && targetInfo.GetSelectionCategory() == TARGET_SELECT_CATEGORY_DEFAULT
+            && targetInfo.GetTarget() != TARGET_DEST_DB
+            && targetInfo.GetTarget() != TARGET_DEST_HOME)
+            fo = destTarget->GetOrientation();
+    }
     //FIXME: this can be better check for most objects but still hack
     else if (m_spellInfo->Effects[effIndex].HasRadius() && m_spellInfo->Speed == 0)
     {
@@ -5423,8 +5437,9 @@ void Spell::EffectTransmitted(SpellEffIndex effIndex)
 
     GameObject* pGameObj = sObjectMgr->IsGameObjectStaticTransport(name_id) ? new StaticTransport() : new GameObject();
 
-    G3D::Quat rotation = G3D::Quat::fromAxisAngleRotation(G3D::Vector3::unitZ(), m_caster->GetOrientation());
-    if (!pGameObj->Create(cMap->GenerateLowGuid<HighGuid::GameObject>(), name_id, cMap, m_caster->GetPhaseMask(), fx, fy, fz, m_caster->GetOrientation(), rotation, 100, GO_STATE_READY))
+    G3D::Quat rotation = G3D::Quat::fromAxisAngleRotation(G3D::Vector3::unitZ(), fo);
+    if (!pGameObj->Create(cMap->GenerateLowGuid<HighGuid::GameObject>(), name_id, cMap, m_caster->GetPhaseMask(),
+        fx, fy, fz, fo, rotation, 100, GO_STATE_READY))
     {
         delete pGameObj;
         return;

--- a/src/server/scripts/Spells/spell_mage.cpp
+++ b/src/server/scripts/Spells/spell_mage.cpp
@@ -15,6 +15,7 @@
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "GameObject.h"
 #include "Pet.h"
 #include "Player.h"
 #include "SpellAuraEffects.h"
@@ -1467,6 +1468,44 @@ private:
     bool _canProcT10 = false;
 };
 
+enum RitualOfRefreshment
+{
+    SPELL_MAGE_RITUAL_OF_REFRESHMENT_R1 = 43987,
+    SPELL_MAGE_RITUAL_OF_REFRESHMENT_R2 = 58659,
+    GO_MAGE_REFRESHMENT_PORTAL_R1       = 186811,
+    GO_MAGE_REFRESHMENT_PORTAL_R2       = 193062
+};
+
+// 43985, 58661 - Conjure Refreshment Table
+class spell_mage_conjure_refreshment_table : public SpellScript
+{
+public:
+    spell_mage_conjure_refreshment_table(uint32 ritualSpellId, uint32 portalEntry)
+        : _ritualSpellId(ritualSpellId), _portalEntry(portalEntry) { }
+
+    PrepareSpellScript(spell_mage_conjure_refreshment_table);
+
+    // the destination follows the mage, who may have turned or walked off while the group finished
+    // the ritual; the table has to land where the portal was left
+    void SetDest(SpellDestination& dest)
+    {
+        Unit* caster = GetCaster();
+        if (GameObject* portal = caster->GetGameObject(_ritualSpellId))
+            if (portal->GetEntry() == _portalEntry && portal->GetOwnerGUID() == caster->GetGUID())
+                dest.Relocate(portal->GetPosition());
+    }
+
+    void Register() override
+    {
+        OnDestinationTargetSelect += SpellDestinationTargetSelectFn(
+            spell_mage_conjure_refreshment_table::SetDest, EFFECT_0, TARGET_DEST_CASTER_FRONT);
+    }
+
+private:
+    uint32 _ritualSpellId;
+    uint32 _portalEntry;
+};
+
 // -31661 - Dragon's Breath
 class spell_mage_dragon_breath : public AuraScript
 {
@@ -1644,6 +1683,10 @@ void AddSC_mage_spell_scripts()
     RegisterSpellScript(spell_mage_combustion);
     RegisterSpellScript(spell_mage_glyph_of_eternal_water);
     RegisterSpellScript(spell_mage_combustion_proc);
+    RegisterSpellScriptWithArgs(spell_mage_conjure_refreshment_table, "spell_mage_conjure_refreshment_table_r1",
+        SPELL_MAGE_RITUAL_OF_REFRESHMENT_R1, GO_MAGE_REFRESHMENT_PORTAL_R1);
+    RegisterSpellScriptWithArgs(spell_mage_conjure_refreshment_table, "spell_mage_conjure_refreshment_table_r2",
+        SPELL_MAGE_RITUAL_OF_REFRESHMENT_R2, GO_MAGE_REFRESHMENT_PORTAL_R2);
     RegisterSpellScript(spell_mage_dragon_breath);
     RegisterSpellScript(spell_mage_empowered_fire);
     RegisterSpellScript(spell_mage_gen_extra_effects);


### PR DESCRIPTION
## Changes Proposed:

The Ritual of Refreshment table now appears on the portal that started the ritual, keeping the
facing the ritual was cast at.

Before this, the table was created wherever the mage stood and faced at the moment the third
participant completed the ritual. Turning or walking away after the cast moved the table with you.

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request.
   - Tools/models used: Claude Code (Opus 5). It was used for the research, the regression analysis
     and the first draft of the patch. Every line was reviewed, built and tested in game by me
     before opening this.
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:

- Closes #16101
- Related ChromieCraft issue: chromiecraft/chromiecraft#5346
- Supersedes #26752, which I closed myself while it sat unreviewed. This one is rebased on current
  master and adds the orientation part.

## SOURCE:

Retail behaviour was established by @heyitsbench in
[#16101 (comment)](https://github.com/azerothcore/azerothcore-wotlk/issues/16101#issuecomment-2479021987),
with a reference drawing:

> But if Pameline turns to face along the blue line *after* the portal is created and the party
> members use the portal, the table will instead be created on the blue circle. This is not
> correct. The table should be created on the red circle again according to official servers, as
> that's the position it was deemed to go to with the initial cast.

The approach avoids the game object casting route, which @sogladev tried and reported back on in
[#16101 (comment)](https://github.com/azerothcore/azerothcore-wotlk/issues/16101#issuecomment-2479109193):

> If the fix below were used to have the gobject cast, the owner is set to that of the world
> trigger NPC. When using the table, the user and the owner must be in the same group; This check
> fails. [...] I tried setting the group to that of the original caster if present, but this breaks
> other gobjects like summoning portals

So `GameObject.cpp` is untouched here, and the `ApplySpellFix` on `{ 43985, 58661 }` stays as it is.
Removing it would send the target back to `TARGET_DEST_CASTER` and drop the table inside the mage.

## What the change does

**Position and facing.** A new `SpellScript` on 43985 and 58661 hooks `OnDestinationTargetSelect`
and snaps the destination onto the caster's own portal, found through `Unit::GetGameObject()` with
the ritual spell id, then checked against the expected entry and owner GUID. Two mages ritualling
next to each other each get their own portal. If the portal cannot be resolved the destination is
left alone, so the behaviour falls back to what it does today.

That alone fixes the position but not the facing, because `Spell::EffectTransmitted` took only
x/y/z from the destination and always used `m_caster->GetOrientation()`. It now takes the facing
from the destination too, but only when the effect's implicit target is caster referenced, of the
default selection category, and not `TARGET_DEST_DB` or `TARGET_DEST_HOME`. Everything that passes
that filter is built as `SpellDestination(*m_caster)`, so its orientation already was the caster's,
and the value only differs when a script moved the destination on purpose.

**Portal animation.** An earlier revision set `Data2` (`animSpell`) to 32783 on both portal
entries so that clicking one played the ritual channel. @heyitsbench confirmed both objects carry
`Data2` 0 on retail, so that has been removed and no longer forms part of this PR.

## Regression analysis

`EffectTransmitted` is shared, so I enumerated the blast radius instead of reasoning about it.
`Spell.dbc` has 222 `SPELL_EFFECT_TRANS_DOOR` effects. 142 pass the new filter, and all of them
build their destination from the caster, so the facing is unchanged. The other 80 keep the old
behaviour, including the 11 whose destination carries a foreign facing:

| Spell | Game object | Destination comes from |
| --- | --- | --- |
| 69767 Summon Ice Wall | 201385 Ice Wall (DOOR) | nearby object |
| 53097 Portal: Acherus | 191155 Portal to Acherus | `spell_target_position` |
| 9055 Create Witherbark Totem Bundle | 174764 | `spell_target_position` |
| 9082 Create Containment Coffer | 122088 | nearby object |
| 42793 / 46574 / 48974 Burn Body, Grain, Corpse | 182071 Small Chapel Fire | nearby object |
| 47431 Capture Jormungar Spawn | 190510 | target's facing |
| 54026 Place Seaforium Charge | 190753 Seaforium Bomb | target's facing |
| 54249 / 59594 Lava Burn | 194952 / 191457 Lava Bomb | target's facing |

Ice Wall matters most of those, since it is a DOOR type used as a collision barrier. It is excluded.

Of the 142 that do pass the filter, only four have a script in master, and none of them touches the
facing: `spell_warl_ritual_of_summoning` and `spell_gen_planting_scourge_banner` only use
`OnCheckCast`, `spell_gen_basic_campfire` only adjusts Z, and `spell_spawn_blood_pool` relocates
with an explicit `caster->GetOrientation()`. So the two table spells are the only game objects in
the game whose facing changes.

## Tests Performed:

Tested in game on 3.3.5a, both ranks, with three characters for the ritual and a warlock for the
regression checks.

- Mage standing still: table lands on the portal with its facing.
- Mage turns 180° after casting, before the ritual completes: table still lands on the portal with
  the original facing.
- Mage walks 15 yards away: table lands on the portal, away from the mage.
- Two mages in the same group ritualling about 10 yards apart: each table lands on its own portal.
- The table is usable by the group and still spends its 50 charges.
- A ritual that never reaches 3 participants creates no table, and the portal expires clean.
- No regression on Ritual of Summoning, Ritual of Souls or Ritual of Doom.

Builds clean with no warnings, and both codestyle scripts pass.

## How to Test the Changes:

1. On a mage of level 70 or above, cast Ritual of Refreshment and have two party members click the
   portal. The table should appear on the portal.
2. Cast it again, and this time turn 180° while the party members are clicking. The table should
   still appear on the portal, facing the same way it did at cast time.
3. Cast it again and run 15 yards away before the ritual completes. Same result.
4. Repeat with rank 2 (level 80).
5. With two mages in the same group, cast both rituals about 10 yards apart and complete them.
   Each table should land on its own portal.
7. As a warlock, cast Ritual of Summoning, Ritual of Souls and Ritual of Doom, and check they still
   behave as before.

