### PR TITLE
fix(DB/Creature): move Salvaged Chopper First Aid to action bar slot 6

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1787881140119275500.sql
+++ b/data/sql/updates/pending_db_world/rev_1787881140119275500.sql
@@ -1,0 +1,8 @@
+-- Ulduar: Salvaged Chopper action bar layout, sniff-verified.
+-- Grab Pyrite (67372) sits at position 4, position 5 is empty, First Aid (64660) at position 6.
+DELETE FROM `creature_template_spell` WHERE `CreatureID` IN (33062, 34045) AND `Index` IN (3, 4, 5);
+INSERT INTO `creature_template_spell` (`CreatureID`, `Index`, `Spell`, `VerifiedBuild`) VALUES
+(33062, 3, 67372, 69497),
+(33062, 5, 64660, 69497),
+(34045, 3, 67372, 69497),
+(34045, 5, 64660, 69497);


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Reorders the Salvaged Chopper (33062 and its 25man counterpart 34045) vehicle action bar so it matches sniffed data: Grab Pyrite moves to slot 4, slot 5 stays empty and First Aid sits at slot 6.

When Grab Pyrite was added to the chopper it was appended at slot 5, leaving First Aid at slot 4. Sniffs of the encounter encode the real bar position of each button, and all of them show Grab Pyrite at 4, a gap at 5 and First Aid at 6. The gap is intentional and works fine, `creature_template_spell` indexes map 1:1 to bar slots and the core handles sparse indexes (TC has the same kind of gap on the Salvaged Demolisher Mechanic Seat).

Worth noting for reviewers: TC's data has First Aid at index 3, but that comes from the legacy parser storing vehicle spells by packet array position while the packet itself is compacted, so the gap was lost. The video linked in the issue (WotLK era) also shows First Aid on slot 6.

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/27311

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [x] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. `.tele ulduar`
2. Enter a Salvaged Chopper.
3. The bar should be: Sonic Horn, Tar, Speed Boost, Grab Pyrite, empty slot, First Aid on slot 6.

## Known Issues and TODO List:

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
