### PR TITLE
fix(Scripts/Ulduar): fix Razorscale add spawn composition and queuein…

### DIFF
--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_razorscale.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_razorscale.cpp
@@ -280,6 +280,8 @@ struct boss_razorscale : public BossAI
             case ACTION_GROUND_PHASE:
                 me->InterruptNonMeleeSpells(false);
                 events.SetPhase(PHASE_GROUND);
+                events.CancelEvent(EVENT_SUMMON_MINIONS);
+                events.CancelEvent(EVENT_SUMMON_MINIONS_DELAYED);
                 _harpoonHits = 0;
                 me->SetSpeedRate(MOVE_RUN, 3.0f);
                 me->GetMotionMaster()->MovePoint(POINT_RAZORSCALE_LAND, RazorLandPos, FORCED_MOVEMENT_NONE, 0.0f, false, false, AnimTier::Fly);
@@ -917,10 +919,11 @@ struct npc_razorscale_spawner : public ScriptedAI
         scheduler.Schedule(1s, [this](TaskContext) { DoCastSelf(SPELL_SUMMON_MOLE_MACHINE); })
             .Schedule(6s, [this](TaskContext)
         {
-            DoCastSelf(DwarfSummonSpells[urand(0, 2)]);
-            // Vrykul: RNG-based, independent chance per spawner
-            if (roll_chance_i(30))
+            // A mole machine either spawns a Sentinel alone (25% chance) or a pack of Dark Rune Dwarves
+            if (roll_chance_i(25))
                 DoCastSelf(SPELL_TRIGGER_SUMMON_IRON_VRYKUL);
+            else
+                DoCastSelf(DwarfSummonSpells[urand(0, 2)]);
         });
     }
 


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
- [ ] Core (units, players, creatures, game systems).
- [x] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests
- [x] AI tools were partially used in preparing this pull request.
   - Tools/models used: Claude / Gemini

### Problem & Blizzlike Mechanics Explained:

1. **Minion Wave Chains Stacking Across Air/Ground Cycles:**
   During the air phase, minion waves are scheduled on a 48-second recurring chain (`EVENT_SUMMON_MINIONS`). When Razorscale was brought down to the ground (`ACTION_GROUND_PHASE`), these pending minion summon events were not cancelled. Because the ground phase lasts ~36–40 seconds, the unexpired 48s timer survived the grounding window. When Razorscale returned to the air, `ScheduleAirEvents()` initiated a brand new summon chain alongside the surviving timer, causing minion summon chains to duplicate across multiple air phases and flood the encounter area with adds.
   * *Fix:* In `boss_razorscale::DoAction` under `ACTION_GROUND_PHASE`, explicitly cancel `EVENT_SUMMON_MINIONS` and `EVENT_SUMMON_MINIONS_DELAYED` so no surviving air-phase minion timers persist into subsequent cycles.

2. **Dark Rune Sentinel Mole Machine Exclusivity & Spawn Chance:**
   Previously in `npc_razorscale_spawner::Reset`, mole machines always cast a dwarf summon trigger, and then independently rolled a chance to also summon a Dark Rune Sentinel (`SPELL_TRIGGER_SUMMON_IRON_VRYKUL`), causing mole machines to spawn both a Sentinel and Dark Rune Dwarves simultaneously. As confirmed by retail packet sniffs and TrinityCore, a mole machine either spawns a Dark Rune Sentinel alone (with a 25% chance) or a pack of Dark Rune Dwarves, never both from the same machine.
   * *Fix:* Changed the spawner script so that when the Sentinel roll succeeds (25% chance), only the Sentinel is summoned; otherwise, a Dark Rune Dwarf pack trigger is selected.

## Issues Addressed:

- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/27335

## SOURCE:

The changes have been validated through:
- [x] Official WotLK retail packet sniffs (mole machines spawning a Sentinel exclusively cast spell 63798 with ~25% ratio; minion summon chains reset cleanly per cycle).
- [x] TrinityCore implementation reference: https://github.com/TrinityCore/TrinityCore/blob/3.3.5/src/server/scripts/Northrend/Ulduar/Ulduar/boss_razorscale.cpp#L268-L274

## Tests Performed:

- [x] Built `worldserver` with 0 errors/warnings.
- [x] Engaged Razorscale through multiple air and ground cycles:
  - Verified minion summon timers do not carry over or stack after ground phases.
  - Verified mole machines spawning a Dark Rune Sentinel do not spawn dwarves alongside them.

## How to Test the Changes:

1. Teleport to Razorscale: `.go c id 33186`
2. Start the encounter and observe mole machines during the air phase:
   - Verify that mole machines spawning a Dark Rune Sentinel spawn only the Sentinel.
3. Bring Razorscale down using harpoons, allow the ground phase to end, and let her return to the air:
   - Verify that minion waves spawn at the normal cadence without stacked duplicate waves.

## Known Issues and TODO List:

None.