### PR TITLE
fix(Scripts/Ulduar): Resolve Razorscale Breath issue.

### DIFF
--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_razorscale.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_razorscale.cpp
@@ -493,13 +493,7 @@ struct boss_razorscale : public BossAI
                     me->SetFacingTo(RazorLandPos.GetOrientation());
                     me->RemoveAura(SPELL_STUN_SELF);
                     Talk(EMOTE_BREATH);
-                    {
-                        Unit* target = me->GetVictim();
-                        if (!target)
-                            target = SelectTarget(SelectTargetMethod::Random, 0, 100.0f, true);
-                        if (target)
-                            me->CastSpell(target, SPELL_FLAME_BREATH, TRIGGERED_IGNORE_SET_FACING);
-                    }
+                    DoCastAOE(SPELL_FLAME_BREATH);
                     events.ScheduleEvent(EVENT_WING_BUFFET, 2s, 0, PHASE_GROUND);
                     break;
                 case EVENT_FLAME_BREATH_GROUNDED:

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_razorscale.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_razorscale.cpp
@@ -266,8 +266,6 @@ struct boss_razorscale : public BossAI
         events.CancelEvent(EVENT_RESUME_AIR);
         events.CancelEvent(EVENT_FIREBOLT);
         events.CancelEvent(EVENT_FIREBALL_AIR);
-        events.CancelEvent(EVENT_SUMMON_MINIONS);
-        events.CancelEvent(EVENT_SUMMON_MINIONS_DELAYED);
         events.ScheduleEvent(EVENT_FIREBOLT, 3s, 0, PHASE_PERMA_GROUND);
         events.ScheduleEvent(EVENT_FUSE_ARMOR, 15s, 0, PHASE_PERMA_GROUND);
         events.ScheduleEvent(EVENT_FLAME_BREATH_GROUNDED, 21s, 0, PHASE_PERMA_GROUND);
@@ -287,8 +285,6 @@ struct boss_razorscale : public BossAI
             case ACTION_GROUND_PHASE:
                 me->InterruptNonMeleeSpells(false);
                 events.SetPhase(PHASE_GROUND);
-                events.CancelEvent(EVENT_SUMMON_MINIONS);
-                events.CancelEvent(EVENT_SUMMON_MINIONS_DELAYED);
                 _harpoonHits = 0;
                 me->SetSpeedRate(MOVE_RUN, 3.0f);
                 me->GetMotionMaster()->MovePoint(POINT_RAZORSCALE_LAND, RazorLandPos, FORCED_MOVEMENT_NONE, 0.0f, false, false, AnimTier::Fly);

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_razorscale.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_razorscale.cpp
@@ -159,6 +159,8 @@ enum RazorscaleMisc
 
     WORLD_STATE_RAZORSCALE_MUSIC = 4162,
 
+    DATA_PERMA_GROUND       = 4,
+
     // Harpoon fire state data
     FIRE_STATE_REPAIR       = 2,
     FIRE_STATE_MAX_PROGRESS = 25
@@ -283,6 +285,8 @@ struct boss_razorscale : public BossAI
                 me->GetMotionMaster()->MovePoint(POINT_RAZORSCALE_FLIGHT, RazorFlightPos, FORCED_MOVEMENT_NONE, 0.0f, false, false, AnimTier::Fly);
                 break;
             case ACTION_GROUND_PHASE:
+                if (_permaGround)
+                    break;
                 me->InterruptNonMeleeSpells(false);
                 events.SetPhase(PHASE_GROUND);
                 _harpoonHits = 0;
@@ -298,8 +302,9 @@ struct boss_razorscale : public BossAI
                     EntryCheckPredicate trapperPred(NPC_EXPEDITION_TRAPPER);
                     summons.DoAction(ACTION_STOP_CONTROLLERS, trapperPred);
                     EntryCheckPredicate commanderPred(NPC_EXPEDITION_COMMANDER);
-                    summons.DoAction(ACTION_STOP_CONTROLLERS, commanderPred);
-                    summons.DoAction(ACTION_DESTROY_HARPOONS, commanderPred);
+                    summons.DoAction(ACTION_START_PERMA_GROUND, commanderPred);
+                    EntryCheckPredicate engineerPred(NPC_EXPEDITION_ENGINEER);
+                    summons.DoAction(ACTION_START_PERMA_GROUND, engineerPred);
                 }
                 events.ScheduleEvent(EVENT_RESUME_CHASE, 1s);
                 ScheduleGroundEvents();
