### PR TITLE
fix(Core/Player): Poly or Fearing a MC'ing priest causing invalid state

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -13148,13 +13148,11 @@ void Player::SetClientControl(Unit* target, bool allowMove, bool packetOnly /*= 
         return;
     }
 
-    // still affected by some aura that shouldn't allow control, only allow on last such aura to be removed
-    if (target->HasUnitState(UNIT_STATE_FLEEING | UNIT_STATE_CONFUSED))
-        allowMove = false;
-
+    // A fleeing/confused target can't be controlled by the client yet, but the mover
+    // must still switch so control is restored once the crowd control ends.
     WorldPacket data(SMSG_CLIENT_CONTROL_UPDATE, target->GetPackGUID().size() + 1);
     data << target->GetPackGUID();
-    data << uint8(allowMove ? 1 : 0);
+    data << uint8((allowMove && !target->HasUnitState(UNIT_STATE_FLEEING | UNIT_STATE_CONFUSED)) ? 1 : 0);
     SendDirectMessage(&data);
 
     // We want to set the packet only


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Restores logic to prevent allowMove being set when building `SMSG_CLIENT_CONTROL_UPDATE` if the player is still confused or fleeing. 

Related PR:
- https://github.com/azerothcore/azerothcore-wotlk/pull/24539

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: DS V4 Pro to write the comment and self-review
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/27253

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.

----------------------------

# Self-review — fix/mc-priest-fear-poly → c143cdaa7cb

**Outcome** 1 finding — dismissed — no fixes, rounds stopped (nothing fixed)

**Reviewed** `2ea8ad3ee455` (`fix/mc-priest-fear-poly` vs parent `c143cdaa7cb`, single-commit diff — 1 file, +3 −5)

**Tested** In-game by author: 2 characters (Mage/Priest) — Fear `.cast 6215` and Polymorph `.cast 12826` on the MC'ing priest, test NPC `.npc add 38581`; author confirmed control state for charmer and charmee (Fear+MC path).

**By** unknown — self-review v0.4, 2026-08-22

<details>
<summary>Review details (1 round)</summary>

**Intent** Fix the invalid state when a Priest who is mind-controlling (or a player under Fear/Polymorph) is crowd-controlled: the client must not gain movement control while `UNIT_STATE_FLEEING`/`UNIT_STATE_CONFUSED` remains, but the mover must still switch so control is restored once the CC ends. Follow-up fixup of merged PR #24539 "fix(Core/Player): Prevent player gaining client control when charmed".

**Project rules** `.agents/docs/self-review-rules.md` present and applied; `.agents/docs/code-review.md` and `.agents/docs/cpp-guidelines.md` applied as checklists.

**Procedural** Uncommitted tracked change `.gitignore` (adds `reasonix.toml`, `.reasonix`) treated as a deliberate local-only tweak, not part of the reviewed commit. Reviewer coverage: every changed file covered (`src/server/game/Entities/Player/Player.cpp`); reviewer harness/model reported unknown. PR #24539 discussion walked: 1 inline comment (Copilot) still applies at this head and is Finding 1; Nyeriah's approval had no body; no conversation comments.

## Round 1 — `2ea8ad3ee455`, 1 finding

1. `src/server/game/Entities/Player/Player.cpp:13145` — `UNIT_STATE_CHARMED` guard early-returns on `allowMove=false`, dropping the control-lost resend from `MovementHandler.cpp:358-359` after worldport/teleport while charmed, and logs `LOG_ERROR` in a benign flow (pre-existing from merged PR #24539, not touched by this diff) → **dismissed**: "The guard prevents client control from being granted while it is still charmed." (author's verbatim reason)

</details>