### PR TITLE
fix(Core/Creature): Prevent trainers from offering lower ranks of learned skills and spells

### DIFF
--- a/src/server/game/Entities/Creature/Trainer.cpp
+++ b/src/server/game/Entities/Creature/Trainer.cpp
@@ -153,8 +153,49 @@ namespace Trainer
 
     SpellState Trainer::GetSpellState(Player const* player, Spell const* trainerSpell) const
     {
-        if (player->HasSpell(trainerSpell->SpellId))
+        auto hasSpellOrHigherRank = [player](uint32 spellId) -> bool
+        {
+            if (player->HasSpell(spellId))
+                return true;
+
+            while ((spellId = sSpellMgr->GetNextSpellInChain(spellId)))
+                if (player->HasSpell(spellId))
+                    return true;
+
+            return false;
+        };
+
+        auto isSkillRankKnown = [player](uint32 spellId) -> bool
+        {
+            if (SpellLearnSkillNode const* spellLearnSkill = sSpellMgr->GetSpellLearnSkill(spellId))
+            {
+                if (player->HasSkill(spellLearnSkill->skill))
+                {
+                    if (spellLearnSkill->maxvalue > 0 &&
+                        player->GetPureMaxSkillValue(spellLearnSkill->skill) >= spellLearnSkill->maxvalue)
+                        return true;
+                    if (spellLearnSkill->step > 0 &&
+                        player->GetSkillStep(spellLearnSkill->skill) >= spellLearnSkill->step)
+                        return true;
+                }
+            }
+            return false;
+        };
+
+        if (hasSpellOrHigherRank(trainerSpell->SpellId) || isSkillRankKnown(trainerSpell->SpellId))
             return SpellState::Known;
+
+        SpellInfo const* trainerSpellInfo = sSpellMgr->AssertSpellInfo(trainerSpell->SpellId);
+
+        for (SpellEffectInfo const& eff : trainerSpellInfo->GetEffects())
+        {
+            if (eff.IsEffect(SPELL_EFFECT_SKILL_STEP))
+            {
+                uint32 skillId = eff.MiscValue;
+                if (player->HasSkill(skillId) && player->GetSkillStep(skillId) > uint32(eff.CalcValue()))
+                    return SpellState::Known;
+            }
+        }
 
         // check race/class requirement
         if (!player->IsSpellFitByClassAndRace(trainerSpell->SpellId))
@@ -165,7 +206,7 @@ namespace Trainer
             return SpellState::Unavailable;
 
         for (int32 reqAbility : trainerSpell->ReqAbility)
-            if (reqAbility && !player->HasSpell(reqAbility))
+            if (reqAbility && !hasSpellOrHigherRank(reqAbility) && !isSkillRankKnown(reqAbility))
                 return SpellState::Unavailable;
 
         // check level requirement
@@ -175,24 +216,24 @@ namespace Trainer
         // check ranks
         bool hasLearnSpellEffect = false;
         bool knowsAllLearnedSpells = true;
-        for (SpellEffectInfo const& spellEffectInfo : sSpellMgr->AssertSpellInfo(trainerSpell->SpellId)->GetEffects())
+        for (SpellEffectInfo const& spellEffectInfo : trainerSpellInfo->GetEffects())
         {
             if (!spellEffectInfo.IsEffect(SPELL_EFFECT_LEARN_SPELL))
                 continue;
 
             hasLearnSpellEffect = true;
-            if (!player->HasSpell(spellEffectInfo.TriggerSpell))
+            if (!hasSpellOrHigherRank(spellEffectInfo.TriggerSpell) && !isSkillRankKnown(spellEffectInfo.TriggerSpell))
                 knowsAllLearnedSpells = false;
 
             if (uint32 previousRankSpellId = sSpellMgr->GetPrevSpellInChain(spellEffectInfo.TriggerSpell))
-                if (!player->HasSpell(previousRankSpellId))
+                if (!hasSpellOrHigherRank(previousRankSpellId) && !isSkillRankKnown(previousRankSpellId))
                     return SpellState::Unavailable;
         }
 
         if (!hasLearnSpellEffect)
         {
             if (uint32 previousRankSpellId = sSpellMgr->GetPrevSpellInChain(trainerSpell->SpellId))
-                if (!player->HasSpell(previousRankSpellId))
+                if (!hasSpellOrHigherRank(previousRankSpellId) && !isSkillRankKnown(previousRankSpellId))
                     return SpellState::Unavailable;
         }
         else if (knowsAllLearnedSpells)

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -12173,6 +12173,11 @@ void Player::LearnDefaultSkill(uint32 skillId, uint16 rank)
             }
 
             SetSkill(skillId, rank, skillValue, maxValue);
