### PR TITLE
fix(Scripts/Ulduar): share Salvaged Demolisher pyrite between driver and gunner

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1787955538952686400.sql
+++ b/data/sql/updates/pending_db_world/rev_1787955538952686400.sql
@@ -1,0 +1,1 @@
+UPDATE `creature_template` SET `ScriptName` = 'npc_salvaged_demolisher_turret' WHERE `entry` = 33167 AND `ScriptName` = '';

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -155,7 +155,7 @@ If the scenario should stay as a regression, **move** it into `suites/` next to 
 | protocol/teleport | cross-map; named; GoCreatureID | P1 | covered | — |
 | guild/charter_bank | charter buy+turn-in | P2 | covered | — |
 | instances/bind_reset | party tele; ritual summon | P2 | covered; post-reset summon `blocked-harness` (AcceptSummon after reset) | #10708 |
-| instances/ulduar | named tele; Freya wave interval | P2 | covered (`TestAC_27095_*`); Kologarn Charge `blocked-harness` (bridge Z after Charge) | #26266 #27095 |
+| instances/ulduar | named tele; Freya wave interval; Demolisher shared pyrite (spawn-full, seat mirror, repair refuel, Speed Boost cost) | P2 | covered (`TestAC_27095_*`, `TestAC_27313_*`, `TestAC_27331_*`); Kologarn Charge `blocked-harness` (bridge Z after Charge); gunner client-button vehicle cast `blocked-harness` (no possessed-unit cast drive; covered via `.cast self` GM drive) | #26266 #27095 #27313 #27331 |
 
 ---
 

