### PR TITLE
feat(Core/AI): add the UnitAI::OnDespawn hook

### DIFF
--- a/src/server/game/AI/CoreAI/UnitAI.h
+++ b/src/server/game/AI/CoreAI/UnitAI.h
@@ -356,6 +356,11 @@ public:
     virtual void JustExitedCombat() { }
 
     /**
+     * @brief Called when the unit is about to be removed from the world (despawn, grid unload, corpse disappearing, player logging out etc.)
+     */
+    virtual void OnDespawn() { }
+
+    /**
      * @brief Called when evade timer expires (target unreachable for too long)
      */
     virtual void EvadeTimerExpired();

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -12561,6 +12561,9 @@ void Unit::RemoveFromWorld()
     if (IsInWorld())
     {
         m_duringRemoveFromWorld = true;
+        if (IsAIEnabled)
+            GetAI()->OnDespawn();
+
         if (IsVehicle())
             RemoveVehicleKit();
 


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Ports TrinityCore's `UnitAI::OnDespawn` hook. It fires at the top of `Unit::RemoveFromWorld()`, so an AI can react when its unit is about to be removed from the world for any reason: despawn, grid unload, corpse removal, logout. None of the existing hooks cover a silent despawn, `JustDied` only fires on death and `SummonedCreatureDespawn` needs a summoner with an AI, which a player summoner doesn't have.

The port matches the upstream original (same call site, same `IsAIEnabled` guard, same comment), using the current upstream name. It was originally added as `LeavingWorld` in https://github.com/TrinityCore/TrinityCore/commit/2642fb1a48ac0a3154b74f65783b1794a2f7a1c0 and renamed to `OnDespawn` in https://github.com/TrinityCore/TrinityCore/commit/b0164fb2b9cf5b30af536e5c1263c2ba9498da8c. Committed with `--author` crediting the original author.

The default is empty, so this PR alone changes no behavior. First user is the Strengthened Iron Roots fix (follow-up PR).

### AI-assisted Pull Requests

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Fable 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- None directly, prerequisite for the fix for #27281.

## SOURCE:
The changes have been validated through:
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.

## How to Test the Changes:

The hook has no users yet, so there's nothing specific to test here. Covered by the follow-up PR's steps. Since the call is in the removal path of every unit, a general smoke test helps: creatures despawning, corpses decaying, players logging out.

## Known Issues and TODO List:

- [ ] TrinityCore also drives SmartAI's despawn event through this hook, not ported here.
