### PR TITLE
fix(Core/Battlefield): resurrect ghosts when a Wintergrasp workshop is contested

### DIFF
--- a/src/server/game/Battlefield/Zones/BattlefieldWG.cpp
+++ b/src/server/game/Battlefield/Zones/BattlefieldWG.cpp
@@ -581,8 +581,12 @@ uint32 BattlefieldWG::GetAreaByGraveyardId(uint8 gId) const
     return 0;
 }
 
-void BattlefieldWG::RelocateDeadPlayers(uint8 graveyardId, TeamId newOwner)
+void BattlefieldWG::RelocateDeadPlayers(uint8 graveyardId, TeamId losingTeam)
 {
+    // Nobody could use the graveyard before the change, so nobody is left waiting on it.
+    if (losingTeam == TEAM_NEUTRAL)
+        return;
+
     BfGraveyard const* graveyard = GetGraveyardById(graveyardId);
     if (!graveyard)
         return;
@@ -591,19 +595,30 @@ void BattlefieldWG::RelocateDeadPlayers(uint8 graveyardId, TeamId newOwner)
     if (!capturedLoc)
         return;
 
-    ForEachPlayerInZone([this, capturedLoc, newOwner](Player* player)
+    ForEachPlayerInZone([this, capturedLoc, losingTeam](Player* player)
     {
-        // Only players of the losing team waiting to resurrect; they would otherwise be
-        // revived in place on the now-inaccessible captured platform.
-        if (player->GetTeamId() == newOwner || !player->HasAura(SPELL_WAITING_FOR_RESURRECT))
+        // Only the team that just lost it. The other team could never have released here, since
+        // RepopAtGraveyard picks a graveyard their own team holds, so they are passers-by.
+        if (player->GetTeamId() != losingTeam)
             return;
 
-        // Restrict to ghosts actually waiting at the captured graveyard, not elsewhere in the zone.
+        // Ghosts only. Skips the living, and corpses that RepopAtGraveyard will send to a
+        // graveyard their team holds once they release.
+        if (!player->HasPlayerFlag(PLAYER_FLAGS_GHOST))
+            return;
+
+        // Only ghosts waiting at this graveyard, not elsewhere in the zone.
         if (player->GetDistance2d(capturedLoc->x, capturedLoc->y) > 50.0f)
             return;
 
-        if (GraveyardStruct const* safeLoc = GetClosestGraveyard(player))
-            player->TeleportTo(safeLoc->Map, safeLoc->x, safeLoc->y, safeLoc->z, player->GetOrientation());
+        GraveyardStruct const* safeLoc = GetClosestGraveyard(player);
+        if (!safeLoc)
+            return;
+
+        player->TeleportTo(safeLoc->Map, safeLoc->x, safeLoc->y, safeLoc->z, player->GetOrientation());
+
+        // The spirit guides here are phased out for them now, so they can't queue themselves.
+        AddPlayerToResurrectQueue(ObjectGuid::Empty, player->GetGUID());
     });
 }
 

--- a/src/server/game/Battlefield/Zones/BattlefieldWG.h
+++ b/src/server/game/Battlefield/Zones/BattlefieldWG.h
@@ -400,8 +400,8 @@ public:
     uint8 GetSpiritGraveyardId(uint32 areaId) const;
     uint32 GetAreaByGraveyardId(uint8 gId) const;
 
-    // Teleport ghosts waiting at a just-captured graveyard to their team's nearest controlled one.
-    void RelocateDeadPlayers(uint8 graveyardId, TeamId newOwner);
+    // Move ghosts off a graveyard their team just lost, and queue them to resurrect at the new one.
+    void RelocateDeadPlayers(uint8 graveyardId, TeamId losingTeam);
 
     uint32 GetData(uint32 data) const override;
 
@@ -1427,6 +1427,8 @@ struct WGWorkshop
 
     void GiveControlTo(TeamId team, bool init /* for first call in setup*/)
     {
+        TeamId const previousControl = teamControl;
+
         switch (team)
         {
             case TEAM_NEUTRAL:
@@ -1473,10 +1475,10 @@ struct WGWorkshop
             bf->UpdateCounterVehicle(false);
             bf->CapturePointTaken(bf->GetAreaByGraveyardId(workshopId));
 
-            // Workshop graveyard share the workshop id; repop ghosts that lost it.
-            // Only on an actual capture, not while the workshop is merely contested (neutral).
-            if (IsCapturable() && teamControl != TEAM_NEUTRAL)
-                bf->RelocateDeadPlayers(workshopId, teamControl);
+            // Workshop graveyard share the workshop id. Ghosts of the team that just lost it can no
+            // longer see a spirit guide here, so move them to a graveyard they can still use.
+            if (IsCapturable())
+                bf->RelocateDeadPlayers(workshopId, previousControl);
         }
     }
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->
In Wintergrasp, a player who released their spirit at a workshop graveyard loses the battlefield's automatic resurrection as soon as that workshop stops being held by their team. No resurrect timer, no faction spirit guide in range. The generic Spirit Healer at the graveyard still works, so you are not completely stuck, but taking it costs resurrection sickness.

The faction spirit guides at those graveyards are phased in by the factory phase auras 56617 and 56618, and those only fit while the graveyard's control team matches. The moment the workshop goes contested the control team is neutral, both auras drop, and neither guide is visible, so the ghost has no way to queue itself. That is the window the reported video shows: the ghost is stranded right after "The Sunken Ring siege workshop has been attacked by the Alliance!", before any capture.

RelocateDeadPlayers already existed for this ([#26395](https://github.com/EricksOliveira/azerothcore-wotlk/issues/26395)) but covered only part of it. It ran only on an actual capture, and only for players who had already made it into the resurrect queue. A ghost that never got into the queue, which is exactly the reported case, was skipped.

This runs it on the contested transition as well, drops the queue requirement, gates on PLAYER_FLAGS_GHOST so the living and unreleased corpses stay put, and queues the relocated player for resurrection at the destination so the periodic battlefield task revives them without clicking anything.

It also narrows who gets moved, to the team that just lost the graveyard rather than everyone who is not the new owner. Only that team could have released there in the first place, since RepopAtGraveyard picks a graveyard your own team holds. Without that narrowing, a player corpse-running past a workshop his own team was contesting got teleported to his base graveyard and force-resurrected, and the capture point flips often enough during a fight for that to repeat.

One consequence worth knowing: the capture transition ends up a no-op. The point always sits neutral for a while first, since neutralPercent is 80 on the four factory banners, and nobody can release onto a neutral graveyard, so there is nobody left to move by the time the capture lands. The call is kept on both transitions rather than special-cased.

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Opus 5
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/27194

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Tested in-game on Windows, using .bf start and .bf stop to drive battles. Confirmed that a ghost at a workshop graveyard is relocated and resurrected when that workshop goes contested, that the same happens on an outright capture, and that a player who has not released yet is left alone and can still release normally. Verified at one workshop.

Not yet covered, and worth a second pair of eyes: that ghosts of the team gaining control stay put; The Broken Temple, whose graveyard sits in a different area from its workshop; and the losing-team narrowing described above, which landed after that round of testing.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. .bf start to force a battle, then capture a workshop with the Horde.
2. Kill the Horde character inside that workshop area and release. It lands at that workshop's graveyard as a ghost, with a Taunka Spirit Guide visible.
3. Bring the Alliance character onto the capture point until "… siege workshop has been attacked by the Alliance!" fires.
4. The Horde ghost should be teleported to the nearest Horde-controlled graveyard and resurrected there within the respawn interval, without talking to any NPC.
5. Regression check: repeat with an Alliance ghost standing within 50 yards of that same graveyard at the moment it goes contested. It should not be moved.
6. Regression check: a character that died but has not released should stay put through the whole transition, and still release into a graveyard its own team holds.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
