### PR TITLE
fix(Core/Spells): keep the Demolisher gunner seat's pyrite in sync in Ulduar

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1788125293841859700.sql
+++ b/data/sql/updates/pending_db_world/rev_1788125293841859700.sql
@@ -1,0 +1,15 @@
+-- Ulduar repair stations (Auto-Repair 62705) must also hit the Salvaged Siege Turret and the
+-- Salvaged Demolisher Mechanic Seat: the seat is a separate vehicle with its own pyrite pool,
+-- so without it the gunner's pyrite bar is never refueled (sniffed: one pulse hits both
+-- demolisher and seat, energizing each to full).
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 13 AND `SourceGroup` = 7 AND `SourceEntry` = 62705;
+INSERT INTO `conditions`
+    (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`,
+     `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`,
+     `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`)
+VALUES
+    (13, 7, 62705, 0, 0, 31, 0, 3, 33060, 0, 0, 0, 0, '', 'Auto-Repair targets Salvaged Siege Engine'),
+    (13, 7, 62705, 0, 1, 31, 0, 3, 33062, 0, 0, 0, 0, '', 'Auto-Repair targets Salvaged Chopper'),
+    (13, 7, 62705, 0, 2, 31, 0, 3, 33109, 0, 0, 0, 0, '', 'Auto-Repair targets Salvaged Demolisher'),
+    (13, 7, 62705, 0, 3, 31, 0, 3, 33067, 0, 0, 0, 0, '', 'Auto-Repair targets Salvaged Siege Turret'),
+    (13, 7, 62705, 0, 4, 31, 0, 3, 33167, 0, 0, 0, 0, '', 'Auto-Repair targets Salvaged Demolisher Mechanic Seat');

--- a/data/sql/updates/pending_db_world/rev_1788132736305532200.sql
+++ b/data/sql/updates/pending_db_world/rev_1788132736305532200.sql
@@ -1,0 +1,4 @@
+-- Hurl Pyrite Barrel (62490) drains the Demolisher Mechanic Seat's pyrite through its own
+-- DBC effect now (trigger of the serverside power-burn spell 62474), so the linked-spell
+-- workaround would burn the seat twice.
+DELETE FROM `spell_linked_spell` WHERE `spell_trigger` = 62490 AND `spell_effect` = 62474;

--- a/src/server/game/Spells/SpellInfoCorrections.cpp
+++ b/src/server/game/Spells/SpellInfoCorrections.cpp
@@ -1895,12 +1895,6 @@ void SpellMgr::LoadSpellInfoCorrections()
         spellInfo->Effects[EFFECT_0].TargetA = SpellImplicitTargetInfo(TARGET_DEST_DEST);
     });
 
-    // Hurl Pyrite
-    ApplySpellFix({ 62490 }, [](SpellInfo* spellInfo)
-    {
-        spellInfo->Effects[EFFECT_1].Effect = 0;
-    });
-
     // Meeting Stone Summon
     ApplySpellFix({ 23598 }, [](SpellInfo* spellInfo)
     {


### PR DESCRIPTION
## Changes Proposed:

In the Flame Leviathan gauntlet the demolisher gunner sits in a separate vehicle unit, the Salvaged Demolisher Mechanic Seat (33167), which has its own pyrite pool and powers the gunner's abilities. Auto-Repair (62705) targets by area entry through the `conditions` table, and our rows only allowed the Siege Engine, Chopper and Demolisher. The seat was never refueled, so after a repair the gunner sat on an empty bar while the driver's was full. The Siege Turret (33067) was missing from the same list, so it was never repaired at all.

This PR rewrites the Auto-Repair conditions group with the two missing targets, matching TrinityCore. The refuel itself is the spell's own energize effect, so no script change is needed. Verified with a sniff: a single repair pulse hits both the demolisher and its seat and energizes each to full.

While tracing how the seat's pyrite drains, we found that Hurl Pyrite Barrel (62490) natively triggers the serverside spell 62474, a 5 pyrite power burn on the seat, but an old `SpellInfoCorrections` entry nulls that trigger and a `spell_linked_spell` row reimplements it instead. Both predate serverside spell support. This PR keeps the native trigger and removes the correction and the linked row. Only one of the two mechanisms may exist: with both, every barrel throw drained the seat twice (verified in game).

Review notes: the conditions SQL replaces the whole 62705 group, the DELETE catches exactly the three existing rows and each entry sits in its own ElseGroup so they OR together. The C++ change and the second SQL are plain removals.

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Claude Fable 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #27313

## SOURCE:
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [x] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Builds clean (MSVC, Release). Tested in game: driving a damaged demolisher over a repair station now refuels both the driver's and the gunner's pyrite bars, and each Hurl Pyrite Barrel drains 5 pyrite from both bars, once. Not retested: Siege Engine and Chopper repair (their rows are rewritten identically) and a barrel throw with nobody in the gunner seat.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Enter Ulduar with two characters and clear up to Flame Leviathan's gauntlet.
2. Board a Salvaged Demolisher with a driver and a gunner, spend pyrite (gunner speed boost, driver pyrite barrels) and take some damage.
3. Drive over a repair station: both seats' pyrite bars should fill to 50 and the vehicle should heal to full.
4. Throw pyrite barrels as the driver: both bars drop by 5 per throw.

## Known Issues and TODO List:

- [ ] The unused Load into Catapult variant (62427) still has a `spell_linked_spell` row; nothing casts that spell, left as is to keep this PR focused.

## How to Test AzerothCore PRs

When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