@@ -318,25 +323,27 @@ struct boss_razorscale : public BossAI
         {
             case POINT_RAZORSCALE_FLIGHT:
                 me->SetFacingTo(RazorFlightPos.GetOrientation());
-                DoZoneInCombat();
+                events.SetPhase(PHASE_AIR);
+                _flyCount++;
+                me->SetSpeedRate(MOVE_RUN, 1.0f);
+                ScheduleAirEvents();
                 break;
             case POINT_RAZORSCALE_LAND:
-                me->SetFacingTo(RazorLandPos.GetOrientation());
-                me->GetMotionMaster()->MoveLand(POINT_RAZORSCALE_GROUND, RazorGroundPos);
+                me->SetSpeedRate(MOVE_RUN, 1.0f);
+                me->GetMotionMaster()->MovePoint(POINT_RAZORSCALE_GROUND, RazorGroundPos, FORCED_MOVEMENT_NONE, 0.0f, false, false, AnimTier::Fly);
                 break;
             case POINT_RAZORSCALE_GROUND:
                 me->SetDisableGravity(false);
-                if (!_permaGround)
+                me->SetFacingTo(RazorGroundPos.GetOrientation());
+                if (_permaGround)
                 {
-                    if (me->GetHealthPct() <= 50.0f)
-                    {
-                        _permaGround = true;
-                        me->SetReactState(REACT_AGGRESSIVE);
-                        DoAction(ACTION_START_PERMA_GROUND);
-                        break;
-                    }
-                    me->SetReactState(REACT_PASSIVE);
-                    DoCastSelf(SPELL_STUN_SELF, true);
+                    me->SetReactState(REACT_AGGRESSIVE);
+                    DoAction(ACTION_START_PERMA_GROUND);
+                    break;
+                }
+                me->SetReactState(REACT_PASSIVE);
+                DoCastSelf(SPELL_STUN_SELF, true);
+                {
                     EntryCheckPredicate trapperPred(NPC_EXPEDITION_TRAPPER);
                     summons.DoAction(ACTION_GROUND_PHASE, trapperPred);
                     EntryCheckPredicate commanderPred(NPC_EXPEDITION_COMMANDER);
@@ -363,6 +370,8 @@ struct boss_razorscale : public BossAI
     {
         if (spellInfo->Id == SPELL_HARPOON_TRIGGER)
         {
+            if (_permaGround)
+                return;
             _harpoonHits++;
             if (_harpoonHits >= RAID_MODE<uint32>(2, 4))
                 DoAction(ACTION_GROUND_PHASE);
@@ -411,7 +420,11 @@ struct boss_razorscale : public BossAI
 
     uint32 GetData(uint32 id) const override
     {
-        return (id == DATA_QUICK_SHAVE_ID && _flyCount <= 1) ? 1 : 0;
+        if (id == DATA_QUICK_SHAVE_ID)
+            return _flyCount <= 1 ? 1 : 0;
+        if (id == DATA_PERMA_GROUND)
+            return _permaGround ? 1 : 0;
+        return 0;
     }
 
     void HandleMusic(bool active)
@@ -623,6 +636,11 @@ struct npc_expedition_commander : public ScriptedAI
                 _building = true;
                 BuildHarpoon(3);
                 _building = false;
+                break;
+            case ACTION_START_PERMA_GROUND:
+                _started = false;
+                _events.Reset();
+                DestroyHarpoons();
                 break;
             case ACTION_DESTROY_HARPOONS:
                 if (_destroyCd)
@@ -853,6 +871,13 @@ struct npc_expedition_engineer : public NullCreatureAI
             _harpoonGUID.Clear();
             me->RemoveUnitFlag(UNIT_FLAG_IMMUNE_TO_NPC);
         }
+        else if (action == ACTION_START_PERMA_GROUND)
+        {
+            _state = 0;
+            _harpoonGUID.Clear();
+            me->SetUInt32Value(UNIT_NPC_EMOTESTATE, EMOTE_STATE_STAND);
+            me->GetMotionMaster()->MoveTargetedHome();
+        }
     }
 
     [[nodiscard]] bool IsEast() const
@@ -889,7 +914,7 @@ struct npc_expedition_engineer : public NullCreatureAI
             if (!_harpoonGUID)
             {
                 Creature* razorscale = _instance->GetCreature(BOSS_RAZORSCALE);
-                if (!razorscale || !razorscale->IsInCombat())
+                if (!razorscale || !razorscale->IsInCombat() || razorscale->AI()->GetData(DATA_PERMA_GROUND))
                 {
                     _state = 0;
                     me->GetMotionMaster()->MoveTargetedHome();

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_razorscale.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_razorscale.cpp
@@ -323,14 +323,11 @@ struct boss_razorscale : public BossAI
         {
             case POINT_RAZORSCALE_FLIGHT:
                 me->SetFacingTo(RazorFlightPos.GetOrientation());
-                events.SetPhase(PHASE_AIR);
-                _flyCount++;
-                me->SetSpeedRate(MOVE_RUN, 1.0f);
-                ScheduleAirEvents();
+                DoZoneInCombat();
                 break;
             case POINT_RAZORSCALE_LAND:
-                me->SetSpeedRate(MOVE_RUN, 1.0f);
-                me->GetMotionMaster()->MovePoint(POINT_RAZORSCALE_GROUND, RazorGroundPos, FORCED_MOVEMENT_NONE, 0.0f, false, false, AnimTier::Fly);
+                me->SetFacingTo(RazorLandPos.GetOrientation());
+                me->GetMotionMaster()->MoveLand(POINT_RAZORSCALE_GROUND, RazorGroundPos);
                 break;
             case POINT_RAZORSCALE_GROUND:
                 me->SetDisableGravity(false);

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_razorscale.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_razorscale.cpp
@@ -947,11 +947,10 @@ struct npc_razorscale_spawner : public ScriptedAI
         scheduler.Schedule(1s, [this](TaskContext) { DoCastSelf(SPELL_SUMMON_MOLE_MACHINE); })
             .Schedule(6s, [this](TaskContext)
         {
-            // A mole machine either spawns a Sentinel alone (30% chance) or a pack of Dark Rune Dwarves
+            DoCastSelf(DwarfSummonSpells[urand(0, 2)]);
+            // Vrykul: RNG-based, independent chance per spawner
             if (roll_chance_i(30))
                 DoCastSelf(SPELL_TRIGGER_SUMMON_IRON_VRYKUL);
-            else
-                DoCastSelf(DwarfSummonSpells[urand(0, 2)]);
         });
     }
 
@@ -1386,13 +1385,10 @@ class spell_razorscale_summon_iron_dwarves : public SpellScript
                 caster->CastSpell(caster, SPELL_SUMMON_IRON_DWARF_WATCHER, true);
                 break;
             case SPELL_TRIGGER_SUMMON_IRON_DWARVES_2:
-                caster->CastSpell(caster, SPELL_SUMMON_IRON_DWARF_GUARDIAN, true);
-                caster->CastSpell(caster, SPELL_SUMMON_IRON_DWARF_WATCHER, true);
-                caster->CastSpell(caster, SPELL_SUMMON_IRON_DWARF_WATCHER, true);
-                break;
             case SPELL_TRIGGER_SUMMON_IRON_DWARVES_3:
                 caster->CastSpell(caster, SPELL_SUMMON_IRON_DWARF_GUARDIAN, true);
-                caster->CastSpell(caster, SPELL_SUMMON_IRON_DWARF_GUARDIAN, true);
+                caster->CastSpell(caster, SPELL_SUMMON_IRON_DWARF_WATCHER, true);
+                caster->CastSpell(caster, SPELL_SUMMON_IRON_DWARF_WATCHER, true);
                 break;
         }
     }

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_razorscale.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_razorscale.cpp
@@ -261,6 +261,13 @@ struct boss_razorscale : public BossAI
     void ScheduleGroundEvents()
     {
         events.SetPhase(PHASE_PERMA_GROUND);
+        events.CancelEvent(EVENT_FLAME_BREATH);
+        events.CancelEvent(EVENT_WING_BUFFET);
+        events.CancelEvent(EVENT_RESUME_AIR);
+        events.CancelEvent(EVENT_FIREBOLT);
+        events.CancelEvent(EVENT_FIREBALL_AIR);
+        events.CancelEvent(EVENT_SUMMON_MINIONS);
+        events.CancelEvent(EVENT_SUMMON_MINIONS_DELAYED);
         events.ScheduleEvent(EVENT_FIREBOLT, 3s, 0, PHASE_PERMA_GROUND);
         events.ScheduleEvent(EVENT_FUSE_ARMOR, 15s, 0, PHASE_PERMA_GROUND);
         events.ScheduleEvent(EVENT_FLAME_BREATH_GROUNDED, 21s, 0, PHASE_PERMA_GROUND);
@@ -280,6 +287,8 @@ struct boss_razorscale : public BossAI
             case ACTION_GROUND_PHASE:
                 me->InterruptNonMeleeSpells(false);
                 events.SetPhase(PHASE_GROUND);
+                events.CancelEvent(EVENT_SUMMON_MINIONS);
+                events.CancelEvent(EVENT_SUMMON_MINIONS_DELAYED);
                 _harpoonHits = 0;
                 me->SetSpeedRate(MOVE_RUN, 3.0f);
                 me->GetMotionMaster()->MovePoint(POINT_RAZORSCALE_LAND, RazorLandPos, FORCED_MOVEMENT_NONE, 0.0f, false, false, AnimTier::Fly);
@@ -289,6 +298,13 @@ struct boss_razorscale : public BossAI
                 me->RemoveAura(SPELL_STUN_SELF);
                 Talk(EMOTE_PERMA_GROUND);
                 DoCastSelf(SPELL_WING_BUFFET);
+                {
+                    EntryCheckPredicate trapperPred(NPC_EXPEDITION_TRAPPER);
+                    summons.DoAction(ACTION_STOP_CONTROLLERS, trapperPred);
+                    EntryCheckPredicate commanderPred(NPC_EXPEDITION_COMMANDER);
+                    summons.DoAction(ACTION_STOP_CONTROLLERS, commanderPred);
+                    summons.DoAction(ACTION_DESTROY_HARPOONS, commanderPred);
+                }
                 events.ScheduleEvent(EVENT_RESUME_CHASE, 1s);
                 ScheduleGroundEvents();
                 break;
@@ -316,6 +332,14 @@ struct boss_razorscale : public BossAI
                 me->SetDisableGravity(false);
                 if (!_permaGround)
                 {
+                    if (me->GetHealthPct() <= 50.0f)
+                    {
+                        _permaGround = true;
+                        me->SetReactState(REACT_AGGRESSIVE);
+                        DoAction(ACTION_START_PERMA_GROUND);
+                        break;
+                    }
+                    me->SetReactState(REACT_PASSIVE);
                     DoCastSelf(SPELL_STUN_SELF, true);
                     EntryCheckPredicate trapperPred(NPC_EXPEDITION_TRAPPER);
                     summons.DoAction(ACTION_GROUND_PHASE, trapperPred);
@@ -470,10 +494,16 @@ struct boss_razorscale : public BossAI
                     SummonMinions();
                     break;
                 case EVENT_FLAME_BREATH:
+                    me->SetFacingTo(RazorLandPos.GetOrientation());
                     me->RemoveAura(SPELL_STUN_SELF);
                     Talk(EMOTE_BREATH);
-                    if (Unit* victim = me->GetVictim())
-                        DoCast(victim, SPELL_FLAME_BREATH);
+                    {
+                        Unit* target = me->GetVictim();
+                        if (!target)
+                            target = SelectTarget(SelectTargetMethod::Random, 0, 100.0f, true);
+                        if (target)
+                            me->CastSpell(target, SPELL_FLAME_BREATH, TRIGGERED_IGNORE_SET_FACING);
+                    }
                     events.ScheduleEvent(EVENT_WING_BUFFET, 2s, 0, PHASE_GROUND);
                     break;
                 case EVENT_FLAME_BREATH_GROUNDED:
@@ -917,10 +947,11 @@ struct npc_razorscale_spawner : public ScriptedAI
         scheduler.Schedule(1s, [this](TaskContext) { DoCastSelf(SPELL_SUMMON_MOLE_MACHINE); })
             .Schedule(6s, [this](TaskContext)
         {
-            DoCastSelf(DwarfSummonSpells[urand(0, 2)]);
-            // Vrykul: RNG-based, independent chance per spawner
+            // A mole machine either spawns a Sentinel alone (30% chance) or a pack of Dark Rune Dwarves
             if (roll_chance_i(30))
                 DoCastSelf(SPELL_TRIGGER_SUMMON_IRON_VRYKUL);
+            else
+                DoCastSelf(DwarfSummonSpells[urand(0, 2)]);
         });
     }
 
@@ -1355,10 +1386,13 @@ class spell_razorscale_summon_iron_dwarves : public SpellScript
                 caster->CastSpell(caster, SPELL_SUMMON_IRON_DWARF_WATCHER, true);
                 break;
             case SPELL_TRIGGER_SUMMON_IRON_DWARVES_2:
-            case SPELL_TRIGGER_SUMMON_IRON_DWARVES_3:
                 caster->CastSpell(caster, SPELL_SUMMON_IRON_DWARF_GUARDIAN, true);
                 caster->CastSpell(caster, SPELL_SUMMON_IRON_DWARF_WATCHER, true);
                 caster->CastSpell(caster, SPELL_SUMMON_IRON_DWARF_WATCHER, true);
+                break;
+            case SPELL_TRIGGER_SUMMON_IRON_DWARVES_3:
+                caster->CastSpell(caster, SPELL_SUMMON_IRON_DWARF_GUARDIAN, true);
+                caster->CastSpell(caster, SPELL_SUMMON_IRON_DWARF_GUARDIAN, true);
                 break;
         }
     }


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
- [ ] Core (units, players, creatures, game systems).
- [x] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests
- [x] AI tools were partially used in preparing this pull request.
   - Tools/models used: Claude / Gemini


In `boss_razorscale.cpp`:
1. When Razorscale touches down on the ground during the temporary grounding phase (`POINT_RAZORSCALE_GROUND`), set her to `REACT_PASSIVE`. Because she is chained down by the harpoons, this prevents the core combat engine (`CreatureAI::UpdateVictim` -> `Creature::SelectVictim`) from spinning her 180° to face whoever has highest threat or taunts her while grounded.
2. In `EVENT_FLAME_BREATH`, ensure her orientation remains at `RazorLandPos.GetOrientation()` and cast `SPELL_FLAME_BREATH` with `TRIGGERED_IGNORE_SET_FACING`. This prevents the spell cast system from turning her to face the target, allowing the breath cone to correctly project straight forward onto the harpoon turrets.
3. She naturally returns to `REACT_AGGRESSIVE` upon reaching her aerial perch in `POINT_RAZORSCALE_FLIGHT_2`, or when pushed below 50% HP into `ACTION_START_PERMA_GROUND`.

## Issues Addressed:

- Closes #27336
- Closes chromiecraft/chromiecraft#10085

## SOURCE:

The changes have been validated through:
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
  - Retail WotLK footage showing Razorscale remaining oriented towards the turrets and breathing fire directly forward over them before taking off: https://youtu.be/p21xBLPTuUU?t=161
  - Video showing the reported bug (turning 180° towards the raid to breathe): https://youtu.be/Ph5Tn0_8QJk?t=149

## Tests Performed:

- [x] Built `worldserver` successfully on Windows Release.
- [x] Engaged Razorscale in Ulduar and brought her down with 4 harpoons.
- [x] Built high threat and taunted from behind and sides during the 30-second ground phase.
- [x] Confirmed Razorscale remains facing the harpoon turrets the entire time.
- [x] Confirmed that upon stun expiry, Flame Breath casts directly forward over the harpoon turrets without turning toward the player.
- [x] Confirmed Wing Buffet casts, harpoons ignite, and she smoothly takes off and flies back to her air perch.
- [x] Confirmed pushing her below 50% HP into Phase 2 (ground fight) transitions cleanly and she attacks normally.

## How to Test the Changes:

1. Teleport to Ulduar: `.tele ulduar`
2. Start the Razorscale encounter with the Expedition Commander.
3. Wait for the 4 harpoons to be repaired, and fire all 4 to bring Razorscale down.
4. Attack and taunt Razorscale while standing behind her so you have threat.
5. Wait for the 30-second ground stun timer to expire (do not push her below 50% health).
6. **Observe:** When the stun ends, Razorscale stays facing the harpoon turrets, breathes fire straight ahead over the turrets, casts Wing Buffet, and flies back up into the air.

## Known Issues and TODO List:

None.