### PR TITLE
fix(Scripts/Ulduar): Yogg-Saron's Grim Reprisal should not reflect damage dealt by totems

### DIFF
--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
@@ -3000,12 +3000,14 @@ class spell_yogg_saron_grim_reprisal_aura : public AuraScript
         DamageInfo* damageInfo = eventInfo.GetDamageInfo();
 
         if (!damageInfo || !damageInfo->GetDamage())
-        {
             return;
-        }
+
+        Unit* attacker = damageInfo->GetAttacker();
+        if (!attacker || attacker->IsTotem())
+            return;
 
         int32 damage = CalculatePct(static_cast<int32>(damageInfo->GetDamage()), 60);
-        GetTarget()->CastCustomSpell(SPELL_GRIM_REPRISAL_DAMAGE, SPELLVALUE_BASE_POINT0, damage, damageInfo->GetAttacker(), true, nullptr, aurEff);
+        GetTarget()->CastCustomSpell(SPELL_GRIM_REPRISAL_DAMAGE, SPELLVALUE_BASE_POINT0, damage, attacker, true, nullptr, aurEff);
     }
 
     void Register() override


### PR DESCRIPTION
## Changes Proposed:

Grim Reprisal (the 60% damage reflect on the illusion NPCs in Yogg-Saron's brain room) was reflecting totem damage back at the totem itself. Magma Totem's pulses are cast by the totem, not the shaman, and damage totems only have 5 health, so the first pulse near an illusion NPC killed the totem instantly.

In the retail footage linked in the issue the totem keeps pulsing next to a tentacle and survives, which can't happen if any reflect reaches a 5 hp totem. So the proc now skips the reflect when the attacker is a totem. Players and pets still take it as before.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Fable 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #27148

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Retail video from the issue: https://youtu.be/0AGfZwVuxkM?t=166 (original wotlk footage, the magma totem persists while pulsing in the brain room). Totem health comes from the summon effect's base value, which is 5 for damage totems: https://www.wowhead.com/wotlk/spell=58734/magma-totem

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. Follow the setup steps from the issue to reach the brain room with a shaman.
2. Drop a Magma Totem near a tentacle: it should keep pulsing instead of dying to the reflect.
3. Attack a tentacle directly with a player (and optionally a pet): both should still take the 60% reflect.

## Known Issues and TODO List:

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