+
+            std::vector<uint32> rankSpells = sSpellMgr->GetSkillRankSpells(skillId);
+            for (size_t i = 0; i < rankSpells.size() && i < rank; ++i)
+                learnSpell(rankSpells[i], false);
+
             break;
         }
         default:


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests
- [x] AI tools were partially used in preparing this pull request.
   - Tools/models used: Claude / Gemini

### Problem & Blizzlike Mechanics Explained:

1. **Trainers Offering Apprentice Ranks to Characters with Higher Ranks/Skills:**
   In retail WotLK, Death Knights begin with Journeyman Riding (via quest reward spell 52382) and Artisan First Aid (270/300 via `playercreateinfo_skills`). However, in AzerothCore, `Trainer::GetSpellState` only checked if the player possessed the exact `SpellId` offered (`player->HasSpell(trainerSpell->SpellId)`). Because Death Knights never explicitly learned Rank 1 Apprentice Riding (spell 33388) or Apprentice First Aid (spell 3279 / 3273), trainers like Hira Snowdawn (Cold Weather Flying Trainer in Dalaran) and First Aid trainers offered Apprentice Riding and Apprentice First Aid under "Available" for purchase, despite the player already having higher ranks (e.g. Journeyman/Artisan Riding or Artisan First Aid).
   * *Fix:* Updated `Trainer::GetSpellState` to recognize when a player already possesses a higher rank in the spell chain (`sSpellMgr->GetNextSpellInChain`) or already has a skill level/step equal to or exceeding the tier granted by the trainer spell (`sSpellMgr->GetSpellLearnSkill` / `SPELL_EFFECT_SKILL_STEP`). When higher ranks or skills are already present, the spell is correctly evaluated as `SpellState::Known`, hiding it from the "Available" list.

2. **Default Rank Spells Missing for Starting Profession/Rank Skills:**
   When `Player::LearnDefaultSkill` initialized skills with a ranked step (such as Death Knights starting with First Aid rank 4 / Artisan at level 55), it only invoked `SetSkill` to set the numerical skill value and step, but never learned the associated proficiency spells up to that rank (e.g. Apprentice First Aid 3273, Journeyman 3274, Expert 7924, Artisan 10846). Consequently, newly created Death Knights lacked the base First Aid ability button in their spellbook and had no rank spells recorded in `m_spells`.
   * *Fix:* In `Player::LearnDefaultSkill`, after setting the skill step and values for `SKILL_RANGE_RANK`, the player now learns all rank spells up to the granted rank via `sSpellMgr->GetSkillRankSpells(skillId)`.

## Issues Addressed:

- Closes #27196
- Closes chromiecraft/chromiecraft#10030

## SOURCE:

The changes have been validated through:
- [x] Official WotLK Retail behavior:
  - Death Knights starting at level 55 with 270 First Aid automatically possess all prior trainer proficiency ranks and abilities.
  - Trainers do not display already-superseded lower ranks (such as Apprentice Riding or Apprentice First Aid) as available for purchase to players who already possess higher skill ranks or higher chain spells.
  - Issue report screenshots and triage verification: https://github.com/azerothcore/azerothcore-wotlk/issues/27196

## Tests Performed:

- [x] Built `worldserver` on Windows Release with 0 errors/warnings.
- [x] Created a Death Knight and verified:
  - Interacted with Cold Weather Flying Trainer Hira Snowdawn (creature 31238) in Dalaran: Apprentice Riding is no longer offered under "Available".
  - Interacted with First Aid Trainers: Apprentice, Journeyman, Expert, and Artisan First Aid are no longer offered under "Available".
  - Verified First Aid ability and rank spells are correctly learned in the spellbook.
- [x] Verified normal non-DK characters (e.g. level 20 character learning Apprentice Riding or level 1 character learning First Aid) still see Apprentice ranks available and can train them normally.
- [x] Verified unlearning a primary profession correctly resets trainer availability to offer Apprentice again.

## How to Test the Changes:

1. Create a Death Knight character and level to 80 (`.level 80`).
2. Learn class spells (`.learn all my class`).
3. Teleport to Hira Snowdawn in Dalaran (`.go c i 31238`) and open the trainer dialogue:
   - **Before fix:** "Apprentice Riding" appeared under "Available" for 4g.
   - **After fix:** "Apprentice Riding" is not shown under "Available" (marked as "Already known").
4. Visit any First Aid trainer (e.g. Olisarra the Kind in Dalaran, `.go c i 28706`):
   - **Before fix:** "Apprentice First Aid" was offered under "Available".
   - **After fix:** "Apprentice First Aid" is not shown under "Available" (marked as "Already known").
5. Create a level 1 character of another class (e.g. Human Warrior), visit a First Aid trainer:
   - **Result:** Apprentice First Aid is shown under "Available" and can be trained normally.

## Known Issues and TODO List:

None.