### PR TITLE
fix(Scripts/Ulduar): clear helper NPC combat on Thorim encounter end

### DIFF
--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_thorim.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_thorim.cpp
@@ -150,6 +150,8 @@ enum ThormNPCandGOs : uint32
     NPC_ANCIENT_RUNE_GIANT                  = 32873,
     NPC_DARK_RUNE_ACOLYTE_G                 = 33110,
     NPC_IRON_HONOR_GUARD                    = 32875,
+    NPC_GOLEM_RIGHT_HAND_BUNNY              = 33140,
+    NPC_GOLEM_LEFT_HAND_BUNNY               = 33141,
 
     // TRIGGERS
     NPC_LIGHTNING_ORB                       = 33138,
@@ -563,6 +565,11 @@ struct boss_thorim : public BossAI
                 me->RemoveAllAuras();
                 events.Reset();
                 DisableThorim(true);
+
+                // Sif is zone-combatted at summon and never evades: end her combat with Thorim's so
+                // the raid drops combat at the defeat instead of at her later despawn
+                if (Creature* sif = me->FindNearestCreature(NPC_SIF, 250.0f))
+                    sif->CombatStop(true);
 
                 Talk(SAY_DEATH);
 
@@ -1360,6 +1367,17 @@ struct boss_thorim_runic_colossus : public ScriptedAI
         float _nextTriggerPos;
         ObjectGuid _triggerLeftGUID[2], _triggerRightGUID[2];
 
+        // Sweep by entry so it also catches orphans left by a previous colossus that
+        // despawned without dying (wipe path) - their combat refs keep players in combat.
+        void DespawnSmashTriggers()
+        {
+            std::list<Creature*> triggers;
+            me->GetCreatureListWithEntryInGrid(triggers, { NPC_GOLEM_RIGHT_HAND_BUNNY,
+                NPC_GOLEM_LEFT_HAND_BUNNY }, 200.0f);
+            for (Creature* trigger : triggers)
+                trigger->DespawnOrUnsummon();
+        }
+
         void Reset() override
         {
             _nextTriggerPos = 0.0f;
@@ -1367,16 +1385,18 @@ struct boss_thorim_runic_colossus : public ScriptedAI
             _checkTarget = false;
             events.Reset();
             events.ScheduleEvent(EVENT_RC_RUNIC_SMASH, 0ms);
+
+            DespawnSmashTriggers();
             Creature* c;
 
-            if ((c = me->SummonCreature(33140, 2221, -385, me->GetPositionZ())))
+            if ((c = me->SummonCreature(NPC_GOLEM_RIGHT_HAND_BUNNY, 2221, -385, me->GetPositionZ())))
                 _triggerRightGUID[0] = c->GetGUID();
-            if ((c = me->SummonCreature(33140, 2210, -385, me->GetPositionZ())))
+            if ((c = me->SummonCreature(NPC_GOLEM_RIGHT_HAND_BUNNY, 2210, -385, me->GetPositionZ())))
                 _triggerRightGUID[1] = c->GetGUID();
 
-            if ((c = me->SummonCreature(33141, 2235, -385, me->GetPositionZ())))
+            if ((c = me->SummonCreature(NPC_GOLEM_LEFT_HAND_BUNNY, 2235, -385, me->GetPositionZ())))
                 _triggerLeftGUID[0] = c->GetGUID();
-            if ((c = me->SummonCreature(33141, 2246, -385, me->GetPositionZ())))
+            if ((c = me->SummonCreature(NPC_GOLEM_LEFT_HAND_BUNNY, 2246, -385, me->GetPositionZ())))
                 _triggerLeftGUID[1] = c->GetGUID();
         }
 
@@ -1394,6 +1414,9 @@ struct boss_thorim_runic_colossus : public ScriptedAI
             // The Ancient Rune Giant stays immune to players until the colossus falls
             if (Creature* giant = me->FindNearestCreature(NPC_ANCIENT_RUNE_GIANT, 200.0f))
                 giant->RemoveUnitFlag(UNIT_FLAG_IMMUNE_TO_PC);
