### PR TITLE
fix(Core/Spells): load all spell_custom_attr rows

### DIFF
--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -3177,8 +3177,12 @@ void SpellMgr::LoadSpellInfoCustomAttributes()
     }
     else
     {
-        for (count = 0; result->NextRow(); ++count)
+        count = 0;
+
+        do
         {
+            ++count;
+
             Field const* fields = result->Fetch();
 
             uint32 const spellId = fields[0].Get<uint32>();
@@ -3237,7 +3241,8 @@ void SpellMgr::LoadSpellInfoCustomAttributes()
             }
 
             spellInfo->AttributesCu |= attributes;
-        }
+        } while (result->NextRow());
+
         LOG_INFO("server.loading", ">> Loaded {} spell custom attributes from DB in {} ms", count, GetMSTimeDiffToNow(customAttrTime));
     }
 


### PR DESCRIPTION
## Changes Proposed:

`SpellMgr::LoadSpellInfoCustomAttributes()` never applies the **first row** of `spell_custom_attr`.

`DatabaseWorkerPool<T>::Query()` advances the result set as part of its own guard before handing it back:

```cpp
if (!result || !result->GetRowCount() || !result->NextRow())   // <- row 1 is fetched here
```

So the caller receives a result whose first row is already loaded. That is why the other 16 loaders in this file are all `do { ... } while (result->NextRow());`. The custom-attribute loader instead opens with

```cpp
for (count = 0; result->NextRow(); ++count)
```

which calls `NextRow()` again immediately and steps straight to row 2. Row 1 is dropped silently — no warning is logged, and the `>> Loaded {} spell custom attributes from DB` line under-reports by one.

The query has no `ORDER BY`, so InnoDB serves the scan from the clustered primary key and row 1 is the lowest `spell_id`. In the shipped base data that is **spell 53, Backstab (rank 1)**. It therefore never receives `SPELL_ATTR0_CU_REQ_CASTER_BEHIND_TARGET`, `Spell::CheckCast()` never returns `SPELL_FAILED_NOT_BEHIND` for it, and Backstab rank 1 can be cast from in front of the target. Ranks 2-12 are unaffected.

The off-by-one itself is older than #26375, but that PR (merged 2026-07-25) is what made it reachable for this attribute: it moved these attributes out of the core into the database. Before it, Backstab's behind requirement was hardcoded in `LoadSpellInfoCustomAttributes()` (`case 53: // Backstab`), so a dropped DB row made no difference.

Fix: use the same `do/while` idiom as the rest of the file. `++count` is placed at the top of the body so rows rejected via `continue` are still counted, matching the previous `for`-increment semantics.

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Claude Opus 5) — used for the investigation, the one-line code change, and this description.
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #27273
- Closes chromiecraft/chromiecraft#10048

## SOURCE:
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

The intended behaviour is asserted by this repository's own base data: all 12 Backstab ranks carry `attributes = 131072` (`SPELL_ATTR0_CU_REQ_CASTER_BEHIND_TARGET`) in `data/sql/base/db_world/spell_custom_attr.sql`. No external source is needed — the fix only makes the core honour a row it already ships.

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

The bug was found in-game on a 3.3.5a server (a rogue landing Backstab rank 1 from the front) and the mechanism was then confirmed against that server: `spell_custom_attr` holds 510 rows while startup logs `>> Loaded 509 spell custom attributes from DB`, with no `Table 'spell_custom_attr' has wrong spell` warnings — exactly one row silently unapplied. `MIN(spell_id)` is 53.

To be explicit: the diagnosis is verified, but **the fix itself has not yet been tested in-game** at the time of opening this PR.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Compare `SELECT COUNT(*) FROM spell_custom_attr;` with the `>> Loaded N spell custom attributes from DB` line in `Server.log`. Before the fix, `N` is one short; after, they match.
2. Confirm `SELECT MIN(spell_id) FROM spell_custom_attr;` returns 53.
3. Roll a rogue, train Backstab (rank 1, available at level 4), face a target directly and cast Backstab. Before the fix it lands; after the fix it is refused with "You must be behind your target."
4. Repeat with a higher rank (e.g. 2589, level 12) — it should be refused both before and after, confirming no change to already-working ranks.

## Known Issues and TODO List:

- [ ] 
- [ ] 

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
