### PR TITLE
fix(Core/Spells): correct SPELLMOD_COST order of operations

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -10012,8 +10012,11 @@ void Player::ApplySpellMod(uint32 spellId, SpellModOp op, T& basevalue, Spell* s
 
         // skip if already instant or cost is free
         if (mod->op == SPELLMOD_CASTING_TIME || mod->op == SPELLMOD_COST)
-            if (((float)basevalue + (float)basevalue * (totalmul - 1.0f) + (float)totalflat) <= 0)
+        {
+            float currentVal = ((float)basevalue + (float)totalflat) * totalmul;
+            if (currentVal <= 0.0f)
                 return;
+        }
 
         if (mod->type == SPELLMOD_FLAT)
         {
@@ -10067,7 +10070,7 @@ void Player::ApplySpellMod(uint32 spellId, SpellModOp op, T& basevalue, Spell* s
         calculateSpellMod(mod);
     }
 
-    if (op == SPELLMOD_CASTING_TIME || op == SPELLMOD_DURATION)
+    if (op == SPELLMOD_CASTING_TIME || op == SPELLMOD_DURATION || op == SPELLMOD_COST)
         basevalue = (basevalue + totalflat) > 0 ? (basevalue + totalflat) * totalmul : 0;
     else
         basevalue = (basevalue * totalmul) + totalflat;


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [ ] AI tools were partially used in preparing this pull request.

This corrects the order of operations when calculating `SPELLMOD_COST` to align with standard WotLK mechanics: flat reductions are now applied to the base cost before percentage-based multipliers.

Previously, AzerothCore was applying percentage reductions before flat reductions (`(base * pct) - flat`). This caused abilities like a Feral Druid's Shred (with the Shredding Attacks talent and Berserk active) to cost only 12 energy instead of the intended 21 energy. 

This PR updates `Player::ApplySpellMod` to group `SPELLMOD_COST` with `SPELLMOD_CASTING_TIME` and `SPELLMOD_DURATION`, which properly evaluates as `(base + flat) * pct`. Additionally, it fixes a previously overlooked bug in the same function where the early-exit condition (which skips further calculation if the cost drops to zero) was still using the old mathematical formula, ensuring edge cases don't incorrectly trigger the exit early.

## Issues Addressed:

- Closes #16905

## SOURCE:

The behavior and reproduction are documented in the linked issue.
Standard WotLK mechanics dictate that flat cost reductions from talents/items are applied to the spell's base cost before any percentage multipliers are evaluated.
Proof from Wrath Classic: https://youtu.be/mq4aDbyWKNg?t=21
Proof from 2010: https://www.youtube.com/watch?v=kKBUJj8FdiI

## Tests Performed:

- Built `worldserver` successfully on Windows Release.
- Tested in-game with a Feral Druid.
- Confirmed that a talented Shred correctly consumes 21 energy instead of 12 energy during Berserk.

## How to Test the Changes:

1. Create a Druid character.
2. `.levelup 79` (or 80).
3. Spec into the Feral tree, picking up `Shredding Attacks` (2/2) and `Berserk`.
4. Go into Cat Form and use `Berserk`.
5. Attack a target dummy with `Shred`.
6. Confirm that the energy consumed is exactly 21.

## Known Issues and TODO List:

None.