### PR TITLE
fix(Scripts/Ulduar): Yogg-Saron should be defeated below 1.5% health

### DIFF
--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
@@ -150,6 +150,7 @@ enum YoggSpells
     SPELL_LUNATIC_GAZE_YS               = 64163,
     SPELL_DEAFENING_ROAR                = 64189,
     SPELL_SHADOW_BEACON                 = 64465,
+    SPELL_DEATH_ANIMATION               = 64165,
 
     // IMMORTAL GUARDIAN
     SPELL_SIMPLE_TELEPORT               = 64195,
@@ -1161,6 +1162,7 @@ struct boss_yoggsaron : public ScriptedAI
         _instance = me->GetInstanceScript();
         _thirdPhase = false;
         _usedInsane = false;
+        _defeated = false;
         summons.DespawnAll();
         events.Reset();
 
@@ -1184,6 +1186,7 @@ struct boss_yoggsaron : public ScriptedAI
     SummonList summons;
     bool _thirdPhase;
     bool _usedInsane;
+    bool _defeated;
 
     void AttackStart(Unit*) override { }
 
@@ -1195,6 +1198,32 @@ struct boss_yoggsaron : public ScriptedAI
         float o = rand_norm() * M_PI * 2;
         float Zplus = (dist - 38) / 6.5f;
         me->SummonCreature(NPC_IMMORTAL_GUARDIAN, me->GetPositionX() + dist * cos(o), me->GetPositionY() + dist * std::sin(o), 327.2 + Zplus, 0, TEMPSUMMON_CORPSE_TIMED_DESPAWN, 5000);
+    }
+
+    // Never dies from damage: once pushed below 1.5% health he is defeated.
+    // The remaining sliver is not dealt, the death animation plays and the
+    // server kills him half a second later.
+    void DamageTaken(Unit* /*attacker*/, uint32& damage, DamageEffectType /*damagetype*/, SpellSchoolMask /*damageSchoolMask*/) override
+    {
+        if (_defeated)
+        {
+            damage = 0;
+            return;
+        }
+
+        if (damage >= me->GetHealth())
+            damage = me->GetHealth() - 1;
+
+        if (me->GetHealth() - damage >= CalculatePct(me->GetMaxHealth(), 1.5f))
+            return;
+
+        _defeated = true;
+        me->InterruptNonMeleeSpells(true);
+        me->CastSpell(me, SPELL_DEATH_ANIMATION, true);
+        me->m_Events.AddEventAtOffset([this]()
+        {
+            me->KillSelf();
+        }, 500ms);
     }
 
     void JustDied(Unit*  /*who*/) override

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
@@ -1219,7 +1219,7 @@ struct boss_yoggsaron : public ScriptedAI
 
         _defeated = true;
         me->InterruptNonMeleeSpells(true);
-        me->CastSpell(me, SPELL_DEATH_ANIMATION, true);
+        DoCastSelf(SPELL_DEATH_ANIMATION, true);
         me->m_Events.AddEventAtOffset([this]()
         {
             me->KillSelf();


### PR DESCRIPTION
Yogg-Saron currently dies like any creature when his health reaches 0. Evidence from the original game shows he never gets there: once a hit pushes him below ~1.5% health he is defeated. The remaining sliver is never dealt, he plays his death animation ([spell 64165](https://www.wowhead.com/wotlk/spell=64165), a wotlk client spell, self-only, persists through death, sitting right in his P3 spell id block) and the server kills him about half a second later.

Frame-stepping a 2009 kill video (https://youtu.be/HTT4_HBrgFk?t=642): the target frame updates from 692.5k to 626.2k of 41.8M (1.497%), a pace of roughly 44k raid dps, then the defeat toast appears about 0.4s later. The remaining 626k would have taken another ~14 seconds at that pace, so it was never dealt as damage. The two other kill videos linked in the issue end at 773k and 814k, both about 1.5% of their respective max health. A kill sniff shows the same sequence on the wire: the lethal blow is clamped, the Death Animation cast goes out and the encounter-end packets fire before the health 0 update.

Implementation notes: the crossing hit lands normally, matching the video where the bar drops just below the threshold before the defeat, and lethal hits are clamped to leave 1 hp. The Death Animation is cast triggered because Yogg keeps UNIT_FLAG_PACIFIED for the whole fight and a hard cast could be rejected by cast validation depending on the spell's prevention type.

## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/27188

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [x] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. Enter Ulduar (10 or 25) and start the Yogg-Saron encounter, reaching phase 3 (or use GM commands as in the linked issue to progress).
2. Damage him down toward 1.5% of max health in steps.
3. Once a hit pushes him below 1.5%, he should stop taking damage, play his death animation and die about half a second later, with loot, achievements and the weekly quest credit working as before.
4. Also test a single massive overkill hit from above 1.5%: the same defeat sequence should trigger and he must not die twice or at 0 directly.

## Known Issues and TODO List:

- [ ] The 1.5% constant is a best fit from three era kill videos, all 25-man. Nothing is verified for 10-man; the threshold is relative to max health, which the available evidence is consistent with.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
