### PR TITLE
fix(DB/Creature): Trapdoor Crawler no longer casts Poison while crowd controlled

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1788200219248898700.sql
+++ b/data/sql/updates/pending_db_world/rev_1788200219248898700.sql
@@ -1,0 +1,7 @@
+-- Trapdoor Crawler (28221): stop Poison cast from ignoring caster CC (remove SMARTCAST_TRIGGERED)
+DELETE FROM `smart_scripts` WHERE (`source_type` = 0 AND `entryorguid` = 28221);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(28221, 0, 0, 0, 1, 0, 100, 0, 20000, 30000, 20000, 30000, 0, 0, 11, 50981, 32, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Trapdoor Crawler - Out of Combat - Cast \'Burrow\''),
+(28221, 0, 1, 0, 23, 0, 100, 0, 50981, 1, 40000, 50000, 0, 0, 28, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Trapdoor Crawler - On Aura \'Burrow\' - Remove Aura \'null\''),
+(28221, 0, 2, 0, 4, 0, 100, 0, 0, 0, 0, 0, 0, 0, 28, 50981, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Trapdoor Crawler - On Aggro - Remove Aura \'Burrow\''),
+(28221, 0, 3, 0, 0, 0, 100, 0, 2000, 5000, 4000, 8000, 0, 0, 11, 11918, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 'Trapdoor Crawler - In Combat - Cast \'Poison\'');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Trapdoor Crawler (creature entry `28221`) could cast its "Poison" spell (`11918`) while crowd-controlled (stunned, feared, confused/polymorphed), confirmed with CC from multiple different classes.

Root cause: the `smart_scripts` "In Combat - Cast 'Poison'" action had `castFlags = 2` (`SMARTCAST_TRIGGERED`) with no explicit `triggerFlags`, which defaults to `TRIGGERED_FULL_MASK`. That mask includes `TRIGGERED_IGNORE_CASTER_AURAS`, which causes `Spell::CheckCasterAuras` to skip its stun/confuse/fleeing checks entirely (`preventionOnly` path), letting the cast go through regardless of the caster's CC state.

Fix: change `castFlags` to `0` on that action so the Poison cast is a normal (non-triggered) cast and is correctly blocked while the creature is stunned, feared, or confused, same as any other cast. No other rows/values for this creature were changed (the DB update rewrites the full `smart_scripts` block per repo convention, but only this one field's value differs).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code, Sonnet 5
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #27405

## SOURCE:
The changes have been validated through:
- [x] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Video demo after fix: https://www.dropbox.com/scl/fi/f48rrka5xgpg0jkppnfbw/TrapdoorCrawlerFix.mp4?rlkey=uuy0jq2pt6lwzscanbqtbkkki&st=rlqclxxr&dl=0

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing.

1. Apply the SQL update and start/restart worldserver so it imports the pending change.
2. Spawn or locate Trapdoor Crawler (entry `28221`), pull it into combat, and apply a stun/fear/confuse effect (e.g. Polymorph, a stun, a fear, a trap) from any class while it is casting or about to cast Poison.
3. Confirm it no longer casts Poison (`11918`) while the CC is active, and that it resumes casting Poison normally once the CC expires. Also confirm its Burrow/aggro behavior (unrelated rows, untouched by this fix) is unaffected.

## Known Issues and TODO List:

None

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.