### PR TITLE
fix(Core/Spells): fix first row skipped in LoadSpellInfoCustomAttributes

### DIFF
--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -3167,7 +3167,7 @@ void SpellMgr::LoadSpellInfoCustomAttributes()
 {
     uint32 const oldMSTime = getMSTime();
     uint32 const customAttrTime = getMSTime();
-    uint32 count;
+    uint32 count = 0;
 
     QueryResult result = WorldDatabase.Query("SELECT spell_id, attributes FROM spell_custom_attr");
 
@@ -3177,7 +3177,7 @@ void SpellMgr::LoadSpellInfoCustomAttributes()
     }
     else
     {
-        for (count = 0; result->NextRow(); ++count)
+        do
         {
             Field const* fields = result->Fetch();
 
@@ -3237,7 +3237,8 @@ void SpellMgr::LoadSpellInfoCustomAttributes()
             }
 
             spellInfo->AttributesCu |= attributes;
-        }
+            ++count;
+        } while (result->NextRow());
         LOG_INFO("server.loading", ">> Loaded {} spell custom attributes from DB in {} ms", count, GetMSTimeDiffToNow(customAttrTime));
     }
 


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests
- [x] AI tools were partially used in preparing this pull request.
   - Tools/models used: Claude / Gemini

### Problem & Blizzlike Mechanics Explained:

1. **Backstab Rank 1 Working When Facing Target ("Facestab"):**
   Backstab requires the caster to be behind the target (`SPELL_ATTR0_CU_REQ_CASTER_BEHIND_TARGET`), failing with `SPELL_FAILED_NOT_BEHIND` if cast from the front. While higher ranks worked correctly, Rank 1 (Spell ID 53) could be cast from any angle without facing restrictions.
   * *Fix:* Fixed `SpellMgr::LoadSpellInfoCustomAttributes()` where row 0 of the table was skipped on startup.

2. **First Row Skipped in `spell_custom_attr`:**
   In `SpellMgr.cpp`, custom attributes were loaded using `for (count = 0; result->NextRow(); ++count)`. Because `result->NextRow()` was evaluated before entering the loop, row 0 was skipped. The very first row in `spell_custom_attr` is Spell 53 (Backstab Rank 1), causing it to never receive `SPELL_ATTR0_CU_REQ_CASTER_BEHIND_TARGET`.
   * *Fix:* Changed the loop to standard `do { ... ++count; } while (result->NextRow());` so row 0 is loaded correctly.

## Issues Addressed:

- Closes #27273
- Closes chromiecraft/chromiecraft#10048

## SOURCE:

The changes have been validated through:
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
  - Backstab Rank 1 (Spell 53) tooltip: "Must be behind the target."
  - Table `spell_custom_attr`: `(53, 131072)` (`SPELL_ATTR0_CU_REQ_CASTER_BEHIND_TARGET`).
  - Issue reproduction video: https://dl.dropboxusercontent.com/scl/fi/iplzmps0ehdxljmv6ftsw/wow_GvuL7kXxMH.mp4?rlkey=08gek691z4qz99t06f3l80ayf&dl=0

## Tests Performed:

- [x] Built `worldserver` on Windows Release.
- [x] Verified `.spellinfo attributes 53` before fix: missing `SPELL_ATTR0_CU_REQ_CASTER_BEHIND_TARGET`.
- [x] Verified `.spellinfo attributes 53` after fix: `SPELL_ATTR0_CU_REQ_CASTER_BEHIND_TARGET` is present.
- [x] Tested in-game with Rogue using `.learn 53`:
  - From the front: blocked with *"You must be behind your target"*.
  - From behind: executes normally and awards combo point.
- [x] Verified higher ranks remain working.

## How to Test the Changes:

1. Create a Rogue character and equip a dagger.
2. Learn Backstab Rank 1: `.learn 53`
3. Attack an enemy mob while standing directly in front of it.
4. Attempt to cast Backstab: verify it fails with *"You must be behind your target"*.
5. Move behind the target and cast Backstab: verify it hits and awards a combo point.

## Known Issues and TODO List:

None.