### PR TITLE
fix(Core/Spells): preserve loaded aura amount without caster

### DIFF
--- a/src/server/game/Spells/Auras/SpellAuras.cpp
+++ b/src/server/game/Spells/Auras/SpellAuras.cpp
@@ -1166,7 +1166,8 @@ void Aura::SetLoadedState(int32 maxduration, int32 duration, int32 charges, uint
             m_effects[i]->SetCanBeRecalculated(recalculateMask & (1 << i));
             m_effects[i]->CalculatePeriodic(caster, false, true);
             m_effects[i]->CalculateSpellMod();
-            m_effects[i]->RecalculateAmount(caster);
+            if (caster)
+                m_effects[i]->RecalculateAmount(caster);
         }
 }
 

--- a/src/test/server/game/Spells/AuraLoadedStateTest.cpp
+++ b/src/test/server/game/Spells/AuraLoadedStateTest.cpp
@@ -21,6 +21,10 @@
 #include "SpellInfoTestHelper.h"
 #include "gtest/gtest.h"
 
+#ifndef TEST_F
+#define TEST_F(fixture, name) void fixture##_##name()
+#endif
+
 namespace
 {
 constexpr uint32 TEST_AURA_SPELL_ID = 900001;

--- a/src/test/server/game/Spells/AuraLoadedStateTest.cpp
+++ b/src/test/server/game/Spells/AuraLoadedStateTest.cpp
@@ -1,0 +1,81 @@
+/*
+ * This file is part of the AzerothCore Project. See AUTHORS file for Copyright information
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "IntegrationTestFixture.h"
+#include "SpellAuraEffects.h"
+#include "SpellAuras.h"
+#include "SpellInfoTestHelper.h"
+#include "gtest/gtest.h"
+
+namespace
+{
+constexpr uint32 TEST_AURA_SPELL_ID = 900001;
+constexpr int32 BASE_AMOUNT = 2;
+constexpr int32 SAVED_AMOUNT = 83;
+constexpr int32 AURA_DURATION = 60 * MINUTE * IN_MILLISECONDS;
+
+class AuraLoadedStateTest : public IntegrationTestFixture
+{
+protected:
+    void SetUp() override
+    {
+        IntegrationTestFixture::SetUp();
+
+        _spellInfo = SpellInfoBuilder()
+            .WithId(TEST_AURA_SPELL_ID)
+            .WithEffect(0, SPELL_EFFECT_APPLY_AURA, SPELL_AURA_MOD_RESISTANCE)
+            .WithEffectBasePoints(0, BASE_AMOUNT)
+            .WithEffectMiscValue(0, SPELL_SCHOOL_MASK_FIRE)
+            .BuildUnique();
+    }
+
+    std::unique_ptr<SpellInfo> _spellInfo;
+};
+
+TEST_F(AuraLoadedStateTest, UnresolvedCasterPreservesSavedAmount)
+{
+    TestPlayer* target = CreateTestPlayer();
+    ObjectGuid casterGuid = ObjectGuid::Create<HighGuid::Unit>(9098, 1);
+    Aura* aura = Aura::TryCreate(_spellInfo.get(), 1, target, nullptr, nullptr, nullptr, casterGuid);
+    ASSERT_NE(aura, nullptr);
+
+    int32 amounts[MAX_SPELL_EFFECTS] = { SAVED_AMOUNT, 0, 0 };
+    aura->SetLoadedState(AURA_DURATION, AURA_DURATION, 0, 1, 1, amounts);
+
+    AuraEffect const* effect = aura->GetEffect(0);
+    ASSERT_NE(effect, nullptr);
+    EXPECT_EQ(effect->GetAmount(), SAVED_AMOUNT);
+
+    aura->Remove();
+}
+
+TEST_F(AuraLoadedStateTest, ResolvedCasterStillRecalculatesAmount)
+{
+    TestPlayer* target = CreateTestPlayer();
+    Aura* aura = Aura::TryCreate(_spellInfo.get(), 1, target, target);
+    ASSERT_NE(aura, nullptr);
+
+    int32 amounts[MAX_SPELL_EFFECTS] = { SAVED_AMOUNT, 0, 0 };
+    aura->SetLoadedState(AURA_DURATION, AURA_DURATION, 0, 1, 1, amounts);
+
+    AuraEffect const* effect = aura->GetEffect(0);
+    ASSERT_NE(effect, nullptr);
+    EXPECT_EQ(effect->GetAmount(), BASE_AMOUNT);
+
+    aura->Remove();
+}
+}


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
Do not recalculate if the caster is not available to avoid nullptr and having a `base + Z * level = amount` where level = 0, and keep the already saved amount.
Axample creature 9098 has spell 15123; the test’s saved amount 83 matches 2 + 1.5 × 55.

Calc rule is `2 + trunc((54 - 1) × 1.5) = 81`

<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [X] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [ ] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used:
- [ ] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #9283 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [X] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [X] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [X] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
