### PR TITLE
fix(Scripts/SSC): restore Hydross cleansing field

### DIFF
--- a/src/server/game/Spells/SpellInfoCorrections.cpp
+++ b/src/server/game/Spells/SpellInfoCorrections.cpp
@@ -63,6 +63,12 @@ void SpellMgr::LoadSpellInfoCorrections()
         spellInfo->AuraInterruptFlags &= ~AURA_INTERRUPT_FLAG_SPELL_ATTACK;
     });
 
+    // Cleansing Field
+    ApplySpellFix({ 37934 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_0].RadiusEntry = sSpellRadiusStore.LookupEntry(EFFECT_RADIUS_25_YARDS);
+    });
+
     // Has Brewfest Mug
     ApplySpellFix({ 42533 }, [](SpellInfo* spellInfo)
     {

--- a/src/server/scripts/Outland/CoilfangReservoir/SerpentShrine/boss_hydross_the_unstable.cpp
+++ b/src/server/scripts/Outland/CoilfangReservoir/SerpentShrine/boss_hydross_the_unstable.cpp
@@ -74,6 +74,8 @@ enum Misc
     GROUP_ABILITIES                 = 1,
     GROUP_OOC_PURIFY_ELEMENTALS     = 2,
 
+    CLEANSING_FIELD_RADIUS_MOD      = 11500,
+
     NPC_PURIFIED_WATER_ELEMENTAL    = 21260,
     NPC_PURE_SPAWN_OF_HYDROSS       = 22035,
     NPC_TAINTED_HYDROSS_ELEMENTAL   = 21253
@@ -292,14 +294,17 @@ class spell_hydross_cleansing_field_aura : public AuraScript
     {
         if (GetTarget()->GetEntry() == NPC_HYDROSS_THE_UNSTABLE)
             if (Unit* caster = GetCaster())
-                caster->CastSpell(caster, SPELL_CLEANSING_FIELD, true);
+                // Include the beam helpers' 3-yard combat reach in the 20-yard DBC radius.
+                caster->CastCustomSpell(SPELL_CLEANSING_FIELD, SPELLVALUE_RADIUS_MOD,
+                    CLEANSING_FIELD_RADIUS_MOD, caster, true);
     }
 
     void HandleEffectRemove(AuraEffect const*  /*aurEff*/, AuraEffectHandleModes /*mode*/)
     {
         if (GetTarget()->GetEntry() == NPC_HYDROSS_THE_UNSTABLE)
             if (Unit* caster = GetCaster())
-                caster->CastSpell(caster, SPELL_CLEANSING_FIELD, true);
+                caster->CastCustomSpell(SPELL_CLEANSING_FIELD, SPELLVALUE_RADIUS_MOD,
+                    CLEANSING_FIELD_RADIUS_MOD, caster, true);
     }
 
     void Register() override

--- a/src/server/scripts/Outland/CoilfangReservoir/SerpentShrine/boss_hydross_the_unstable.cpp
+++ b/src/server/scripts/Outland/CoilfangReservoir/SerpentShrine/boss_hydross_the_unstable.cpp
@@ -74,8 +74,6 @@ enum Misc
     GROUP_ABILITIES                 = 1,
     GROUP_OOC_PURIFY_ELEMENTALS     = 2,
 
-    CLEANSING_FIELD_RADIUS_MOD      = 11500,
-
     NPC_PURIFIED_WATER_ELEMENTAL    = 21260,
     NPC_PURE_SPAWN_OF_HYDROSS       = 22035,
     NPC_TAINTED_HYDROSS_ELEMENTAL   = 21253
@@ -294,17 +292,14 @@ class spell_hydross_cleansing_field_aura : public AuraScript
     {
         if (GetTarget()->GetEntry() == NPC_HYDROSS_THE_UNSTABLE)
             if (Unit* caster = GetCaster())
-                // Include the beam helpers' 3-yard combat reach in the 20-yard DBC radius.
-                caster->CastCustomSpell(SPELL_CLEANSING_FIELD, SPELLVALUE_RADIUS_MOD,
-                    CLEANSING_FIELD_RADIUS_MOD, caster, true);
+                caster->CastSpell(caster, SPELL_CLEANSING_FIELD, true);
     }
 
     void HandleEffectRemove(AuraEffect const*  /*aurEff*/, AuraEffectHandleModes /*mode*/)
     {
         if (GetTarget()->GetEntry() == NPC_HYDROSS_THE_UNSTABLE)
             if (Unit* caster = GetCaster())
-                caster->CastCustomSpell(SPELL_CLEANSING_FIELD, SPELLVALUE_RADIUS_MOD,
-                    CLEANSING_FIELD_RADIUS_MOD, caster, true);
+                caster->CastSpell(caster, SPELL_CLEANSING_FIELD, true);
     }
 
     void Register() override


### PR DESCRIPTION
## Changes Proposed:

Restore Hydross's Cleansing Field by setting spell `37934` to a 25-yard radius in `SpellInfoCorrections`.

PR #26967 changed source-, destination-, and target-referenced area searches to use center-to-center distance. The two Hydross Beam Helpers are 22.1 and 21.0 yards from the field trigger, so the original 20-yard radius no longer reaches them after their 3-yard combat reach stopped extending the search. Without those helpers, the blue beam is not restored and Hydross switches immediately to nature form.

This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools were used entirely or partially to prepare this pull request.
  - Tools/models used: Codex, GPT-5
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:

- Closes #27118

## SOURCE:

The changes have been validated through:
- [ ] Live research (checked on live servers, e.g. Classic WotLK, Retail, etc.)
- [ ] Sniffs
- [x] Video evidence, knowledge databases, or other public sources
- [ ] The changes come partially or entirely from another project

The linked issue contains footage demonstrating both crossings of the arena boundary.

## Tests Performed:

- [x] The original radius correction was tested in-game by the author.
- [ ] Tested in-game by another community member.
- [x] The final `SpellInfoCorrections` implementation requires an in-game retest.

Static verification:
- `git diff --check`
- AzerothCore C++ codestyle linter
- AzerothCore SQL codestyle linter

No local build was performed.

## How to Test the Changes:

1. Enter Serpentshrine Cavern in 25-player mode.
2. Teleport near Hydross with `.go xyz -219.17448 -301.5581 -3.6818278 548`.
3. Confirm the blue cleansing beams are visible and engage Hydross at his initial position.
4. Confirm he starts and remains in frost form inside the cleansing field.
5. Pull him beyond the purple boundary and confirm he changes to nature form once.
6. Move him back inside and confirm he returns to frost form.
7. Evade and re-engage him, confirming that the beams and initial frost form reset correctly.

## Known Issues and TODO List:

- [ ] Audit other entry-filtered area spells affected by #26967 separately, including spell `71189`.

## How to Test AzerothCore PRs

Testing instructions: http://www.azerothcore.org/wiki/How-to-test-a-PR
