### PR TITLE
fix(DB/SAI): Champion of Hodir should cast Freezing Breath on the second highest threat target

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1788098081694810100.sql
+++ b/data/sql/updates/pending_db_world/rev_1788098081694810100.sql
@@ -1,0 +1,6 @@
+-- Champion of Hodir: Freezing Breath targets the second highest threat unit instead of the current tank.
+DELETE FROM `smart_scripts` WHERE (`entryorguid` = 34133) AND (`source_type` = 0);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(34133, 0, 0, 0, 0, 0, 100, 2, 6000, 10000, 15000, 20000, 0, 0, 11, 64639, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Champion of Hodir - In Combat - Cast \'Stomp\' (Normal Dungeon)'),
+(34133, 0, 1, 0, 0, 0, 100, 4, 6000, 10000, 15000, 20000, 0, 0, 11, 64652, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Champion of Hodir - In Combat - Cast \'Stomp\' (Heroic Dungeon)'),
+(34133, 0, 2, 0, 0, 0, 100, 0, 10000, 15000, 15000, 25000, 0, 0, 11, 64649, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 'Champion of Hodir - In Combat - Cast \'Freezing Breath\'');


### PR DESCRIPTION
## Changes Proposed:
Champion of Hodir (34133) was casting Freezing Breath (64649) on its current victim, so the frontal cone always hit the main tank. This changes the SAI target to the second highest threat unit, matching how the ability worked on retail.

There is no emulator reference for this one: TC 3.3.5 doesn't script this creature at all and cmangos only casts Stomp. The closest sources are era Wowhead comments on the NPC. The top rated one from 3.1.0 describes the breath going on "the top threat player in the raid (after the MT)" and the positioning tactic built around it, which is also what the video in the linked issue shows. A later reply claims it was random instead, so if anyone has a sniff or threat meter footage contradicting second on threat, happy to adjust.

The update rewrites the full smart_scripts block for 34133, the Stomp rows are unchanged apart from standardized comments.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Fable 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #27178

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)

Era comments on https://www.wowhead.com/wotlk/npc=34133/champion-of-hodir#comments and the video linked in the issue.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. Attack a Champion of Hodir near the Hodir approach in Ulduar with two characters on its threat list.
2. The one with less threat should get turned to and hit by Freezing Breath instead of the current tank.

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
