### PR TITLE
fix(Core/Spells): Fix Charge pathing against oversized targets standing over unwalkable space (e.g. Kologarn)

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -6261,16 +6261,49 @@ SpellCastResult Spell::CheckCast(bool strict, uint32* /*param1*/, uint32* /*para
                         m_preGeneratedPath = std::make_unique<PathGenerator>(m_caster);
                         m_preGeneratedPath->SetPathLengthLimit(range);
 
+                        float destX = target->GetPositionX();
+                        float destY = target->GetPositionY();
+                        float destZ = target->GetPositionZ();
+                        bool cutPath = true;
+
+                        // Targets with an oversized combat reach can stand entirely over unwalkable space
+                        // (e.g. Kologarn) so pathing to their center fails or creates a shortcut into the void.
+                        // For these targets, path directly to the nearest point on the melee ring facing the caster.
+                        if (target->GetCombatReach() > NOMINAL_MELEE_RANGE)
+                        {
+                            target->GetNearPoint2D(m_caster, destX, destY, 0.0f, target->GetAngle(m_caster));
+                            destZ = target->GetPositionZ();
+                            m_caster->UpdateAllowedPositionZ(destX, destY, destZ);
+                            cutPath = false;
+                        }
+
                         // first try with raycast, if it fails fall back to normal path
-                        bool result = m_preGeneratedPath->CalculatePath(target->GetPositionX(), target->GetPositionY(), target->GetPositionZ(), false);
-                        if (m_preGeneratedPath->GetPathType() & PATHFIND_SHORT)
+                        bool result = m_preGeneratedPath->CalculatePath(destX, destY, destZ, false);
+                        bool pathFailed = !result || (m_preGeneratedPath->GetPathType() &
+                            (PATHFIND_NOPATH | PATHFIND_INCOMPLETE | PATHFIND_SHORT));
+
+                        if (pathFailed && !cutPath)
+                        {
+                            destX = target->GetPositionX();
+                            destY = target->GetPositionY();
+                            destZ = target->GetPositionZ();
+                            cutPath = true;
+
+                            result = m_preGeneratedPath->CalculatePath(destX, destY, destZ, false);
+                            pathFailed = !result || (m_preGeneratedPath->GetPathType() &
+                                (PATHFIND_NOPATH | PATHFIND_INCOMPLETE | PATHFIND_SHORT));
+                        }
+
+                        if (pathFailed)
                             return SPELL_FAILED_NOPATH;
-                        else if (!result || m_preGeneratedPath->GetPathType() & (PATHFIND_NOPATH | PATHFIND_INCOMPLETE))
-                            return SPELL_FAILED_NOPATH;
-                        else if (m_preGeneratedPath->IsInvalidDestinationZ(target)) // Check position z, if not in a straight line
+                        else if (cutPath && m_preGeneratedPath->IsInvalidDestinationZ(target))
                             return SPELL_FAILED_NOPATH;
 
-                        m_preGeneratedPath->ShortenPathUntilDist(G3D::Vector3(target->GetPositionX(), target->GetPositionY(), target->GetPositionZ()), objSize); // move back
+                        if (cutPath)
+                        {
+                            m_preGeneratedPath->ShortenPathUntilDist(
+                                G3D::Vector3(destX, destY, destZ), objSize);
+                        }
                     }
                     if (Player* player = m_caster->ToPlayer())
                         player->SetCanTeleport(true);


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests
- [x] AI tools were partially used in preparing this pull request.
   - Tools/models used: Claude / Gemini

### Problem & Blizzlike Mechanics Explained:

1. **Charge Pathing Against Oversized Targets Over Unwalkable Terrain:**
   In `Spell::CheckCast` for `SPELL_EFFECT_CHARGE`, `CalculatePath` was called directly against the target's center coordinates (`target->GetPositionX()`, `target->GetPositionY()`, `target->GetPositionZ()`). For bosses like Kologarn whose center is suspended over a bottomless chasm or unwalkable void, pathfinding to the center failed, returning `SPELL_FAILED_NOPATH` ("No path available") when standing normally on the ground.
   * *Fix:* Adopted the proven solution already used in `TargetedMovementGenerator.cpp` for pets and melee combat against oversized targets. For targets with `CombatReach > NOMINAL_MELEE_RANGE`, the arrival position is calculated on the melee perimeter facing the caster via `target->GetNearPoint2D()` with `m_caster->UpdateAllowedPositionZ()`. The charge path is then built directly to this contact point on the solid raid platform floor.

2. **Jumping Before Charging Caused Death in Chasm / Pit:**
   To work around "No path available", players previously had to do weird jump or jump-back tricks before casting Charge. When jumping, `_sourceUnit->IsFalling()` evaluated to true in `PathGenerator::BuildPolyPath`, building a direct shortcut ray through the air towards Kologarn's center in the void. Subsequent path shortening (`ShortenPathUntilDist`) ended at a point hanging over empty air, launching the player off the platform edge into the pit to their death.
   * *Fix:* Pathing directly to the near point on the melee boundary ensures the destination always rests on the solid platform. Players no longer need to perform any weird jumps or jump-backs to bypass path checks; Charge works normally while standing anywhere on the platform in range, and jumping will no longer shoot the character into the pit.

3. **Fallback & Standard Creature Safety:**
   Normal mobs (`CombatReach <= NOMINAL_MELEE_RANGE`) continue to use the standard center-pathing logic without any modification. If near-point pathing ever fails for an oversized target, it cleanly falls back to the original center-pathing logic to prevent any unintended regressions.

## Issues Addressed:

- Closes #26266

## SOURCE:

The changes have been validated through:
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
  - Retail WotLK video showing normal Charge mechanics on Kologarn: https://youtu.be/OaIWgbV3OSQ?si=J8FgS_HP1x49qUFO&t=1
  - Official retail encounter footage showing melee players charging and stopping cleanly at the platform edge.

## Tests Performed:

- [x] Built `worldserver` on Windows Release.
- [x] Tested in-game with Warrior Charge (`100`) against Kologarn.
- [x] Confirmed Charge works directly while standing normally on the platform floor without requiring any jump or jump-back tricks.
- [x] Confirmed Charge cleanly stops on the solid floor at the platform edge within melee range of Kologarn without falling into the chasm.
- [x] Confirmed jumping before casting Charge also safely stops at the platform edge instead of launching into the pit.
- [x] Confirmed standard Charge pathing on regular mobs (`CombatReach <= 5.0f`) remains unaffected.

## How to Test the Changes:

1. Create a level 80 Warrior character.
2. Teleport to Kologarn's platform: `.go xyz 1760 -24.4 448.8 603`
3. Target Kologarn and cast Charge (`.cast 100`) while standing normally on the ground (no jumping needed).
4. Verify the player charges across the floor and cleanly stops on the platform edge in melee range of Kologarn without "No path available" and without falling into the pit.
5. Jump and cast Charge: verify the character still safely stops on the platform edge instead of launching into the chasm.

## Known Issues and TODO List:

None.