### PR TITLE
fix(Core/Spells): Prevent shorter-duration equal auras from overwriting in exclusive highest groups

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -4612,6 +4612,18 @@ bool Unit::IsHighestExclusiveAuraEffect(SpellInfo const* spellInfo, AuraType aur
                 for (int32 i = 0; i < MAX_SPELL_EFFECTS; ++i)
                     diff += int32((auraEffectMask & (1 << i)) >> i) - int32((existingAurEff->GetBase()->GetEffectMask() & (1 << i)) >> i);
 
+            if (!diff && spellInfo->GetFirstRankSpell()->Id != existingAurEff->GetSpellInfo()->GetFirstRankSpell()->Id)
+            {
+                int32 newDuration = spellInfo->GetMaxDuration();
+                int32 existingDuration = existingAurEff->GetBase()->GetMaxDuration();
+                if (newDuration == -1 && existingDuration != -1)
+                    diff = 1;
+                else if (newDuration != -1 && existingDuration == -1)
+                    diff = -1;
+                else
+                    diff = newDuration - existingDuration;
+            }
+
             if (diff > 0)
             {
                 Aura const* base = existingAurEff->GetBase();


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests
- [x] AI tools were partially used in preparing this pull request.
   - Tools/models used: Claude / Gemini

### Problem & Blizzlike Mechanics Explained:

1. **Battle Shout Rank 10 Overwriting Blessing of Might Rank 10 Based Solely on Cast Order:**
   In retail WotLK 3.3.5a, Blessing of Might and Battle Shout belong to the exclusive flat Attack Power group (`SPELL_GROUP_STACK_RULE_EXCLUSIVE_HIGHEST`). At level 80, both untalented Rank 10 spells provide exactly 550 AP (and both fully talented provide 687 AP). Currently in AzerothCore, because both spells provide the exact same AP value (`diff == 0`), whichever spell is cast last unconditionally overwrites the other. Consequently, whenever a Warrior shouts Battle Shout (2-minute duration), it wipes off the Paladin's 10-minute Blessing of Might (or 30-minute Greater Blessing of Might), leaving the player with no AP buff at all once the 2-minute shout expires.
   * *Fix:* In `Unit::IsHighestExclusiveAuraEffect`, when two different spells in `SPELL_GROUP_STACK_RULE_EXCLUSIVE_HIGHEST` provide the exact same effect amount (`!diff`), duration is now used as the tiebreaker (`diff = newDuration - existingDuration`). A shorter-duration buff will no longer overwrite an equal-strength longer-duration buff, while a longer-duration buff (e.g. Blessing of Might) will cleanly overwrite a shorter-duration shout.

2. **Tiebreaking & Stacking Preservation:**
   When amounts are unequal, the higher-potency buff still wins as intended (e.g. a 5/5 Commanding Presence Battle Shout providing 687 AP will correctly overwrite an untalented 550 AP Blessing of Might). Furthermore, refreshing the same spell (e.g. a Warrior refreshing their own Battle Shout, or a Paladin refreshing their Blessing) does not trigger the cross-spell tiebreaker and continues to refresh normally.
   * *Fix:* Restricted the duration tiebreaker to compare only across different spells (`spellInfo->GetFirstRankSpell()->Id != existingAurEff->GetSpellInfo()->GetFirstRankSpell()->Id`), preserving normal refresh mechanics for identical spells while protecting long-term blessings and raid buffs across the core.

## Issues Addressed:

- Closes #26909
- Closes chromiecraft/chromiecraft#9966

## SOURCE:

The changes have been validated through:
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
  - Blizzard Patch 3.0.3 Patch Notes: *"Blessing of Might: Rank 8 points increased slightly to prevent from being overwritten by Battle Shout 8 that has a shorter duration (also applies to Greater Blessing of Might 3.)"*
  - Official retail mechanic design demonstrating that shorter-duration buffs must not wipe out equal-potency longer-duration blessings.
  - Video evidence from issue report: https://dl.dropboxusercontent.com/scl/fi/32i2skyhnoguepwcqfipb/aM6AEtMEwu.mp4?rlkey=pya331vupmqxhq1se92d29w2l&dl=0

## Tests Performed:

- [x] Built `worldserver` on Windows Release with 0 errors/warnings.
- [x] Verified casting Blessing of Might Rank 10 (10 min / 550 AP) followed by Battle Shout Rank 10 (2 min / 550 AP): confirmed Blessing of Might is preserved and NOT overwritten.
- [x] Verified casting Battle Shout Rank 10 followed by Blessing of Might Rank 10: confirmed Blessing of Might overwrites the shorter-duration Battle Shout as expected.
- [x] Verified a more powerful talented Battle Shout (687 AP with 5/5 Commanding Presence) still overwrites an untalented Blessing of Might (550 AP).
- [x] Verified refreshing the same spell (Battle Shout on Battle Shout, or Blessing of Might on Blessing of Might) refreshes the aura duration without issue.

## How to Test the Changes:

1. Create a level 80 Paladin and a level 80 Warrior.
2. Cast Blessing of Might Rank 10 (`.cast 48932`) or Greater Blessing of Might Rank 2 (`.cast 48934`) on the Warrior.
3. As the Warrior, cast Battle Shout Rank 10 (`.cast 47436`) on self.
   - **Before fix:** Blessing of Might was removed and replaced by Battle Shout.
   - **After fix:** Blessing of Might remains active on the Warrior; the shorter-duration Battle Shout does not wipe it out.
4. Let Blessing of Might expire or remove it, cast Battle Shout first, then cast Blessing of Might on the Warrior:
   - **Result:** The longer-duration Blessing of Might replaces the shorter-duration Battle Shout.
5. Learn 5/5 Commanding Presence on the Warrior (`.learn 12861`) and test casting Battle Shout against untalented Blessing of Might:
   - **Result:** The more powerful 687 AP Battle Shout correctly overwrites the weaker 550 AP Blessing of Might.

## Known Issues and TODO List:

None.