### PR TITLE
fix(Scripts/Ulduar): despawn Freya's Strengthened Iron Roots on wipe and defeat

### DIFF
--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_freya.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_freya.cpp
@@ -997,6 +997,19 @@ struct boss_freya_iron_root : public NullCreatureAI
 
     void JustDied(Unit* /*killer*/) override
     {
+        ReleaseRootedPlayer();
+    }
+
+    // The root aura is infinite and self-cast by the victim, so nothing engine-side
+    // removes it; a root despawned without being killed must free its victim too
+    void OnDespawn() override
+    {
+        ReleaseRootedPlayer();
+    }
+
+private:
+    void ReleaseRootedPlayer()
+    {
         if (!me->IsSummon())
             return;
 

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp
@@ -168,8 +168,9 @@ ObjectData const gameobjectData[] =
 
 ObjectData const summonData[] =
 {
-    { NPC_SARONITE_ANIMUS,  BOSS_VEZAX }, // summoned by a Saronite Vapor, not Vezax
-    { 0,                    0          }
+    { NPC_SARONITE_ANIMUS,          BOSS_VEZAX }, // summoned by a Saronite Vapor, not Vezax
+    { NPC_STRENGTHENED_IRON_ROOTS,  BOSS_FREYA }, // summoned by the rooted player, not Freya
+    { 0,                            0          }
 };
 
 BossBoundaryData const boundaries =

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/ulduar.h
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/ulduar.h
@@ -173,6 +173,7 @@ enum UlduarNPCs
     NPC_HODIR                               = 32845,
     NPC_THORIM                              = 32865,
     NPC_FREYA                               = 32906,
+    NPC_STRENGTHENED_IRON_ROOTS             = 33168,
     NPC_VEZAX                               = 33271,
     NPC_SARONITE_ANIMUS                     = 33524,
     NPC_SARA                                = 33134,


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Depends on #27285, the root AI overrides the hook added there, so this branch won't compile (CI stays red) until that one merges.

Freya's Strengthened Iron Roots are summoned by the rooted player, not by Freya (her spell force-casts the roots spell on the target, and that one summons the NPC), so they never entered her summon list. They survived wipes and her defeat and sat in the Conservatory until the instance reset.

Two parts:

- The roots are registered in the instance's summon data, which routes them into Freya's `JustSummoned`. Her existing `summons.DespawnAll()` on reset and on defeat now cleans them up, the same mechanism the Saronite Animus already uses for Vezax.
- The roots aura has no duration and is self-cast by the victim, so nothing engine-side removes it when the root goes away without dying. The root AI now frees its victim from `OnDespawn` as well, previously only `JustDied` did. Without this, killing Freya while someone is still rooted would leave that player permanently rooted with the damage still ticking.

Elder Ironbranch's weaker roots during the elder trash fight are left alone, that AI has no summon tracking and the report is about Freya's.

### AI-assisted Pull Requests

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Fable 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #27281

## SOURCE:
The changes have been validated through:
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)

Spell data: Freya's Iron Roots (62862) force-casts 62861 on each target, which applies the self-cast root and periodic damage with no duration and summons the root NPC. That's why the victim has to be freed explicitly when the root despawns.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.

## How to Test the Changes:

1. Leave Elder Ironbranch alive and engage Freya for hard mode (Strengthened Iron Roots gets cast periodically, 3 targets on 25man).
2. Get rooted, then wipe: the root NPC despawns with the rest of her summons and the encounter resets clean.
3. Get rooted, then defeat Freya: the root despawns and the rooted player is freed, no leftover root aura or damage ticks.
4. Regression: kill a root normally mid-fight, its victim is freed as before.

## Known Issues and TODO List:

- [ ] Elder Ironbranch's own Iron Roots (the weaker trash version) can still linger if the raid wipes on the elder fight, out of scope here.
