### PR TITLE
docs(agents): key the self-review rule to opening a PR

### DIFF
--- a/.agents/docs/code-review.md
+++ b/.agents/docs/code-review.md
@@ -26,10 +26,10 @@ line, not as background reading.
   call leaves a null result, not just what enables it.
 - Check the change is still needed against current `master`: the surrounding code may have moved,
   or another change may have landed the same fix.
-- On an existing PR, walk every discussion item one by one, bot reviews included: what was raised, whether it was
-  answered, and whether it still applies to the current head. Never skip one because it looks
-  resolved, old, or minor; this walk overrides any read-comments-lightly default of the reviewing
-  skill. `gh pr view` misses review bodies and inline threads; pull all three:
+- On an existing PR, walk every discussion item one by one, bot reviews included: what was raised,
+  whether it was answered, and whether it still applies to the current head. Never skip one
+  because it looks resolved, old, or minor; this walk overrides any read-comments-lightly default
+  of the reviewing skill. `gh pr view` misses review bodies and inline threads; pull all three:
 
   ```
   gh api repos/azerothcore/azerothcore-wotlk/issues/<N>/comments --paginate  # conversation comments

--- a/.agents/docs/code-review.md
+++ b/.agents/docs/code-review.md
@@ -26,7 +26,7 @@ line, not as background reading.
   call leaves a null result, not just what enables it.
 - Check the change is still needed against current `master`: the surrounding code may have moved,
   or another change may have landed the same fix.
-- On an existing PR, walk every discussion item one by one: what was raised, whether it was
+- On an existing PR, walk every discussion item one by one, bot reviews included: what was raised, whether it was
   answered, and whether it still applies to the current head. Never skip one because it looks
   resolved, old, or minor; this walk overrides any read-comments-lightly default of the reviewing
   skill. `gh pr view` misses review bodies and inline threads; pull all three:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,8 @@ Read the matching doc(s) BEFORE starting the task:
 - Creating or modifying SQL → `.agents/docs/sql-guidelines.md`
   - SmartAI work (`smart_scripts` data) → also `.agents/docs/cpp-scripts.md`
 - Reviewing a changeset or PR → `.agents/docs/code-review.md`
-- Self-reviewing a changeset before submission → also `.agents/docs/self-review-rules.md`
+- Opening or updating a PR → `.agents/docs/code-review.md` + `.agents/docs/self-review-rules.md`:
+  self-review before submitting; read existing comments, bot reviews included
 - Touching a subsystem that has a doc in `.agents/docs/systems/` → read that doc too
 - Capturing a lesson or adding/updating agent docs → `.agents/docs/README.md`
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,8 +19,7 @@ Read the matching doc(s) BEFORE starting the task:
 - Creating or modifying SQL → `.agents/docs/sql-guidelines.md`
   - SmartAI work (`smart_scripts` data) → also `.agents/docs/cpp-scripts.md`
 - Reviewing a changeset or PR → `.agents/docs/code-review.md`
-- Opening or updating a PR → `.agents/docs/code-review.md` + `.agents/docs/self-review-rules.md`:
-  self-review before submitting; read existing comments, bot reviews included
+- Self-reviewing, or opening or updating a PR → also `.agents/docs/self-review-rules.md`
 - Touching a subsystem that has a doc in `.agents/docs/systems/` → read that doc too
 - Capturing a lesson or adding/updating agent docs → `.agents/docs/README.md`
 


### PR DESCRIPTION
## Changes Proposed:

The "Mandatory reading per task" bullet for self-review currently reads:

> Self-reviewing a changeset before submission → also `.agents/docs/self-review-rules.md`

That only fires once you've already decided to self-review, which is circular: an agent
whose task is "fix X and open a PR" never classifies itself as self-reviewing, so it
never opens the doc. Naming the PR action in the trigger puts the obligation where the
work actually happens.

It also routes `code-review.md` for PR authors, not just reviewers, via the existing
`also` idiom. The rule about walking every existing comment lives there and applies
just as much when the PR is your own, so this adds the bot-reviews emphasis to that
rule rather than restating it in the routing line.

Found the hard way on #27255: I opened it without self-reviewing, and the review I then
ran caught a fix of mine that was completely inert. I had also not read the CodeRabbit
and Copilot comments before calling it ready, and one of them was a real finding.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Agent docs only.

### AI-assisted Pull Requests

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Opus 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes

## Tests Performed:
- [x] This pull request requires further testing and may have edge cases to be tested.

Docs only, nothing to run.
