### PR TITLE
fix(Scripts/Ulduar): Allow CC on Thorim's pre-fight pack and add NPCs

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1787434051690719900.sql
+++ b/data/sql/updates/pending_db_world/rev_1787434051690719900.sql
@@ -1,0 +1,17 @@
+--
+-- Thorim: the pre-fight pack, the Dark Rune casters and the Iron Ring/Honor Guards all inherit the shared
+-- boss set -361 (interrupt, every CC and knockback immune) from AC's original base data, and the Dark Rune
+-- Warbringer sits on -359 (the same minus charm). Classic Wrath footage shows the Dark Rune Acolytes
+-- interrupted and knocked back, the pre-fight Acolyte Death Gripped, the pre-fight mercenaries Mind
+-- Controlled/sheeped/feared (the fight starts when the last pack member dies, so one can be kept CC'd),
+-- the Iron Ring Guards stunned and slowed, and the Warbringer stunned and slowed by a hunter trap.
+-- Clear the immunities:
+-- Dark Rune Acolyte 32886/33159 (arena), 33110/33161 (gauntlet), Dark Rune Evoker 32878/33156,
+-- Dark Rune Warbringer 32877/33155 (stays Mind Controllable for its Aura of Celerity), Dark Rune
+-- Commoner 32904/33157 and Dark Rune Champion 32876/33158 (arena adds, same unsourced mask),
+-- Captured Mercenary Soldier 32885/33153 + 32883/33152, Captured Mercenary Captain 32908/33151 + 32907/33150,
+-- Iron Ring Guard 32874/33162, Iron Honor Guard 32875/33163.
+-- Jormungar Behemoth, Runic Colossus and Ancient Rune Giant stay.
+UPDATE `creature_template` SET `CreatureImmunitiesId` = 0 WHERE `entry` IN
+(32886,33159,33110,33161,32878,33156,32877,33155,32904,33157,32876,33158,
+32885,33153,32883,33152,32908,33151,32907,33150,32874,33162,32875,33163);

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_thorim.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_thorim.cpp
@@ -484,6 +484,16 @@ struct boss_thorim : public BossAI
             _isHitAllowed = true;
     }
 
+    void SummonedCreatureDies(Creature* summon, Unit* /*killer*/) override
+    {
+        // start pack deaths must be counted here: a member killed while Mind Controlled
+        // still has PossessedAI installed when it dies, so its own JustDied never runs
+        if (summon->EntryEquals(NPC_JORMUNGAR_BEHEMOT, NPC_CAPTURED_MERCENARY_SOLDIER_ALLY,
+            NPC_CAPTURED_MERCENARY_SOLDIER_HORDE, NPC_CAPTURED_MERCENARY_CAPTAIN_ALLY,
+            NPC_CAPTURED_MERCENARY_CAPTAIN_HORDE, NPC_DARK_RUNE_ACOLYTE_I))
+            DoAction(ACTION_START_TRASH_DIED);
+    }
+
     void KilledUnit(Unit* victim) override
     {
         if (victim->IsPlayer())
@@ -1100,13 +1110,6 @@ struct boss_thorim_start_npcs : public ScriptedAI
             me->GetThreatMgr().ClearAllThreat();
             if (Unit* attacker = ObjectAccessor::GetUnit(*me, guid))
                 AttackStart(attacker);
-        }
-
-        void JustDied(Unit*) override
-        {
-            if (me->GetInstanceScript())
-                if (Creature* thorim = me->GetInstanceScript()->GetCreature(BOSS_THORIM))
-                    thorim->AI()->DoAction(ACTION_START_TRASH_DIED);
         }
 
         void JustEngagedWith(Unit*  /*who*/) override


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Thorim's pre-fight mercenaries, Dark Rune Acolytes/Evokers and Iron Ring/Honor Guards all inherit the shared boss immunity set -361 from AzerothCore's original base data, which put it on every Thorim NPC in one sweep, and the Dark Rune Warbringer sits on -359 (the same set minus charm). Nothing on them could be interrupted, stunned, slowed, knocked back, Death Gripped or (Warbringer excepted) Mind Controlled. That started as the two linked issues about interrupts (the spells themselves are flagged interruptible in Spell.dbc and the script casts them untriggered; the immunity mask was the only blocker), and Classic Wrath footage then showed the mask is wrong well beyond interrupts.

