### PR TITLE
fix(DB/Database): parse MariaDB 11.x version as integers (11.8 refused as [1,1,8] < [8,0,0])

### DIFF
--- a/src/server/database/Database/DatabaseWorkerPool.cpp
+++ b/src/server/database/Database/DatabaseWorkerPool.cpp
@@ -390,15 +390,18 @@ bool DatabaseIncompatibleVersion(std::string const mysqlVersion)
     // "1.2.3" => [1, 2, 3]
     auto parse = [](std::string const& input)
     {
+        // Fixed: read full numbers ("11.8.6" => [11, 8, 6]) — the original
+        // char-by-char read broke on 2-digit majors (MariaDB 11.x failed the
+        // >= 8.0 check with [1,1,x] < [8,0,0]).
         std::vector<uint8> result;
         std::istringstream parser(input);
-        result.push_back(parser.get());
-        for (int i = 1; i < 3; i++)
+        int num = 0;
+        char dot = 0;
+        for (int i = 0; i < 3; i++)
         {
-            // Skip period
-            parser.get();
-            // Append int from parser to output
-            result.push_back(parser.get());
+            parser >> num;
+            result.push_back(static_cast<uint8>(num));
+            parser >> dot;
         }
         return result;
     };


### PR DESCRIPTION
## Bug

`DatabaseIncompatibleVersion()` in `src/server/database/Database/DatabaseWorkerPool.cpp` parses the server version string **character by character** (`parser.get()`), so `"11.8.6"` becomes `[1, 1, 8]` instead of `[11, 8, 6]`. Compared against `[8, 0, 0]`, MariaDB 11.x is reported as incompatible and the server refuses to start:

```
AzerothCore does not support MySQL versions below 8.0
```

## Reproduction

- MariaDB 11.8 (current stable of Ubuntu 24.04+/26.04 LTS repositories)
- `DatabaseIncompatibleVersion("11.8.6")` → `[1,1,8]` < `[8,0,0]` → returns `true` (incompatible)

## Fix

Read the full integers instead of chars, skipping the `.` separators:

```cpp
auto parse = [](std::string const& input)
{
    std::vector<uint8_t> result;
    std::istringstream parser(input);
    int num = 0;
    char dot = 0;
    for (int i = 0; i < 3; i++)
    {
        parser >> num;
        result.push_back(static_cast<uint8_t>(num));
        parser >> dot;
    }
    return result;
};
```

`"11.8.6"` → `[11, 8, 6]` → `>= [8, 0, 0]` → accepted.

## Testing

- `DatabaseIncompatibleVersion("8.0.35")` → `false` (unchanged)
- `DatabaseIncompatibleVersion("5.6.6")` → `true` (unchanged)
- `DatabaseIncompatibleVersion("11.8.6")` → `false` (fixed)
