### PR TITLE
fix(Core/Events): don't hold a map-store iterator across game event AI hooks

### DIFF
--- a/src/server/game/Events/GameEventMgr.cpp
+++ b/src/server/game/Events/GameEventMgr.cpp
@@ -1875,14 +1875,16 @@ void GameEventMgr::SendWorldStateUpdate(Player* player, uint16 eventId)
 class GameEventAIHookWorker
 {
 public:
-    GameEventAIHookWorker(Map* map, uint16 eventId, bool activate) : _map(map), _eventId(eventId), _activate(activate) { }
+    GameEventAIHookWorker(Map* map, uint16 eventId, bool activate) :
+        _map(map), _eventId(eventId), _activate(activate) { }
 
     void Visit(std::unordered_map<ObjectGuid, Creature*>& creatureMap)
     {
         for (ObjectGuid const& guid : Snapshot(creatureMap))
         {
             Creature* creature = _map->GetCreature(guid);
-            if (!creature || !creature->IsInWorld() || creature->IsDuringRemoveFromWorld() || !creature->FindMap() || !creature->IsAIEnabled || !creature->AI())
+            if (!creature || !creature->IsInWorld() || creature->IsDuringRemoveFromWorld() ||
+                !creature->FindMap() || !creature->IsAIEnabled || !creature->AI())
                 continue;
 
             creature->AI()->sOnGameEvent(_activate, _eventId);

--- a/src/server/game/Events/GameEventMgr.cpp
+++ b/src/server/game/Events/GameEventMgr.cpp
@@ -1875,26 +1875,61 @@ void GameEventMgr::SendWorldStateUpdate(Player* player, uint16 eventId)
 class GameEventAIHookWorker
 {
 public:
-    GameEventAIHookWorker(uint16 eventId, bool activate) : _eventId(eventId), _activate(activate) { }
+    GameEventAIHookWorker(Map* map, uint16 eventId, bool activate) : _map(map), _eventId(eventId), _activate(activate) { }
 
     void Visit(std::unordered_map<ObjectGuid, Creature*>& creatureMap)
     {
-        for (auto const& p : creatureMap)
-            if (p.second->IsInWorld() && !p.second->IsDuringRemoveFromWorld() && p.second->FindMap() && p.second->IsAIEnabled && p.second->AI())
-                p.second->AI()->sOnGameEvent(_activate, _eventId);
+        for (ObjectGuid const& guid : Snapshot(creatureMap))
+        {
+            Creature* creature = _map->GetCreature(guid);
+            if (!creature || !creature->IsInWorld() || creature->IsDuringRemoveFromWorld() || !creature->FindMap() || !creature->IsAIEnabled || !creature->AI())
+                continue;
+
+            creature->AI()->sOnGameEvent(_activate, _eventId);
+        }
     }
 
     void Visit(std::unordered_map<ObjectGuid, GameObject*>& gameObjectMap)
     {
-        for (auto const& p : gameObjectMap)
-            if (p.second->IsInWorld() && p.second->FindMap() && p.second->AI())
-                p.second->AI()->OnGameEvent(_activate, _eventId);
+        for (ObjectGuid const& guid : Snapshot(gameObjectMap))
+        {
+            GameObject* gameObject = _map->GetGameObject(guid);
+            if (!gameObject || !gameObject->IsInWorld() || !gameObject->FindMap() || !gameObject->AI())
+                continue;
+
+            gameObject->AI()->OnGameEvent(_activate, _eventId);
+        }
     }
 
     template<class T>
     void Visit(std::unordered_map<ObjectGuid, T*>&) { }
 
 private:
+    //! A SMART_EVENT_GAME_EVENT_START script can erase its own creature from the map's
+    //! object store while that store is being walked. Confirmed chain (game event 89
+    //! "Leprithus", entry 572, SMART_ACTION_RESPAWN_TARGET on self):
+    //!
+    //!   GameEventAIHookWorker::Visit -> SmartScript::ProcessEventsFor -> ProcessAction
+    //!     -> Creature::Respawn -> Map::AddObjectToRemoveList
+    //!     -> Unit::CleanupBeforeRemoveFromMap -> Creature::RemoveFromWorld
+    //!     -> _objectsStore.Remove<Creature>()
+    //!
+    //! The erase frees the hash node the loop is standing on, so reading the next node
+    //! yields garbage and the following dereference faults. Walk a snapshot of the guids
+    //! and resolve each object again: the store, not a pointer cached across the AI call,
+    //! is the authority on whether the object is still there.
+    template<class T>
+    static std::vector<ObjectGuid> Snapshot(std::unordered_map<ObjectGuid, T*> const& objectMap)
+    {
+        std::vector<ObjectGuid> guids;
+        guids.reserve(objectMap.size());
+        for (auto const& p : objectMap)
+            guids.push_back(p.first);
+
+        return guids;
+    }
+
+    Map* _map;
     uint16 _eventId;
     bool _activate;
 };
@@ -1905,7 +1940,7 @@ void GameEventMgr::RunSmartAIScripts(uint16 eventId, bool activate)
     //! Not entirely sure how this will affect units in non-loaded grids.
     sMapMgr->DoForAllMaps([eventId, activate](Map* map)
     {
-        GameEventAIHookWorker worker(eventId, activate);
+        GameEventAIHookWorker worker(map, eventId, activate);
         TypeContainerVisitor<GameEventAIHookWorker, MapStoredObjectTypesContainer> visitor(worker);
         visitor.Visit(map->GetObjectsStore());
     });


### PR DESCRIPTION
## Changes Proposed:

`GameEventAIHookWorker::Visit` walks `Map::GetObjectsStore()` with a range-for and calls into creature/gameobject AI while still holding the iterator. A `SMART_EVENT_GAME_EVENT_START` script can erase its own creature from that store, which frees the hash node the loop is standing on; the next read of `__next_` returns garbage and the following dereference faults.

Confirmed chain (game event 89 "Leprithus", entry 572, `SMART_ACTION_RESPAWN_TARGET` on self):

```
GameEventAIHookWorker::Visit -> SmartScript::ProcessEventsFor -> ProcessAction
  -> Creature::Respawn -> Map::AddObjectToRemoveList
  -> Unit::CleanupBeforeRemoveFromMap -> Creature::RemoveFromWorld
  -> _objectsStore.Remove<Creature>()        // node freed
```

`Creature::Respawn()` reaches `AddObjectToRemoveList()` through its non-compatibility-mode branch, whose comment reads *"destroy and let ProcessRespawns() recreate"* — it assumes a safe call point, and `RunSmartAIScripts` calls it in the middle of iterating that very container.

The fix walks a snapshot of the guids and resolves each object through the store again, following the convention in `.agents/docs/cpp-guidelines.md`:

> **Long-lived references**: don't store a raw `Player*` / `Creature*` / `Unit*` past the current call/tick — the object can be removed (logout, despawn, instance unload) and the pointer dangles. Store the `ObjectGuid` and resolve at use time via `ObjectAccessor::FindPlayer(guid)`, `Map::GetCreature(guid)`, etc.

The new loop does not depend on knowing *which* script mutates the store: whatever is erased, the re-lookup returns `nullptr` and the entry is skipped.

Two other events ship the same pattern but effectively never fire (`occurence` ~10 years): event 85 (`Stitches`, 13 creatures) and event 87 (`Scarlet Oracle`, 2 creatures). Fixing the traversal covers those too.

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Claude Opus 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:

No AzerothCore issue. Same crash signature as TrinityCore#26687 (open since 2021), TrinityCore#17587 and TrinityCore#7235. The hypothesis there was a null `AI()` on a gameobject; the logging added in #26687 only ever caught a benign null on a transport (`Orgrim's Hammer`), and the reporter noted the crash happens "2 times in years", so it was never reproduced. The actual fault is iterator invalidation on the creature path.

## SOURCE:

The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources: crash report registers and disassembly from the faulting build, plus an instrumented run — both reproduced below.
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

<details>
<summary>Faulting instruction and registers (arm64, Release build)</summary>

```
exception: EXC_BAD_ACCESS (SIGSEGV)
KERN_INVALID_ADDRESS at 0x67d2c2ce13e9463b

x21 = 0x0000000000000059          ; eventId = 89
x27 = 0x67d2c2ce13e94623          ; hash node pointer, garbage
fault address = x27 + 0x18
```

Disassembly of `GameEventMgr::RunSmartAIScripts` around the fault:

```
<+332>: ldr    x27, [x27]         ; x27 = node->__next_
<+336>: cbz    x27, <+320>
<+340>: ldr    x8,  [x27, #0x18]  ; faults: node->second (Creature*)
<+344>: ldrb   w9,  [x8, #0x5d]   ; IsInWorld() inlined
```

`0x18` is the value offset of a libc++ `__hash_node` whose key is an 8-byte `ObjectGuid`, so `x27` is a node, and the garbage came from the previous node's `__next_` — that node had already been freed.

</details>

<details>
<summary>Instrumented run: the erase, caught in the act</summary>

Temporary probe comparing `size()` / `bucket_count()` around each AI call, plus a backtrace in `Creature::RemoveFromWorld()`:

```
[GEDIAG] creature Leprithus entry 572 mutated creature store during event 89:
         size 11985->11984  buckets 12853->12853
```

Size drops by one with the bucket count unchanged: an erase, not a rehash. `unordered_map::erase` frees the node, which is what leaves the garbage `__next_` above.

```
#01 Creature::RemoveFromWorld()
#02 Unit::CleanupBeforeRemoveFromMap(bool)
#03 Map::AddObjectToRemoveList(WorldObject*)
#04 Creature::Respawn(bool)
#05 SmartScript::ProcessAction(...)
#06 SmartScript::ProcessEventsFor(SMART_EVENT, ...)
#07 GameEventAIHookWorker::Visit(std::unordered_map<ObjectGuid, Creature*>&)
#08 GameEventMgr::RunSmartAIScripts(unsigned short, bool)
```

The probe was removed before this PR; the diff is the fix only.

</details>

## Tests Performed:

This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author.
- [x] This pull request requires further testing and may have edge cases to be tested.

Built and run on a 3.3.5a realm (macOS/arm64, Release, ~100 bots online). The crash reproduced twice before the change — once from the scheduled 20:00 trigger, once from `.event start 89` — and the same trigger survived after it. The AI hook really ran on the fixed build rather than passing vacuously: Leprithus respawned and its `creature_respawn` row was consumed each time.

Edge cases I could not cover: the gameobject `Visit` path takes the same change but I have no reproducer for it, and I did not test a spawn group in `SPAWNGROUP_FLAG_COMPATIBILITY_MODE`, where `Creature::Respawn` takes the other branch and does not erase.

## How to Test the Changes:

Event 89 (`Leprithus`) runs daily at 20:00 for 600 minutes. Entry 572 carries `smart_scripts` id 3: `event_type 68` (`SMART_EVENT_GAME_EVENT_START`, param 89) -> `action_type 70` (`SMART_ACTION_RESPAWN_TARGET`, target self). `Creature::Respawn()` only reaches the erase when the creature is dead, which is why this is rare on a normal realm — Leprithus is a rare spawn in Duskwood on a 20 hour timer, so it is almost always alive when the event fires.

1. Kill Leprithus (Duskwood, entry 572, spawn 134021) and keep the grid loaded
2. `.event start 89`

Before: worldserver dies with `SIGSEGV` in `GameEventMgr::RunSmartAIScripts`.
After: the event applies, Leprithus respawns, the server keeps running.

## Known Issues and TODO List:

- [ ] The `Snapshot()` copy is O(objects) per map per event transition. Measured on the same container sizes: 12 000 objects 28 µs -> 115 µs, 40 000 113 µs -> 391 µs, 150 000 615 µs -> 1806 µs. `RunSmartAIScripts` only runs on event start/stop, and `MinRecordUpdateTimeDiff` defaults to 100 ms, so this stays three orders of magnitude below the threshold at which a slow tick is logged. Still worth a second opinion if someone runs far larger maps.