This clears `CreatureImmunitiesId` on 24 entries: Dark Rune Acolyte (arena 32886/33159, gauntlet 33110/33161), Dark Rune Evoker (32878/33156), Dark Rune Warbringer (32877/33155), Dark Rune Commoner (32904/33157), Dark Rune Champion (32876/33158), Captured Mercenary Soldier (32885/33153, 32883/33152), Captured Mercenary Captain (32908/33151, 32907/33150), Iron Ring Guard (32874/33162) and Iron Honor Guard (32875/33163). The 10-man gauntlet Acolyte 33110 already had no immunities (the only Thorim add without the mask, which is why the gauntlet part of #27180 only reproduced on 25-man), so the data now simply matches it. The Evoker, the Commoner, the Champion and the Iron Honor Guard have no footage of their own; they get the same treatment because they share the role, the data history and the same unsourced mask with the adds that do. Jormungar Behemoth, Runic Colossus and Ancient Rune Giant are left untouched (no evidence either way). The Warbringer stays Mind Controllable for its Aura of Celerity; with no immunity set that ability is untouched, it just stops resisting everything else.

Script part: the pre-fight pack reports its deaths to Thorim so the lever unlocks after the sixth one. That ran through each add's `JustDied`, which is swallowed when a creature dies while Mind Controlled (it still has `PossessedAI` installed at that moment, since the AI swap back is deferred to the next update). Now that the pack is MC-able, the counting moved to Thorim's `SummonedCreatureDies`, which the core calls on the summoner regardless of the dying creature's AI. The start condition itself is unchanged: the fight still begins when the whole pack is dead, so keeping one member CC'd to delay it works like on retail.

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Claude Fable 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #27180
- Closes #27181

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Classic Wrath kill footage: https://youtu.be/ewxLBdYTrPg?t=1513 shows the gauntlet Acolytes getting interrupted and knocked back and the pre-fight Acolyte getting Death Gripped. https://youtu.be/Jhgm4tepLEQ?t=69 (boss guide) shows the pre-fight humanoids being Mind Controlled, sheeped and feared, keeping one CC'd to delay the start, and Iron Ring Guards stunned and slowed. https://youtu.be/4B89g-erF5M?t=162 shows a Dark Rune Warbringer stunned and slowed by a hunter Frost Trap. The Thorim tactics page on warcraft.wiki.gg marks the four caster abilities as interruptible (Acolyte: Greater Heal, Holy Smite; Evoker: Runic Lightning, Runic Mending). Spell.dbc flags them interruptible as well. The known Warbringer MC tactic (raid borrows its Aura of Celerity) keeps working and was re-verified in-game on both sizes.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Tested in-game on both 10-man and 25-man (Windows 11, RelWithDebInfo build):

- Interrupts land on the pre-fight Acolyte, the gauntlet Acolyte and the arena Evoker on both sizes (Kick/Counterspell).
- Crowd control lands on the gauntlet Acolyte, the gauntlet guards and all the arena adds (Evoker, Warbringer, Commoner, Champion); the Warbringer/Commoner/Champion checks ran on 10-man, their 25-man twins carry the identical change.
- Mind Controlling a pre-fight pack member and killing it while controlled still counts its death: the encounter starts exactly when the whole pack is down, on both sizes.
- Keeping the last pack member crowd controlled through several CC cycles delays the start until it dies.
- Mind Controlling the Dark Rune Warbringer grants the raid Aura of Celerity on both sizes.
- The untouched Runic Colossus and Ancient Rune Giant are still CC-immune, matching the footage.

- Knockbacks (Thunderstorm and Typhoon) verified in-game on multiple add types.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Follow the steps in the issues with a class that has an interrupt, on 10-man and 25-man.
2. Kill the pre-fight pack normally: the lever unlocks after the sixth death and Thorim engages shortly after.
3. Mind Control a Captured Mercenary or the pre-fight Acolyte and kill it while the MC is active: the death must still count (lever unlocks once the rest are dead). Keep one pack member sheeped/feared instead of killing it: the fight must not start until it dies.
4. Death Grip or Typhoon the pre-fight Acolyte and the gauntlet Acolytes: they should move. Stun and slow the Iron Ring Guards.
5. Stun or Frost Trap a Dark Rune Warbringer in the arena; it should be affected and still be MC-able for Aura of Celerity.
6. Regression: the gauntlet giants are still CC-immune.

## Known Issues and TODO List:

- None.
