### PR TITLE
fix(Core/Vehicles): don't seat accessories on dead spawns awaiting respawn

### DIFF
--- a/src/server/game/Entities/Vehicle/Vehicle.cpp
+++ b/src/server/game/Entities/Vehicle/Vehicle.cpp
@@ -139,7 +139,9 @@ void Vehicle::Reset(bool evading /*= false*/)
     else
     {
         ApplyAllImmunities();
-        InstallAllAccessories(evading);
+        // Dead spawns waiting out a respawn timer must not seat live accessories; they are seated on revival.
+        if (_me->IsAlive())
+            InstallAllAccessories(evading);
         if (_usableSeatNum)
             _me->SetNpcFlag(UNIT_NPC_FLAG_SPELLCLICK);
     }


### PR DESCRIPTION
<!-- Paste-ready PR body for fix/vehicle-accessory-dead-spawns -> azerothcore/azerothcore-wotlk master -->

## Changes Proposed:

Kologarn's arms come back a couple of hours after the boss is killed, floating over the bridge with no torso.

A creature waiting out its respawn timer is loaded dead into the grid, but grid load and `Map::AddToMap` still run `Vehicle::Reset()` on it, which installs its `vehicle_template_accessory` entries. The accessories are summoned alive and seated on the invisible dead vehicle. For Kologarn that means both arms floating at his spawn point whenever the instance map reloads (everyone leaves long enough for it to unload, or the server restarts) before his 7 day respawn timer elapses. Any DB-spawned vehicle with accessories can hit this the same way.

The fix ports TrinityCore's guard: `Vehicle::Reset()` only installs accessories while the base creature is alive. Revived spawns still get theirs, since the `JustRespawned` tick in `Creature::Update` resets the vehicle kit once the creature is alive again, and a fresh instance loads the boss alive so the normal install path is untouched. Wipe recovery keeps going through the evade path.

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Claude Fable 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #27266
- Closes #25991

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Ported from TrinityCore: https://github.com/TrinityCore/TrinityCore/commit/551d0559aac663e9485b0eaffac5326536180c27 (their PR TrinityCore/TrinityCore#20033). Committed with `--author` crediting the original author.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. Kill Kologarn, then have everyone leave the instance long enough for the map to unload (or restart the worldserver).
2. Re-enter and check the bridge: no floating arms.
3. `.respawn` the boss (or wait out the timer) and confirm the arms come back with him and the fight works, including the in-combat arm respawns.
4. Regression check on another accessory vehicle, e.g. pull Flame Leviathan and wipe, then confirm its turret seats come back on reset.

## Known Issues and TODO List:

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
