### PR TITLE
fix(Scripts/Ulduar): add the missing event after Flame Leviathan's death

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1787487143452855000.sql
+++ b/data/sql/updates/pending_db_world/rev_1787487143452855000.sql
@@ -70,8 +70,11 @@ INSERT INTO `gameobject_summon_groups` (`summonerId`, `summonerType`, `groupId`,
     (603, 2, 0, 194569, -706.122, -92.6024, 429.876, 0, 0, 0, 0, 1, 0, 'Flame Leviathan outro - Expedition Base Camp teleporter'),
     (603, 2, 1, 194481, 235.41939, -138.5261, 409.5674, 0, 0, 0, 0, 1, 0, 'Flame Leviathan outro - Portal to Dalaran');
 
-DELETE FROM `waypoint_data` WHERE `id` = 341190;
+DELETE FROM `waypoint_data` WHERE `id` IN (341190, 336960);
 INSERT INTO `waypoint_data` (`id`, `point`, `position_x`, `position_y`, `position_z`, `orientation`, `delay`, `move_type`) VALUES
+    (336960, 1, 243.5128, -126.59239, 409.80365, NULL, 0, 0),
+    (336960, 2, 242.85948, -123.83485, 409.80365, NULL, 0, 0),
+    (336960, 3, 239.31581, -123.64426, 409.80365, NULL, 0, 0),
     (341190, 1, 246.18864, -80.409645, 409.73053, NULL, 0, 0),
     (341190, 2, 243.60237, -79.01533, 409.76364, NULL, 0, 0),
     (341190, 3, 232.66634, -111.32069, 409.80365, NULL, 0, 0),

--- a/data/sql/updates/pending_db_world/rev_1787487143452855000.sql
+++ b/data/sql/updates/pending_db_world/rev_1787487143452855000.sql
@@ -1,0 +1,89 @@
+--
+DELETE FROM `creature_text` WHERE `CreatureID` = 34119 AND `GroupID` BETWEEN 0 AND 5;
+INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `TextRange`, `comment`) VALUES
+    (34119, 0, 0, 'What a battle! Did you see that, Rhydian?!', 14, 0, 100, 0, 0, 0, 34225, 3, 'Brann Bronzebeard'),
+    (34119, 1, 0, 'Perhaps so, but it''s only a matter of time until we break back into Ulduar. Any luck finding a way to teleport inside?', 14, 0, 100, 0, 0, 0, 34226, 3, 'Brann Bronzebeard'),
+    (34119, 2, 0, 'Oi. So we''ll have to contend with that thing after all then?', 14, 0, 100, 0, 0, 0, 34229, 3, 'Brann Bronzebeard'),
+    (34119, 3, 0, 'What about the plated proto-drake and the fire giant that were spotted nearby? Think your mages can handle those?', 14, 0, 100, 0, 0, 0, 34231, 3, 'Brann Bronzebeard'),
+    (34119, 4, 0, 'Sneak?! What do you think we are, marmots?', 14, 0, 100, 0, 0, 0, 34233, 3, 'Brann Bronzebeard'),
+    (34119, 5, 0, 'Fine. If our allies are going to be the ones getting their hands dirty, we''ll leave it to them to decide how to proceed.', 14, 0, 100, 0, 0, 0, 34235, 3, 'Brann Bronzebeard');
+
+DELETE FROM `creature_text` WHERE `CreatureID` = 33696 AND `GroupID` BETWEEN 2 AND 6;
+INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `TextRange`, `comment`) VALUES
+    (33696, 2, 0, 'Our friends fought well, Brann, but we''re not done yet.', 14, 0, 100, 0, 0, 0, 34227, 3, 'Archmage Rhydian'),
+    (33696, 3, 0, 'None at all. I suspect it has something to do with that giant mechanical construct that our scouts spotted in front of the gate.', 14, 0, 100, 0, 0, 0, 34228, 3, 'Archmage Rhydian'),
+    (33696, 4, 0, 'The Kirin Tor can''t possibly spare any additional resources to take on anything that size. We may not have to though.', 14, 0, 100, 0, 0, 0, 34230, 3, 'Archmage Rhydian'),
+    (33696, 5, 0, 'We can sneak past them. As long as we can take down that construct in front of the gate, we should be able to get inside.', 14, 0, 100, 0, 0, 0, 34232, 3, 'Archmage Rhydian'),
+    (33696, 6, 0, 'We''re hunting an old god, Brann.', 14, 0, 100, 0, 0, 0, 34234, 3, 'Archmage Rhydian');
+
+DELETE FROM `creature_summon_groups` WHERE `summonerId` = 603 AND `summonerType` = 2 AND `groupId` IN (0, 1, 2, 3, 4, 5, 6, 7);
+INSERT INTO `creature_summon_groups` (`summonerId`, `summonerType`, `groupId`, `entry`, `position_x`, `position_y`, `position_z`, `orientation`, `summonType`, `summonTime`, `Comment`) VALUES
+    (603, 2, 0, 34119, 233.9606, -123.4371, 409.6916, 6.152104, 8, 0, 'Flame Leviathan outro - Brann Bronzebeard'),
+    (603, 2, 0, 34144, 214.305, -97.7288, 409.902, 4.69557, 8, 0, 'Flame Leviathan outro - Expedition Mercenary'),
+    (603, 2, 0, 34144, 214.345, -93.4653, 409.902, 4.70543, 8, 0, 'Flame Leviathan outro - Expedition Mercenary'),
+    (603, 2, 0, 34144, 214.357, -88.4769, 409.902, 4.72817, 8, 0, 'Flame Leviathan outro - Expedition Mercenary'),
+    (603, 2, 0, 34144, 244.563, -98.3617, 409.819, 4.68692, 8, 0, 'Flame Leviathan outro - Expedition Mercenary'),
+    (603, 2, 0, 34144, 244.701, -94.1342, 409.819, 4.80294, 8, 0, 'Flame Leviathan outro - Expedition Mercenary'),
+    (603, 2, 0, 34144, 244.495, -89.2472, 409.819, 4.60713, 8, 0, 'Flame Leviathan outro - Expedition Mercenary'),
+    (603, 2, 0, 34145, 256.192, -100.648, 409.817, 4.53754, 8, 0, 'Flame Leviathan outro - Expedition Engineer'),
+    (603, 2, 0, 34145, 256.93, -96.4637, 409.819, 4.75397, 8, 0, 'Flame Leviathan outro - Expedition Engineer'),
+    (603, 2, 0, 34145, 257.797, -91.5382, 409.819, 4.6667, 8, 0, 'Flame Leviathan outro - Expedition Engineer'),
+    (603, 2, 0, 34145, 224.66, -98.4238, 409.902, 4.68688, 8, 0, 'Flame Leviathan outro - Expedition Engineer'),
+    (603, 2, 0, 34145, 224.788, -93.4255, 409.902, 4.92305, 8, 0, 'Flame Leviathan outro - Expedition Engineer'),
+    (603, 2, 0, 34145, 224.916, -88.4271, 409.902, 4.6683, 8, 0, 'Flame Leviathan outro - Expedition Engineer'),
+    (603, 2, 1, 34144, 174.96938, -50.3517, 409.81348, 6.189358, 8, 0, 'Flame Leviathan outro - Expedition Mercenary (march start)'),
+    (603, 2, 1, 34144, 169.75806, -50.084938, 409.8034, 6.21121, 8, 0, 'Flame Leviathan outro - Expedition Mercenary (march start)'),
+    (603, 2, 1, 34144, 165.67856, -49.93559, 409.80365, 6.238564, 8, 0, 'Flame Leviathan outro - Expedition Mercenary (march start)'),
+    (603, 2, 1, 34144, 175.66461, -36.33496, 409.86987, 0.145557, 8, 0, 'Flame Leviathan outro - Expedition Mercenary (march start)'),
+    (603, 2, 1, 34144, 170.46495, -36.359524, 409.80362, 0.073692, 8, 0, 'Flame Leviathan outro - Expedition Mercenary (march start)'),
+    (603, 2, 1, 34144, 166.39493, -36.500145, 409.80362, 0.017686, 8, 0, 'Flame Leviathan outro - Expedition Mercenary (march start)'),
+    (603, 2, 1, 34145, 172.66048, -28.88596, 409.88696, 0.074632, 8, 0, 'Flame Leviathan outro - Expedition Engineer (march start)'),
+    (603, 2, 1, 34145, 167.35666, -28.648111, 409.88696, 0.027685, 8, 0, 'Flame Leviathan outro - Expedition Engineer (march start)'),
+    (603, 2, 1, 34145, 162.81847, -28.781794, 409.88696, 0.010288, 8, 0, 'Flame Leviathan outro - Expedition Engineer (march start)'),
+    (603, 2, 1, 34145, 173.35124, -43.763077, 409.7804, 6.220645, 8, 0, 'Flame Leviathan outro - Expedition Engineer (march start)'),
+    (603, 2, 1, 34145, 169.66489, -43.603226, 409.80365, 6.228433, 8, 0, 'Flame Leviathan outro - Expedition Engineer (march start)'),
+    (603, 2, 1, 34145, 165.013, -43.62926, 409.80362, 6.264964, 8, 0, 'Flame Leviathan outro - Expedition Engineer (march start)'),
+    (603, 2, 2, 33696, 235.96461, -135.27695, 409.68192, 1.152289, 8, 0, 'Flame Leviathan outro - Archmage Rhydian'),
+    (603, 2, 3, 34120, 246.4216, -80.03793, 416.2025, 4.43, 8, 0, 'Flame Leviathan outro - Brann''s Flying Machine'),
+    (603, 2, 4, 34119, 246.18864, -80.409645, 409.73053, 4.3, 8, 0, 'Flame Leviathan outro - Brann Bronzebeard (at the flying machine)'),
+    (603, 2, 5, 33672, 213.43213, -126.89188, 409.66467, 1.413717, 8, 0, 'Flame Leviathan outro - Kirin Tor Mage'),
+    (603, 2, 5, 33672, 217.12311, -127.19917, 409.65933, 1.48353, 8, 0, 'Flame Leviathan outro - Kirin Tor Mage'),
+    (603, 2, 5, 33672, 220.89046, -127.4266, 409.65076, 1.53589, 8, 0, 'Flame Leviathan outro - Kirin Tor Mage'),
+    (603, 2, 5, 33672, 215.50282, -117.47635, 409.6517, 1.413717, 8, 0, 'Flame Leviathan outro - Kirin Tor Mage'),
+    (603, 2, 5, 33672, 219.1938, -117.78364, 409.6517, 1.48353, 8, 0, 'Flame Leviathan outro - Kirin Tor Mage'),
+    (603, 2, 5, 33672, 222.96115, -118.01107, 409.69476, 1.53589, 8, 0, 'Flame Leviathan outro - Kirin Tor Mage'),
+    (603, 2, 5, 33672, 250.41705, -127.29872, 409.887, 1.413717, 8, 0, 'Flame Leviathan outro - Kirin Tor Mage'),
+    (603, 2, 5, 33672, 254.10774, -127.60563, 409.887, 1.48353, 8, 0, 'Flame Leviathan outro - Kirin Tor Mage'),
+    (603, 2, 5, 33672, 257.87512, -127.83306, 409.887, 1.53589, 8, 0, 'Flame Leviathan outro - Kirin Tor Mage'),
+    (603, 2, 5, 33672, 247.926, -117.22721, 409.887, 1.413717, 8, 0, 'Flame Leviathan outro - Kirin Tor Mage'),
+    (603, 2, 5, 33672, 251.61697, -117.53451, 409.887, 1.48353, 8, 0, 'Flame Leviathan outro - Kirin Tor Mage'),
+    (603, 2, 5, 33672, 255.38434, -117.76194, 409.887, 1.53589, 8, 0, 'Flame Leviathan outro - Kirin Tor Mage'),
+    (603, 2, 6, 32780, -705.9705, -92.55729, 430.51917, 0, 8, 0, 'Flame Leviathan outro - Base camp teleporter stalker'),
+    (603, 2, 7, 33662, 240.24995, -136.47862, 409.65237, 3.455752, 8, 0, 'Flame Leviathan outro - Kirin Tor Battle-Mage (channels at the portal)'),
+    (603, 2, 7, 33662, 230.50803, -137.14876, 409.65076, 5.846853, 8, 0, 'Flame Leviathan outro - Kirin Tor Battle-Mage (channels at the portal)'),
+    (603, 2, 7, 33662, 127.4796, -70.88797, 409.88696, 3.176499, 8, 0, 'Flame Leviathan outro - Kirin Tor Battle-Mage (Formation Grounds teleporter)');
+
+DELETE FROM `gameobject` WHERE `guid` = 34283;
+
+DELETE FROM `gameobject_summon_groups` WHERE `summonerId` = 603 AND `summonerType` = 2 AND `groupId` IN (0, 1);
+INSERT INTO `gameobject_summon_groups` (`summonerId`, `summonerType`, `groupId`, `entry`, `position_x`, `position_y`, `position_z`, `orientation`, `rotation0`, `rotation1`, `rotation2`, `rotation3`, `respawnTime`, `Comment`) VALUES
+    (603, 2, 0, 194569, -706.122, -92.6024, 429.876, 0, 0, 0, 0, 1, 0, 'Flame Leviathan outro - Expedition Base Camp teleporter'),
+    (603, 2, 1, 194481, 235.41939, -138.5261, 409.5674, 0, 0, 0, 0, 1, 0, 'Flame Leviathan outro - Portal to Dalaran');
+
+DELETE FROM `waypoint_data` WHERE `id` = 341190;
+INSERT INTO `waypoint_data` (`id`, `point`, `position_x`, `position_y`, `position_z`, `orientation`, `delay`, `move_type`) VALUES
+    (341190, 1, 246.18864, -80.409645, 409.73053, NULL, 0, 0),
+    (341190, 2, 243.60237, -79.01533, 409.76364, NULL, 0, 0),
+    (341190, 3, 232.66634, -111.32069, 409.80365, NULL, 0, 0),
+    (341190, 4, 229.933, -122.90609, 409.5674, NULL, 0, 0),
+    (341190, 5, 233.96056, -123.43707, 409.6916, NULL, 0, 0);
+
+DELETE FROM `creature_template_movement` WHERE `CreatureId` = 34120;
+INSERT INTO `creature_template_movement` (`CreatureId`, `Ground`, `Swim`, `Flight`, `Rooted`, `Chase`, `Random`, `InteractionPauseTimer`) VALUES
+    (34120, 1, 0, 2, 0, 0, 0, NULL);
+
+DELETE FROM `gossip_menu` WHERE `MenuID` = 90002;
+INSERT INTO `gossip_menu` (`MenuID`, `TextID`) VALUES
+    (90002, 14471);
+
+UPDATE `creature_template` SET `gossip_menu_id` = 90002, `npcflag` = `npcflag` | 1 WHERE `entry` = 34119;

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_flame_leviathan.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_flame_leviathan.cpp
@@ -98,10 +98,7 @@ enum GosNpcs
     NPC_LIQUID                          = 33189,
 
     // Starting event