--- a/e2e/suites/instances/northrend/ulduar/demolisher_pyrite_e2e_test.go
+++ b/e2e/suites/instances/northrend/ulduar/demolisher_pyrite_e2e_test.go
@@ -87,9 +87,10 @@ func setUnitEnergy(t *testing.T, bot *e2eharness.ScenarioBot, guid uint64, value
 
 // pairSeatByDrain pairs the discoverable mechanic seat with its parent demolisher.
 // Seats ride the vehicle and carry no usable world position or owner link in the
-// client cache, so the pairing is driven: drain each demolisher and see which one
-// the seat mirrors. Returns with the paired demolisher drained to 0. Doubles as
-// the mirror oracle - a seat that follows no demolisher is the 27313 bug.
+// client cache, so the pairing is driven: set each demolisher to a unique nonzero
+// sentinel and see which one the seat mirrors (a pre-drained seat reads 0 and can
+// never false-match a sentinel). Returns with the paired demolisher drained to 0.
+// Doubles as the mirror oracle - a seat that follows no demolisher is the 27313 bug.
 func pairSeatByDrain(t *testing.T, bot *e2eharness.ScenarioBot) (seat, demo uint64) {
 	t.Helper()
 	seat = bot.WaitUnit(t, npcDemolisherMechSeat, 30*time.Second)
@@ -102,10 +103,15 @@ func pairSeatByDrain(t *testing.T, bot *e2eharness.ScenarioBot) (seat, demo uint
 	// live data. Soft: on an unfixed core the seat reads 0 forever, and the drain
 	// loop still classifies that correctly.
 	waitUnitEnergy(bot, seat, demolisherMaxPyrite, 30*time.Second)
-	for _, d := range demos {
-		setUnitEnergy(t, bot, d.GUID, 0)
-		if waitUnitEnergy(bot, seat, 0, 3*time.Second) {
-			t.Logf("seat 0x%X mirrors demolisher 0x%X", seat, d.GUID)
+	for i, d := range demos {
+		sentinel := uint32(7 + i)
+		if cur, _ := unitEnergy(bot, seat); cur == sentinel {
+			sentinel += 10
+		}
+		setUnitEnergy(t, bot, d.GUID, sentinel)
+		if waitUnitEnergy(bot, seat, sentinel, 3*time.Second) {
+			t.Logf("seat 0x%X mirrors demolisher 0x%X (sentinel %d)", seat, d.GUID, sentinel)
+			setUnitEnergy(t, bot, d.GUID, 0)
 			return seat, d.GUID
 		}
 		setUnitEnergy(t, bot, d.GUID, demolisherMaxPyrite)

--- a/e2e/suites/instances/northrend/ulduar/demolisher_pyrite_e2e_test.go
+++ b/e2e/suites/instances/northrend/ulduar/demolisher_pyrite_e2e_test.go
@@ -1,0 +1,278 @@
+//go:build e2e
+
+package ulduar_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+
+	"github.com/azerothcore/AzerothGhost/client"
+	"github.com/azerothcore/AzerothGhost/e2e/e2eharness"
+	"github.com/azerothcore/azerothcore-wotlk/e2e/internal/meta"
+)
+
+// Salvaged Demolisher shared pyrite pool (issues 27313 / 27331).
+// The demolisher (33109) is the pool; its mechanic seat (33167) mirrors it
+// (npc_salvaged_demolisher_turret). Costed seat abilities charge the parent via
+// their own SPELL_EFFECT_POWER_BURN on TARGET_UNIT_VEHICLE (Speed Boost 62471).
+const (
+	npcSalvagedDemolisher = uint32(33109)
+	npcDemolisherMechSeat = uint32(33167)
+	spellDemoAutoRepair   = uint32(62705)
+	spellDemoSpeedBoost   = uint32(62471)
+	demolisherMaxPyrite   = uint32(50)
+	speedBoostPyriteCost  = uint32(25)
+
+	// UNIT_FIELD_POWER1 + POWER_ENERGY: same update-field index server- and client-side.
+	fieldEnergy    = uint16(client.UnitFieldPower1 + 3)
+	fieldMaxEnergy = uint16(client.UnitFieldMaxPower1 + 3)
+)
+
+// Formation Grounds demolisher pad (between the VEHICLE_POS_START demolisher spawns).
+const (
+	demoPadX = float32(-748.0)
+	demoPadY = float32(-205.0)
+	demoPadZ = float32(431.5)
+)
+
+// msgSetRaidDifficulty switches the solo bot to 25-man normal BEFORE entering, so
+// these tests use their own fresh instance (unsaved solo players share one
+// instance per map+difficulty; a 10-man may be polluted by manual testing).
+const msgSetRaidDifficulty = uint16(0x4EB)
+
+func setRaidDifficulty25(t *testing.T, bot *e2eharness.ScenarioBot) {
+	t.Helper()
+	if err := bot.World.SendPacketRaw(msgSetRaidDifficulty, []byte{1, 0, 0, 0}); err != nil {
+		e2eharness.Preconditionf(t, "MSG_SET_RAID_DIFFICULTY send: %v", err)
+	}
+}
+
+func unitEnergy(bot *e2eharness.ScenarioBot, guid uint64) (cur, max uint32) {
+	obj := bot.World.GetObject(guid)
+	if obj == nil {
+		return 0, 0
+	}
+	return obj.Value(fieldEnergy), obj.Value(fieldMaxEnergy)
+}
+
+// waitUnitEnergy polls the object cache until the unit's pyrite equals want.
+func waitUnitEnergy(bot *e2eharness.ScenarioBot, guid uint64, want uint32, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cur, _ := unitEnergy(bot, guid); cur == want {
+			return true
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return false
+}
+
+// setUnitEnergy drives the selected-unit GM path: select guid, set its pyrite, wait
+// for the cache to reflect it (Preconditionf on failure - the drive, not the oracle).
+func setUnitEnergy(t *testing.T, bot *e2eharness.ScenarioBot, guid uint64, value uint32) {
+	t.Helper()
+	if err := bot.World.SetTarget(guid); err != nil {
+		e2eharness.Preconditionf(t, "SetTarget 0x%X: %v", guid, err)
+	}
+	bot.FlushWorld(t)
+	bot.GM(t, fmt.Sprintf(".debug setvalue %d %d", fieldEnergy, value))
+	if !waitUnitEnergy(bot, guid, value, 10*time.Second) {
+		cur, _ := unitEnergy(bot, guid)
+		e2eharness.Preconditionf(t, "unit 0x%X pyrite=%d after .debug setvalue %d (GM drive failed)", guid, cur, value)
+	}
+}
+
+// pairSeatByDrain pairs the discoverable mechanic seat with its parent demolisher.
+// Seats ride the vehicle and carry no usable world position or owner link in the
+// client cache, so the pairing is driven: drain each demolisher and see which one
+// the seat mirrors. Returns with the paired demolisher drained to 0. Doubles as
+// the mirror oracle - a seat that follows no demolisher is the 27313 bug.
+func pairSeatByDrain(t *testing.T, bot *e2eharness.ScenarioBot) (seat, demo uint64) {
+	t.Helper()
+	seat = bot.WaitUnit(t, npcDemolisherMechSeat, 30*time.Second)
+	demos := bot.UnitsByEntry(120, npcSalvagedDemolisher)
+	if len(demos) == 0 {
+		e2eharness.Preconditionf(t, "no demolishers in cache")
+	}
+	// A just-(re)activated instance serves stale zeros briefly; wait for the seat
+	// to surface its true (mirrored full) value so the drain probes below act on
+	// live data. Soft: on an unfixed core the seat reads 0 forever, and the drain
+	// loop still classifies that correctly.
+	waitUnitEnergy(bot, seat, demolisherMaxPyrite, 30*time.Second)
+	for _, d := range demos {
+		setUnitEnergy(t, bot, d.GUID, 0)
+		if waitUnitEnergy(bot, seat, 0, 3*time.Second) {
+			t.Logf("seat 0x%X mirrors demolisher 0x%X", seat, d.GUID)
+			return seat, d.GUID
+		}
+		setUnitEnergy(t, bot, d.GUID, demolisherMaxPyrite)
+	}
+	e2eharness.ConfirmedBugf(t, 27313, "seat 0x%X does not mirror any of %d demolishers' pyrite", seat, len(demos))
+	return 0, 0
+}
+
+// Issue: https://github.com/azerothcore/azerothcore-wotlk/issues/27331
+// Freshly spawned Salvaged Demolishers (instance load summons them) must have a
+// full pyrite pool on both the demolisher and its mechanic seat.
+func TestAC_27331_DemolisherSpawnsFullPyrite(t *testing.T) {
+	meta.Begin(t, meta.TestMeta{
+		Tags:     []string{"med", "instances", "issue"},
+		Runtime:  "med",
+		Issue:    27331,
+		Category: "instances/northrend/ulduar",
+	})
+
+	bot := e2eharness.NewSolo(t, e2eharness.ScenarioOpts{Prefix: "DemPyr", Level: 80})
+
+	// Entering the map spawns the vehicles; 25-man normal keeps the instance
+	// away from manual 10-man sessions (TestAC_27313 restores what it drains).
+	setRaidDifficulty25(t, bot)
+	bot.Teleport(t, demoPadX, demoPadY, demoPadZ, e2eharness.MapUlduar)
+	seat := bot.WaitUnit(t, npcDemolisherMechSeat, 30*time.Second)
+
+	demos := bot.UnitsByEntry(120, npcSalvagedDemolisher)
+	if len(demos) != 5 {
+		e2eharness.Preconditionf(t, "%d demolishers in cache, want the 5 of a 25-man (difficulty switch failed?)", len(demos))
+	}
+	// All seats run the same mirror AI; the discoverable one joins the census.
+	units := append(demos, e2eharness.UnitSnap{GUID: seat, Entry: npcDemolisherMechSeat})
+
+	// A just-(re)activated instance can serve the spawn-time 0 in the create block
+	// and deliver the real value only on a later update, so wait for every unit to
+	// read full before judging. Sound as a waiter: nothing on an unfixed core ever
+	// writes pyrite to these units (33109/33167 lack UNIT_FLAG2_REGENERATE_POWER),
+	// so they read 0 forever there.
+	deadline := time.Now().Add(60 * time.Second)
+	for time.Now().Before(deadline) {
+		allFull := true
+		for _, u := range units {
+			if cur, _ := unitEnergy(bot, u.GUID); cur != demolisherMaxPyrite {
+				allFull = false
+				break
+			}
+		}
+		if allFull {
+			break
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+
+	// On an unfixed core every vehicle spawns empty; a mix of full and non-full
+	// means another session mutated this shared instance and the spawn state is
+	// no longer judgeable (unsaved solo players share one instance per difficulty).
+	full, empty := 0, 0
+	for _, u := range units {
+		cur, max := unitEnergy(bot, u.GUID)
+		if max != demolisherMaxPyrite {
+			e2eharness.Preconditionf(t, "entry %d 0x%X max pyrite=%d want %d (power type not energy? ScriptName SQL applied?)",
+				u.Entry, u.GUID, max, demolisherMaxPyrite)
+		}
+		switch cur {
+		case max:
+			full++
+		case 0:
+			empty++
+		}
+		t.Logf("entry %d 0x%X pyrite %d/%d", u.Entry, u.GUID, cur, max)
+	}
+	if empty == len(units) {
+		e2eharness.ConfirmedBugf(t, 27331, "all %d demolishers and the seat spawned with 0 pyrite, want full", len(demos))
+	}
+	if full != len(units) {
+		e2eharness.Preconditionf(t, "mixed pyrite (%d full, %d empty of %d) - concurrently mutated shared instance, spawn state not judgeable",
+			full, empty, len(units))
+	}
+	t.Logf("PASS AC#27331 %d demolishers + seat 0x%X spawned with full pyrite", len(demos), seat)
+}
+
+// Issue: https://github.com/azerothcore/azerothcore-wotlk/issues/27313
+// The demolisher and its mechanic seat share one pyrite pool: the seat mirrors the
+// parent (drain and repair-refuel both propagate), and the gunner's Speed Boost
+// takes exactly 25 from the shared pool (its power burn hits the parent; a cost
+// forwarded on top would drain the pool to 0).
+func TestAC_27313_DemolisherRepairSharedPyrite(t *testing.T) {
+	meta.Begin(t, meta.TestMeta{
+		Tags:     []string{"med", "instances", "issue"},
+		Runtime:  "med",
+		Issue:    27313,
+		Category: "instances/northrend/ulduar",
+	})
+
+	bot := e2eharness.NewSolo(t, e2eharness.ScenarioOpts{Prefix: "DemRep", Level: 80})
+
+	setRaidDifficulty25(t, bot)
+	bot.Teleport(t, demoPadX, demoPadY, demoPadZ, e2eharness.MapUlduar)
+
+	// Mirror oracle: the seat follows its parent's drain (leaves the pair drained).
+	seat, demo := pairSeatByDrain(t, bot)
+
+	// Restore full state on exit (best effort) so a reused instance stays judgeable.
+	t.Cleanup(func() {
+		if !bot.Alive() {
+			return
+		}
+		if err := bot.World.SetTarget(demo); err != nil {
+			return
+		}
+		bot.FlushWorld(t)
+		bot.GM(t, fmt.Sprintf(".debug setvalue %d %d", fieldEnergy, demolisherMaxPyrite))
+		bot.GM(t, ".unaura 62705") // repair lockout aura
+	})
+
+	// Repair event: cast Auto-repair from the demolisher on itself, non-triggered
+	// (the GM "triggered" keyword is TRIGGERED_FULL_DEBUG_MASK, which includes
+	// TRIGGERED_IGNORE_EFFECTS - no energize). The station's trap geometry is not
+	// the oracle; the energize only ever hits the main vehicle, so the seat must
+	// be refueled by the mirror. Clear a leftover 62705 lockout aura first: the
+	// spell script filters targets that still have it.
+	if err := bot.World.SetTarget(demo); err != nil {
+		e2eharness.Preconditionf(t, "SetTarget demolisher: %v", err)
+	}
+	bot.FlushWorld(t)
+	bot.GM(t, ".unaura 62705")
+	bot.GM(t, fmt.Sprintf(".cast self %d", spellDemoAutoRepair))
+	if !waitUnitEnergy(bot, demo, demolisherMaxPyrite, 15*time.Second) {
+		cur, _ := unitEnergy(bot, demo)
+		e2eharness.Preconditionf(t, "demolisher pyrite=%d after Auto-repair, energize did not land (drive failed)", cur)
+	}
+	if !waitUnitEnergy(bot, seat, demolisherMaxPyrite, 10*time.Second) {
+		cur, _ := unitEnergy(bot, seat)
+		e2eharness.ConfirmedBugf(t, 27313, "repair refueled the demolisher (50) but the seat shows %d", cur)
+	}
+	t.Logf("repair leg: parent and seat both refueled to %d", demolisherMaxPyrite)
+
+	// Gunner spend parity: Speed Boost from the seat must take exactly 25 from the
+	// shared pool - the seat pays the 25 cost, its power burn takes 25 from the
+	// parent, and the mirror keeps both at the same value. A core that forwards
+	// the cost on top loses 50 from the pool instead of 25. Non-triggered so cost
+	// and effects run; the spell has no DBC cooldown.
+	if err := bot.World.SetTarget(seat); err != nil {
+		e2eharness.Preconditionf(t, "SetTarget seat: %v", err)
+	}
+	bot.FlushWorld(t)
+	bot.GM(t, fmt.Sprintf(".cast self %d", spellDemoSpeedBoost))
+	want := demolisherMaxPyrite - speedBoostPyriteCost
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if cur, _ := unitEnergy(bot, demo); cur != demolisherMaxPyrite {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	demoCur, _ := unitEnergy(bot, demo)
+	if demoCur == demolisherMaxPyrite {
+		e2eharness.Preconditionf(t, "demolisher pyrite unchanged after Speed Boost (cast failed?)")
+	}
+	if demoCur != want {
+		e2eharness.ConfirmedBugf(t, 27313, "Speed Boost took %d pyrite from the pool (parent at %d), want exactly %d",
+			demolisherMaxPyrite-demoCur, demoCur, speedBoostPyriteCost)
+	}
+	if !waitUnitEnergy(bot, seat, want, 10*time.Second) {
+		cur, _ := unitEnergy(bot, seat)
+		e2eharness.ConfirmedBugf(t, 27313, "seat pyrite=%d after Speed Boost, want %d (mirror of parent)", cur, want)
+	}
+	t.Logf("PASS AC#27313 shared pool: drain mirrored, repair refueled both, Speed Boost cost exactly %d", speedBoostPyriteCost)
+}

--- a/e2e/suites/instances/northrend/ulduar/demolisher_pyrite_e2e_test.go
+++ b/e2e/suites/instances/northrend/ulduar/demolisher_pyrite_e2e_test.go
@@ -50,7 +50,7 @@ func setRaidDifficulty25(t *testing.T, bot *e2eharness.ScenarioBot) {
 	}
 }
 
-func unitEnergy(bot *e2eharness.ScenarioBot, guid uint64) (cur, max uint32) {
+func unitEnergy(bot *e2eharness.ScenarioBot, guid uint64) (cur, maxPower uint32) {
 	obj := bot.World.GetObject(guid)
 	if obj == nil {
 		return 0, 0
@@ -171,18 +171,18 @@ func TestAC_27331_DemolisherSpawnsFullPyrite(t *testing.T) {
 	// no longer judgeable (unsaved solo players share one instance per difficulty).
 	full, empty := 0, 0
 	for _, u := range units {
-		cur, max := unitEnergy(bot, u.GUID)
-		if max != demolisherMaxPyrite {
+		cur, maxPower := unitEnergy(bot, u.GUID)
+		if maxPower != demolisherMaxPyrite {
 			e2eharness.Preconditionf(t, "entry %d 0x%X max pyrite=%d want %d (power type not energy? ScriptName SQL applied?)",
-				u.Entry, u.GUID, max, demolisherMaxPyrite)
+				u.Entry, u.GUID, maxPower, demolisherMaxPyrite)
 		}
 		switch cur {
-		case max:
+		case maxPower:
 			full++
 		case 0:
 			empty++
 		}
-		t.Logf("entry %d 0x%X pyrite %d/%d", u.Entry, u.GUID, cur, max)
+		t.Logf("entry %d 0x%X pyrite %d/%d", u.Entry, u.GUID, cur, maxPower)
 	}
 	if empty == len(units) {
 		e2eharness.ConfirmedBugf(t, 27331, "all %d demolishers and the seat spawned with 0 pyrite, want full", len(demos))

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_flame_leviathan.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_flame_leviathan.cpp
@@ -1207,6 +1207,29 @@ struct boss_flame_leviathan_safety_container : public NullCreatureAI
     }
 };
 
+// On retail the Salvaged Demolisher and its mechanic seat share a single pyrite pool with
+// the parent demolisher as the source: the repair station's energize targets only the main
+// vehicles, and the one costed seat ability (Speed Boost 62471) already charges the parent
+// itself via its SPELL_EFFECT_POWER_BURN on TARGET_UNIT_VEHICLE - so the seat only needs
+// to mirror the parent's pyrite.
+struct npc_salvaged_demolisher_turret : public VehicleAI
+{
+    npc_salvaged_demolisher_turret(Creature* creature) : VehicleAI(creature) { }
+
+    void UpdateAI(uint32 diff) override
+    {
+        VehicleAI::UpdateAI(diff);
+
+        Unit* parent = me->GetVehicleBase();
+        if (!parent || parent->GetEntry() != NPC_SALVAGED_DEMOLISHER)
+            return;
+
+        Powers powerType = me->getPowerType();
+        if (me->GetPower(powerType) != parent->GetPower(powerType))
+            me->SetPower(powerType, parent->GetPower(powerType));
+    }
+};
+
 class go_ulduar_tower : public GameObjectScript
 {
 public:
@@ -1838,6 +1861,7 @@ void AddSC_boss_flame_leviathan()
     // Helpers
     RegisterUlduarCreatureAI(npc_storm_beacon_spawn);
     RegisterUlduarCreatureAI(boss_flame_leviathan_safety_container);
+    RegisterUlduarCreatureAI(npc_salvaged_demolisher_turret);
 
     // GOs
     new go_ulduar_tower();

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp
@@ -1343,6 +1343,10 @@ void instance_ulduar::instance_ulduar_InstanceMapScript::SummonLeviathanVehicle(
         if (!_leviathanVehiclesUsable)
             veh->RemoveNpcFlag(UNIT_NPC_FLAG_SPELLCLICK);
 
+        // On retail demolishers spawn with full pyrite; the mechanic seat mirrors the parent's pool
+        if (entry == NPC_SALVAGED_DEMOLISHER)
+            veh->SetPower(veh->getPowerType(), veh->GetMaxPower(veh->getPowerType()));
+
         _leviathanVehicles.push_back({ veh->GetGUID(), entry, index });
     }
 }


### PR DESCRIPTION
<!-- PR title: fix(Scripts/Ulduar): share Salvaged Demolisher pyrite between driver and gunner -->

## Changes Proposed:

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

On retail the Salvaged Demolisher and its Mechanic Seat share one pyrite pool, and demolishers arrive at the Formation Grounds fueled. On AC the seat had its own pool that the repair station never refueled (the Auto-repair energize only targets the main vehicles), and demolishers spawned empty.

- New `npc_salvaged_demolisher_turret` script on the Mechanic Seat (33167): mirrors the parent demolisher's pyrite every update, so repairs and Liquid Pyrite grabs reach the gunner's bar and the two bars always agree.
- `SpawnLeviathanEncounterVehicles` now spawns demolishers with full pyrite (both raid sizes, initial spawn and respawns).
- Pending SQL binds the ScriptName.
- Two live-stack e2e regression tests, one per issue.

Note on ability costs: no forwarding is needed. Speed Boost (62471) already charges the parent by itself, the seat pays the 25 cost and the spell burns another 25 from the vehicle via its power burn effect on `TARGET_UNIT_VEHICLE`, and every other seat ability is free. The one-way mirror is enough to keep both bars in lockstep. The mirror logic is where review judgment matters; the e2e file documents its drive choices in comments, the rest is mechanical.

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Fable 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:

- Closes #27313
- Closes #27331

## SOURCE:

The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Shared pool: classic WotLK video https://youtu.be/SL6_moUBTl8?t=38 (driver bar drops 25 when the gunner uses Speed Boost). Spawning fueled: https://www.youtube.com/watch?v=RJCpPqnyCzE. Speed Boost's cost and vehicle power burn confirmed against the 3.3.5a client Spell.dbc.

## Tests Performed:

This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

In-game (10-man): demolishers spawn with full pyrite on both bars, gunner Speed Boost drops both bars by 25, driver Hurl Pyrite Barrel spends correctly, repair station refuels both bars. The two e2e tests pass twice in a row against the fixed core (25-man instance). Builds clean, both codestyle linters pass.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issues
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Teleport to Ulduar with two characters:

```
.tele ulduar
```

2. Check a freshly spawned demolisher: driver and gunner bars both full at 50.
3. Gunner uses Speed Boost: both bars drop by 25.
4. Drain some pyrite, drive over an active repair station: health full and both bars refueled, gunner can boost again immediately.
5. Grab Liquid Pyrite: both bars rise equally (no regression).
6. Destroy a demolisher at the Expedition Base Camp before pulling the boss: the replacement that rolls out after the wreck decays must also arrive with full pyrite.
7. Spot-check a Siege Engine and Chopper repair (untouched by this PR).

## Known Issues and TODO List:

- The e2e suite runs the regression tests automatically; the gunner's client-button cast path can't be driven by the harness and is covered by the in-game test above.