+
+            // The bunnies never evade, so anyone hit by Runic Smash would stay in combat forever
+            DespawnSmashTriggers();
         }
 
         void JustEngagedWith(Unit*) override


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Players could stay permanently in combat after defeating Thorim because the passive helper NPCs around the encounter hold combat references that nothing clears. Thorim himself never dies (his defeat branch only stops his own combat), so the usual boss evade cleanup never runs for anything else.

The Thunder Orbs are already covered by #27470, which stops them from entering combat at all. This PR handles the two remaining holders:

- The gauntlet smash triggers (Thorim Golem Right/Left Hand Bunny 33140/33141) cast Runic Smash on gauntlet runners but never evade, and every Runic Colossus reset orphaned the previous set with its refs intact. The colossus now despawns them by entry when it dies and sweeps orphans in `Reset()` before summoning fresh ones, so wipes and instance-load churn cannot strand any.
- Sif (33196) needs no hit at all: she is zone-combatted the moment she is summoned while Thorim is engaged, then idles on the balcony holding refs. Thorim now ends her combat in his defeat branch with `CombatStop(true)`, so the raid drops combat with him instead of waiting for her own despawn; her RP timers are untouched.

The tunnel Thorim Trap Bunnies (33054/33725) were checked and need nothing: they are trigger-flagged, so `NullCreatureAI` marks them combat-disallowed and their Lightning Field hits never create a ref.

Hardening the helpers against ever entering combat (trigger flags, immunities) is deliberately out of scope, this is cleanup only.

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Claude Fable 5 and 5.1)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #27280

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

The linked issue includes Classic Wrath kill footage where the raid is out of combat after Thorim's defeat. The fix restores that by clearing the helper refs the scripts leave behind; the ref sources themselves were confirmed with `.debug combat` dumps on a live server (in-game testing reproduced the bunny and Sif cases). The retail sniff behind #27470 shows the golem hand bunny and Sif receiving in-combat updates, so those holders are expected.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

In-game on this revision (10 man, RelWithDebInfo, Windows 11) with #27470's SQL applied, covering every path the change touches:

- A normal defeat no longer leaves the raid in combat, and `.debug combat` lists no refs afterwards.
- Gauntlet: a player tagged by Runic Smash leaves combat when the Runic Colossus dies.
- Wiping in the gauntlet and re-pulling leaves only the current four smash triggers around the corridor, with Runic Smash still damaging runners, so the per-reset orphans are gone.
- A defeat after Sif has already despawned (normal mode) drops combat, exercising the lookup's null branch.
- A hard-mode defeat with Sif still alive at the kill drops combat after the fight, exercising her `CombatStop`; no lingering combat was observed.
- Earlier, on the revision that still swept the Thunder Orbs in script rather than leaving them to #27470: GM one-shot kills before and after Sif's spawn drop combat.
- A local live-stack e2e slice (kept out of the PR) drives the gauntlet with a bot: hit by Runic Smash, it must leave combat when the colossus dies. It fails with a confirmed-bug marker on an unfixed core and is green on this branch.
- Regression: P1 charged-pillar visuals and arena lightning, gauntlet Runic Smash still damaging runners, outro dialogue and the cache chest with loot all verified normal.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Follow the issue's repro (level 80, `.cheat god`, `.tele BossThorim`, play the encounter through and defeat Thorim): you must leave combat shortly after his defeat speech, and `.debug combat` on yourself must list no refs.
2. Gauntlet slice: stand in the smash corridor until Runic Smash hits you, then kill the Runic Colossus: you must leave combat.
3. Wipe mid-gauntlet and re-engage a few times: only the current four smash trigger bunnies exist around the corridor and Runic Smash still deals damage.

## Known Issues and TODO List:

- The wipe-survivor path (encounter resets while a smash-tagged player is still alive) was verified by parts (reset sweep fires on every Thorim reset, despawn releases tagged players) rather than end to end.
- In hard mode Sif can still land one Frostbolt in the two seconds between the defeat and `ACTION_SIF_TRANSFORM`, which re-tags the raid until she despawns about five seconds later. That timing is unchanged by this PR; stopping it means reworking her outro script, which the issue does not need.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


