### PR TITLE
fix(Core/MMaps): correct pathing in Arugal room

### DIFF
--- a/src/tools/mmaps_generator/mmaps-config.yaml
+++ b/src/tools/mmaps_generator/mmaps-config.yaml
@@ -124,6 +124,12 @@ mmapsConfig:
     # All parameters defined globally are eligible for override.
     # Just specify the parameter name and new value in the override section.
     mapsOverrides:
+      "33": # Shadowfang Keep
+        tilesOverrides:
+          "32,27": # Archmage Arugal's room
+            # Keep paths on the stairs instead of stepping across the railing.
+            walkableClimb: 4
+
       "48": # Blackfathom Deeps
         cellSizeVertical: 0.5334 # ch*2 = 0.2667 * 2 ≈ 0.5334. Reduce the chance to have underground levels.
 


### PR DESCRIPTION
## Changes

- lower `walkableClimb` from 6 to 4 only for Shadowfang Keep tile `32,27` (`0333227.mmtile`)
- keep the generated corridor on the stairs instead of allowing a step across the railing near Archmage Arugal

## Why

The global climb value is 6 cells (about 1.6 world units). In this room it merges navigation around the stair rail too aggressively. The tile-local value of 4 still connects every stair surface but generates the missing lower-stair turn.

The generated Detour path from Arugal's spawn to the lower room changes from 8 to 10 polygons and remains complete. The change is scoped to one dungeon tile.

## Validation

- generated map 33 tile `27,32` from the official AC Data v20 maps/vmaps
- confirmed generated file `0333227.mmtile` records `walkableClimb = 4`
- confirmed both endpoints resolve to navmesh polygons and `findPath` reaches the destination
- `git diff --check`
- C++ and SQL codestyle checks
- isolated fresh-context review: no findings

[Test-ready regenerated `0333227.mmtile` (AC Data v20)](https://github.com/moostigre/azerothcore-wotlk/releases/download/issue-26870-mmaps-v20/issue-26870-fixed-mmap-v20.zip)

Closes #26870