-    NPC_ULDUAR_COLOSSUS                 = 33237,
     NPC_BRANN_RADIO                     = 34054,
-    NPC_ULDUAR_GAUNTLET_GENERATOR       = 33571,
-    NPC_DEFENDER_GENERATED              = 33572,
 
     // Hard Mode
     NPC_THORIM_HAMMER_TARGET            = 33364,

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp
@@ -390,7 +390,14 @@ public:
             }
             _leviathanCrewGUIDs.clear();
 
-            scheduler.Schedule(34s, [this](TaskContext /*context*/)
+            scheduler.Schedule(13s, [this](TaskContext /*context*/)
+            {
+                if (Creature* rhydian = instance->GetCreature(_formationRhydianGUID))
+                {
+                    rhydian->SetHomePosition({ 239.31581f, -123.64426f, 409.80365f, 3.104f });
+                    rhydian->GetMotionMaster()->MovePath(PATH_RHYDIAN_TO_BRANN, FORCED_MOVEMENT_WALK);
+                }
+            }).Schedule(34s, [this](TaskContext /*context*/)
             {
                 std::list<TempSummon*> machine;
                 instance->SummonCreatureGroup(SUMMON_GROUP_LEVIATHAN_OUTRO_MACHINE, &machine);

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp
@@ -20,6 +20,7 @@
 #include "GameTime.h"
 #include "InstanceMapScript.h"
 #include "InstanceScript.h"
+#include "ObjectMgr.h"
 #include "Player.h"
 #include "ScriptedCreature.h"
 #include "Transport.h"
@@ -82,6 +83,22 @@ static uint32 const ObservationRingKeeperBoss[4] =
     BOSS_FREYA, BOSS_HODIR, BOSS_MIMIRON, BOSS_THORIM
 };
 
+// Yelled across the whole map ~59.5s after the kill, replaying when someone approaches the Formation Grounds on later visits
+static struct { bool rhydian; uint8 textGroup; Milliseconds nextDelay; } const BrannRhydianDialogue[] =
+{
+    { false, 0, 8900ms }, // What a battle! Did you see that, Rhydian?!
+    { true,  2, 8500ms }, // Our friends fought well, Brann, but we're not done yet.
+    { false, 1, 8500ms }, // Perhaps so, but it's only a matter of time until we break back into Ulduar...
+    { true,  3, 8500ms }, // None at all. I suspect it has something to do with that giant mechanical construct...
+    { false, 2, 8500ms }, // Oi. So we'll have to contend with that thing after all then?
+    { false, 3, 8500ms }, // What about the plated proto-drake and the fire giant that were spotted nearby?...
+    { true,  4, 8500ms }, // The Kirin Tor can't possibly spare any additional resources...
+    { true,  5, 8500ms }, // We can sneak past them. As long as we can take down that construct...
+    { false, 4, 8500ms }, // Sneak?! What do you think we are, marmots?
+    { true,  6, 8500ms }, // We're hunting an old god, Brann.
+    { false, 5, 0ms    }  // Fine. If our allies are going to be the ones getting their hands dirty...
+};
+
 ObjectData const creatureData[] =
 {
     { NPC_LEVIATHAN,    BOSS_LEVIATHAN  },
@@ -123,6 +140,8 @@ ObjectData const creatureData[] =
     // Algalon helpers
     { NPC_BRANN_BRONZBEARD_ALG,     DATA_BRANN_BRONZEBEARD_ALG  },
     { NPC_BRANN_BASE_CAMP,          DATA_BRANN_BASE_CAMP        },
+    // Flame Leviathan outro
+    { NPC_BRANN_FORMATION_GROUNDS,  DATA_BRANN_FORMATION_GROUNDS },
     { 0,                0               }
 };
 
@@ -206,6 +225,12 @@ public:
         ObjectGuid _repairSGUID[2];
         bool _leviathanTowers[4];
         GuidList _leviathanVehicles;
+        GuidUnorderedSet _leviathanGauntletGUIDs;
+        GuidUnorderedSet _leviathanBeaconGUIDs;
+        GuidList _leviathanCrewGUIDs;
+        bool _leviathanOutroSpawned;
+        bool _leviathanSequenceStarted;
+        ObjectGuid _formationRhydianGUID;
 
         // Hodir
         bool _hmHodir;
@@ -225,6 +250,12 @@ public:
                 _leviathanTowers[i] = true;
 
             _leviathanVehicles.clear();
+            _leviathanGauntletGUIDs.clear();
+            _leviathanBeaconGUIDs.clear();
+            _leviathanCrewGUIDs.clear();
+            _leviathanOutroSpawned = false;
+            _leviathanSequenceStarted = false;
+            _formationRhydianGUID.Clear();
 
             // Hodir
             _hmHodir = true; // If players fail the Hardmode then becomes false
@@ -248,8 +279,172 @@ public:
                 std::min<uint32>(algalonTimer, 60));
         }
 
+        void DespawnLeviathanGauntlet()
+        {
+            for (ObjectGuid const& guid : _leviathanGauntletGUIDs)
+                if (Creature* creature = instance->GetCreature(guid))
+                    creature->DespawnOrUnsummon(0ms, 7_days);
+            _leviathanGauntletGUIDs.clear();
+
+            for (ObjectGuid const& guid : _leviathanBeaconGUIDs)
+                if (GameObject* beacon = instance->GetGameObject(guid))
+                    beacon->SetDestructibleState(GO_DESTRUCTIBLE_DESTROYED, nullptr, true);
+            _leviathanBeaconGUIDs.clear();
+        }
+
+        void SpawnLeviathanOutro(bool justKilled)
+        {
+            if (_leviathanOutroSpawned)
+                return;
+
+            _leviathanOutroSpawned = true;
+
+            std::list<TempSummon*> summons;
+            instance->SummonCreatureGroup(SUMMON_GROUP_LEVIATHAN_OUTRO_RHYDIAN, &summons);
+            if (!summons.empty())
+                _formationRhydianGUID = summons.front()->GetGUID();
+
+            summons.clear();
+            instance->SummonCreatureGroup(SUMMON_GROUP_LEVIATHAN_OUTRO_MAGES, &summons);
+            if (justKilled)
+                for (TempSummon* mage : summons)
+                    mage->CastSpell(mage, SPELL_SIMPLE_TELEPORT_VISUAL, true);
+
+            summons.clear();
+            instance->SummonCreatureGroup(SUMMON_GROUP_LEVIATHAN_OUTRO_BATTLE_MAGES, &summons);
+            for (TempSummon* battleMage : summons)
+            {
+                if (justKilled)
+                    battleMage->CastSpell(battleMage, SPELL_SIMPLE_TELEPORT_VISUAL, true);
+                // The two by the portal sustain it; the one at the Formation Grounds teleporter does not
+                if (battleMage->GetPositionX() > 200.0f)
+                    battleMage->CastSpell(battleMage, SPELL_ARCANE_CHANNELING, false);
+            }
+
+            instance->SummonGameObjectGroup(GO_SUMMON_GROUP_LEVIATHAN_PORTAL);
+
+            // The crew stands by the Leviathan gate until the sequence sends it into formation
+            summons.clear();
+            instance->SummonCreatureGroup(SUMMON_GROUP_LEVIATHAN_OUTRO_MARCH, &summons);
+            for (TempSummon* crew : summons)
+                _leviathanCrewGUIDs.push_back(crew->GetGUID());
+
+            if (justKilled)
+            {
+                StartLeviathanOutroSequence();
+                scheduler.Schedule(61s, [this](TaskContext /*context*/)
+                {
+                    instance->SummonCreatureGroup(SUMMON_GROUP_LEVIATHAN_OUTRO_STALKER);
+                    instance->SummonGameObjectGroup(GO_SUMMON_GROUP_LEVIATHAN_TELEPORTER);
+                });
+                return;
+            }
+
+            instance->SummonCreatureGroup(SUMMON_GROUP_LEVIATHAN_OUTRO_STALKER);
+            instance->SummonGameObjectGroup(GO_SUMMON_GROUP_LEVIATHAN_TELEPORTER);
+
+            // On later visits the landing, march and dialogue replay once someone approaches the Formation Grounds
+            scheduler.Schedule(2s, [this](TaskContext context)
+            {
+                if (_leviathanSequenceStarted)
+                    return;
+
+                bool triggered = false;
+                instance->DoForAllPlayers([&](Player* player)
+                {
+                    if (player->IsAlive() && player->GetExactDist2d(234.0f, -100.0f) < 150.0f)
+                        triggered = true;
+                });
+
+                if (triggered)
+                    StartLeviathanOutroSequence();
+                else
+                    context.Repeat(2s);
+            });
+        }
+
+        void StartLeviathanOutroSequence()
+        {
+            if (_leviathanSequenceStarted)
+                return;
+
+            _leviathanSequenceStarted = true;
+
+            // The crew runs into its formation slots, paired by group row order
+            if (std::vector<TempSummonData> const* formation = sObjectMgr->GetSummonGroup(MAP_ULDUAR, SUMMONER_TYPE_MAP, SUMMON_GROUP_LEVIATHAN_OUTRO))
+            {
+                auto slot = formation->begin();
+                for (ObjectGuid const& guid : _leviathanCrewGUIDs)
+                {
+                    Creature* crew = instance->GetCreature(guid);
+                    if (!crew)
+                        continue;
+                    while (slot != formation->end() && slot->entry != crew->GetEntry())
+                        ++slot;
+                    if (slot == formation->end())
+                        break;
+                    crew->SetHomePosition(slot->pos);
+                    crew->GetMotionMaster()->MovePoint(0, slot->pos, FORCED_MOVEMENT_RUN);
+                    ++slot;
+                }
+            }
+            _leviathanCrewGUIDs.clear();
+
+            scheduler.Schedule(34s, [this](TaskContext /*context*/)
+            {
+                std::list<TempSummon*> machine;
+                instance->SummonCreatureGroup(SUMMON_GROUP_LEVIATHAN_OUTRO_MACHINE, &machine);
+                if (!machine.empty())
+                {
+                    Creature* flyingMachine = machine.front();
+                    flyingMachine->SetCanFly(true);
+                    float const groundZ = flyingMachine->GetMapHeight(flyingMachine->GetPositionX(), flyingMachine->GetPositionY(), flyingMachine->GetPositionZ());
+                    flyingMachine->GetMotionMaster()->MoveLand(0, { flyingMachine->GetPositionX(), flyingMachine->GetPositionY(), groundZ });
+                }
+            }).Schedule(39s, [this](TaskContext /*context*/)
+            {
+                std::list<TempSummon*> brann;
+                instance->SummonCreatureGroup(SUMMON_GROUP_LEVIATHAN_OUTRO_BRANN, &brann);
+                if (brann.empty())
+                    return;
+
+                if (std::vector<TempSummonData> const* formation = sObjectMgr->GetSummonGroup(MAP_ULDUAR, SUMMONER_TYPE_MAP, SUMMON_GROUP_LEVIATHAN_OUTRO))
+                    for (TempSummonData const& slot : *formation)
+                        if (slot.entry == NPC_BRANN_FORMATION_GROUNDS)
+                        {
+                            brann.front()->SetHomePosition(slot.pos);
+                            break;
+                        }
+
+                brann.front()->GetMotionMaster()->MovePath(PATH_BRANN_FORMATION_GROUNDS, FORCED_MOVEMENT_WALK);
+            }).Schedule(59500ms, [this](TaskContext /*context*/)
+            {
+                PlayBrannRhydianLine(0);
+            });
+        }
+
+        void PlayBrannRhydianLine(uint8 index)
+        {
+            auto const& line = BrannRhydianDialogue[index];
+            Creature* speaker = line.rhydian
+                ? instance->GetCreature(_formationRhydianGUID)
+                : GetCreature(DATA_BRANN_FORMATION_GROUNDS);
+            if (speaker)
+                speaker->AI()->Talk(line.textGroup);
+
+            uint8 const next = static_cast<uint8>(index + 1);
+            if (next < static_cast<uint8>(sizeof(BrannRhydianDialogue) / sizeof(BrannRhydianDialogue[0])))
+                scheduler.Schedule(line.nextDelay, [this, next](TaskContext /*context*/)
+                {
+                    PlayBrannRhydianLine(next);
+                });
+        }
+
         void OnPlayerEnter(Player* player) override
         {
+            if (IsBossDone(BOSS_LEVIATHAN))
+                SpawnLeviathanOutro(false);
+
             // mimiron tram:
             if (GameObject* MimironTram = GetGameObject(DATA_MIMIRON_TRAM))
             {
@@ -355,6 +550,9 @@ public:
 
                         if (GameObject* go = GetGameObject(DATA_LEVIATHAN_DOORS))
                             go->SetGoState(GO_STATE_ACTIVE_ALTERNATIVE);
+
+                        DespawnLeviathanGauntlet();
+                        SpawnLeviathanOutro(true);
                     }
                     break;
                 case BOSS_MIMIRON:
@@ -430,6 +628,29 @@ public:
                     if (!GetPersistentData(PERSISTENT_DATA_ALGALON_TIMER))
                         creature->DespawnOrUnsummon();
                     break;
+                // Gone for good once Flame Leviathan is defeated
+                case NPC_STEELFORGED_DEFENDER:
+                case NPC_DEFENDER_GENERATED:
+                case NPC_ULDUAR_GAUNTLET_GENERATOR:
+                case NPC_IRONWORK_CANNON:
+                    if (IsBossDone(BOSS_LEVIATHAN))
+                        creature->DespawnOrUnsummon(0ms, 7_days);
+                    else
+                        _leviathanGauntletGUIDs.insert(creature->GetGUID());
+                    break;
+                case NPC_ULDUAR_COLOSSUS:
+                case NPC_RUNEFORGED_SENTRY:
+                {
+                    // Waypoint patrols survive the kill (sniffed); only the static spawns are cleared
+                    CreatureData const* data = creature->GetCreatureData();
+                    if (data && data->movementType == WAYPOINT_MOTION_TYPE)
+                        break;
+                    if (IsBossDone(BOSS_LEVIATHAN))
+                        creature->DespawnOrUnsummon(0ms, 7_days);
+                    else
+                        _leviathanGauntletGUIDs.insert(creature->GetGUID());
+                    break;
+                }
                 //! These creatures are summoned by something else than Algalon
                 //! but need to be controlled/despawned by him - so they need to be
                 //! registered in his summon list
@@ -466,6 +687,24 @@ public:
         void OnGameObjectCreate(GameObject* gameObject) override
         {
             InstanceScript::OnGameObjectCreate(gameObject);
+
+            if ((gameObject->GetEntry() >= GO_STORM_BEACON_FIRST && gameObject->GetEntry() <= GO_STORM_BEACON_LAST)
+                || gameObject->GetEntry() == GO_STORM_BEACON_FORMATION_GROUNDS)
+            {
+                if (IsBossDone(BOSS_LEVIATHAN))
+                {
+                    // Deferred: this hook runs before the object is in world, where SetDestructibleState
+                    // cannot swap the collision model and AddToWorld would re-enable collision
+                    scheduler.Schedule(1ms, [this, guid = gameObject->GetGUID()](TaskContext /*context*/)
+                    {
+                        if (GameObject* beacon = instance->GetGameObject(guid))
+                            beacon->SetDestructibleState(GO_DESTRUCTIBLE_DESTROYED, nullptr, true);
+                    });
+                }
+                else
+                    _leviathanBeaconGUIDs.insert(gameObject->GetGUID());
+                return;
+            }
 
             switch (gameObject->GetEntry())
             {

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/ulduar.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/ulduar.cpp
@@ -77,7 +77,6 @@ enum UldGameObjects
 
 enum UldSpells
 {
-    SPELL_SIMPLE_TELEPORT       = 12980,
     SPELL_KEEPER_TELEPORT       = 62940,
     SPELL_SNOW_MOUND_PARTICLES  = 64615,
     SPELL_ENERGY_SAP_10         = 64740,
@@ -100,7 +99,7 @@ public:
         {
             scheduler.Schedule(250ms, [this](TaskContext /*context*/)
             {
-                DoCastSelf(SPELL_SIMPLE_TELEPORT);
+                DoCastSelf(SPELL_SIMPLE_TELEPORT_VISUAL);
             });
         }
 

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/ulduar.h
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/ulduar.h
@@ -152,6 +152,9 @@ enum UlduarData
     DATA_HODIR_GOSSIP                       = 811,
     DATA_MIMIRON_GOSSIP                     = 812,
     DATA_THORIM_GOSSIP                      = 813,
+
+    // Flame Leviathan outro
+    DATA_BRANN_FORMATION_GROUNDS            = 814,
 };
 
 enum UlduarNPCs
@@ -222,6 +225,17 @@ enum UlduarNPCs
     NPC_SALVAGED_DEMOLISHER                 = 33109,
     NPC_SALVAGED_DEMOLISHER_TURRET          = 33167,
     NPC_BRANN_BASE_CAMP                     = 33579,
+    NPC_STEELFORGED_DEFENDER                = 33236,
+    NPC_ULDUAR_COLOSSUS                     = 33237,
+    NPC_IRONWORK_CANNON                     = 33264,
+    NPC_ULDUAR_GAUNTLET_GENERATOR           = 33571,
+    NPC_DEFENDER_GENERATED                  = 33572,
+    NPC_ARCHMAGE_RHYDIAN                    = 33696,
+    NPC_RUNEFORGED_SENTRY                   = 34234,
+    NPC_BRANN_FORMATION_GROUNDS             = 34119,
+    NPC_BRANN_S_FLYING_MACHINE              = 34120,
+    NPC_EXPEDITION_MERCENARY                = 34144,
+    NPC_EXPEDITION_ENGINEER_FORMATION       = 34145,
 
     // Algalon the Observer
     NPC_BRANN_BRONZBEARD_ALG                = 34064,
@@ -268,7 +282,9 @@ enum UlduarGameObjects
     GO_FREYAS_GENERATOR                     = 194663,
     GO_HODIRS_GENERATOR                     = 194665,
     GO_THORIMS_GENERATOR                    = 194666,
-    GO_STORM_BEACON                         = 194414,
+    GO_STORM_BEACON_FIRST                   = 194398,
+    GO_STORM_BEACON_LAST                    = 194415,
+    GO_STORM_BEACON_FORMATION_GROUNDS       = 194506,
 
     // Middle
     GO_ARCHIVUM_DOORS                       = 194556,
@@ -348,6 +364,29 @@ enum UlduarMisc
     VEHICLE_POS_START                       = 0,
     VEHICLE_POS_LEVIATHAN                   = 1,
     VEHICLE_POS_NONE                        = 2,
+
+    // creature_summon_groups entries for the post-Leviathan outro
+    SUMMON_GROUP_LEVIATHAN_OUTRO            = 0, // Brann + crew in formation (reload; also the march destinations)
+    SUMMON_GROUP_LEVIATHAN_OUTRO_MARCH      = 1, // crew at the gate, runs into formation (kill)
+    SUMMON_GROUP_LEVIATHAN_OUTRO_RHYDIAN    = 2,
+    SUMMON_GROUP_LEVIATHAN_OUTRO_MACHINE    = 3, // Brann's Flying Machine, airborne (kill)
+    SUMMON_GROUP_LEVIATHAN_OUTRO_BRANN      = 4, // Brann at the landed machine (kill)
+    SUMMON_GROUP_LEVIATHAN_OUTRO_MAGES      = 5, // 12 Kirin Tor Mages flanking Brann's spot
+    SUMMON_GROUP_LEVIATHAN_OUTRO_STALKER    = 6, // base camp teleporter visual stalker
+    SUMMON_GROUP_LEVIATHAN_OUTRO_BATTLE_MAGES = 7, // 2 sustaining the portal + 1 at the Formation Grounds teleporter
+
+    // gameobject_summon_groups: base camp Ulduar Teleporter (~61s after the kill) and the Dalaran portal
+    GO_SUMMON_GROUP_LEVIATHAN_TELEPORTER    = 0,
+    GO_SUMMON_GROUP_LEVIATHAN_PORTAL        = 1,
+
+    // waypoint_data path: Brann's walk from the machine to his formation spot
+    PATH_BRANN_FORMATION_GROUNDS            = 341190,
+
+    // Gossip Keepers, Kirin Tor Mages: teleport-in flash
+    SPELL_SIMPLE_TELEPORT_VISUAL            = 12980,
+
+    // Kirin Tor Battle-Mages sustaining the Dalaran portal
+    SPELL_ARCANE_CHANNELING                 = 39550,
 
     EVENT_TOWER_OF_STORM_DESTROYED          = 21031,
     EVENT_TOWER_OF_FROST_DESTROYED          = 21032,

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/ulduar.h
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/ulduar.h
@@ -379,8 +379,9 @@ enum UlduarMisc
     GO_SUMMON_GROUP_LEVIATHAN_TELEPORTER    = 0,
     GO_SUMMON_GROUP_LEVIATHAN_PORTAL        = 1,
 
-    // waypoint_data path: Brann's walk from the machine to his formation spot
+    // waypoint_data paths: Brann's walk from the machine to his spot, Rhydian's walk to Brann's side
     PATH_BRANN_FORMATION_GROUNDS            = 341190,
+    PATH_RHYDIAN_TO_BRANN                   = 336960,
 
     // Gossip Keepers, Kirin Tor Mages: teleport-in flash
     SPELL_SIMPLE_TELEPORT_VISUAL            = 12980,


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Implements the event that should play after Flame Leviathan's death, currently missing entirely:

- The Iron Concourse gauntlet despawns for the rest of the raid ID: Steelforged Defenders (33236/33572), Ulduar Colossi (33237), Gauntlet Generators (33571), Runeforged Sentries (34234) and Ironwork Cannons (33264).
- The 19 Storm Beacons (194398-194415, 194506) collapse into their destroyed destructible state.
- The base camp intro Brann (33579) and Archmage Rhydian (33696) leave.
- Brann (34119) sets up at the Formation Grounds with 6 Expedition Mercenaries and 6 Expedition Engineers, spawned through a new `creature_summon_groups` entry. He offers his gossip text and holds an 11 line yelled dialogue with Rhydian that starts roughly 80 seconds after the first player enters and replays on every raid visit, as it does on retail.
- All of it is restored on instance reload through the create hooks, so the state survives relogs and server restarts within the lockout.

The dialogue lines map to `broadcast_text` 34225-34235 (Rhydian's five live in the FemaleText column), so the texts are authentic wotlk data. Brann's gossip uses the existing `npc_text` 14471. The crew spawn coordinates match TDB 3.3.5 rows to the decimal, independently confirming the sniffed positions.

Where the evidence forced a decision:
- The four hard mode towers stay standing. The issue asks for them to be destroyed, but every sniffed post-kill instance shows all four intact at full health. Whether they get destroyed at the kill moment itself needs a capture of an actual kill, which we don't have yet.
- Brann's Flying Machine (34120) and its flight in aren't implemented, no capture contains its path.
- Rhydian's position during the dialogue was never captured. He's placed next to Brann and leaves when the dialogue ends, since he's absent from every post-dialogue capture.

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Fable 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Refs https://github.com/azerothcore/azerothcore-wotlk/issues/27230 (left open on purpose: point 2, the tower destruction, contradicts the sniffed post-kill state, see above)

## SOURCE:
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [x] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Builds clean (MSVC worldserver), both codestyle linters pass. A fresh-context self-review ran over the changeset, results posted as a comment below.

## How to Test the Changes:
- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Kill Flame Leviathan. The gauntlet despawns, the beacons collapse and Brann's crew appears at the Formation Grounds, with the dialogue starting shortly after.
2. Leave the instance, let the map unload and re-enter. The state persists (the beacon stumps must not block spells or pet pathing) and the dialogue replays about 80 seconds in.
3. In a fresh instance, before the kill, ride the concourse and check the gauntlet, beacons and vehicle event behave as before.

## Known Issues and TODO List:

- [ ] Confirm with a kill-moment capture whether the four towers get destroyed at the kill (post-kill captures show them intact).
- [ ] Brann's Flying Machine flight in, once a capture provides its path.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
