### PR TITLE
fix(Scripts/Spells): Apply Frost Fever from Chains of Ice to targets immune to slow

### DIFF
--- a/src/server/scripts/Spells/spell_dk.cpp
+++ b/src/server/scripts/Spells/spell_dk.cpp
@@ -425,8 +425,11 @@ class spell_dk_chains_of_ice : public SpellScript
         {
             std::list<TargetInfo> const* targetsInfo = GetSpell()->GetUniqueTargetInfo();
             for (std::list<TargetInfo>::const_iterator ihit = targetsInfo->begin(); ihit != targetsInfo->end(); ++ihit)
-                if (ihit->missCondition == SPELL_MISS_NONE && ihit->targetGUID == target->GetGUID())
-                    GetCaster()->CastSpell(target, 55095 /*SPELL_FROST_FEVER*/, true);
+                if (ihit->targetGUID == target->GetGUID() &&
+                    (ihit->missCondition == SPELL_MISS_NONE ||
+                     ihit->missCondition == SPELL_MISS_IMMUNE ||
+                     ihit->missCondition == SPELL_MISS_IMMUNE2))
+                    GetCaster()->CastSpell(target, SPELL_DK_FROST_FEVER, true);
         }
     }
 


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
- [ ] Core (units, players, creatures, game systems).
- [x] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests
- [x] AI tools were partially used in preparing this pull request.
   - Tools/models used: Claude / Gemini

### Problem & Blizzlike Mechanics Explained:

1. **Chains of Ice Not Applying Frost Fever to Slow-Immune Targets:**
   Since Patch 3.3.3 (and hotfix 2009-12-14), Death Knight's *Chains of Ice* innately applies the *Frost Fever* disease debuff (spell 55095) to the target. In retail WotLK, Frost Fever is a disease and is not a movement-impairing effect; therefore, targets immune to movement speed slows (such as a Paladin with *Hand of Freedom*, a Hunter with *Master's Call*, Wintergrasp Demolishers/vehicles, or dungeon/raid bosses) are immune to the snare component of Chains of Ice, but **still receive Frost Fever**.
   In AzerothCore, `spell_dk_chains_of_ice::HandleAfterCast` checked `if (ihit->missCondition == SPELL_MISS_NONE && ihit->targetGUID == target->GetGUID())`. Because *Chains of Ice* has `SPELL_ATTR4_NO_PARTIAL_IMMUNITY`, when a target is immune to the snare effect (Effect 0, `MECHANIC_SNARE`), the spell's hit check assigns `ihit->missCondition = SPELL_MISS_IMMUNE`. Consequently, `HandleAfterCast` aborted without triggering `GetCaster()->CastSpell(target, SPELL_DK_FROST_FEVER, true)`, preventing Frost Fever from being applied to any slow-immune target.
   * *Fix:* Updated `spell_dk_chains_of_ice::HandleAfterCast` so that targets receiving `SPELL_MISS_IMMUNE` or `SPELL_MISS_IMMUNE2` (due to the snare component) are still processed for the secondary *Frost Fever* application. When `CastSpell` is called, standard target immunity checks for Frost Fever still apply naturally, ensuring that full-immunity effects (such as *Divine Shield*, *Ice Block*, *Anti-Magic Shell*, or *Cyclone*) continue to block Frost Fever as intended, while snare-only immunities (like *Hand of Freedom* or vehicle immunities) allow Frost Fever to land.

## Issues Addressed:

- Closes #26886
- Closes chromiecraft/chromiecraft#9958

## SOURCE:

The changes have been validated through:
- [x] Official Patch Notes:
  - Hotfix (2009-12-14) & Patch 3.3.3 (2010-03-23): *"Chains of Ice: The ability now innately applies Frost Fever to a target."* (https://wowpedia.fandom.com/wiki/Chains_of_Ice)
  - *Hand of Freedom* grants immunity to movement-impairing effects (snares/roots), not diseases.
- [x] Retail WotLK behavior and issue triage verification videos:
  - Chains of Ice vs Demolisher: https://dl.dropboxusercontent.com/scl/fi/xmtndfookc1uy081w55ch/mtC50AeMQ3.mp4?rlkey=rzncff3opepe4ie4ul1jdinlf&dl=0
  - Chains of Ice vs Hand of Freedom: https://dl.dropboxusercontent.com/scl/fi/lribcerblf2im25r26f56/KdMo3sw5Of.mp4?rlkey=c1tsnprobty1emqkwtt6wka0g&dl=0

## Tests Performed:

- [x] Built `worldserver` with 0 errors/warnings.
- [x] Cast *Chains of Ice* against a target with *Hand of Freedom*:
  - Target shows "Immune" to the movement slow.
  - *Frost Fever* debuff is successfully applied and ticks normally.
- [x] Cast *Chains of Ice* against a Wintergrasp vehicle (Demolisher):
  - Vehicle is immune to the movement slow.
  - *Frost Fever* debuff is successfully applied.
- [x] Cast *Chains of Ice* against targets with full magic/damage immunity (*Divine Shield*, *Anti-Magic Shell*):
  - Verified neither the slow nor *Frost Fever* are applied.
- [x] Verified missed/resisted/reflected casts do not apply Frost Fever.

## How to Test the Changes:

1. Create a Level 80 Death Knight and a Level 80 Paladin of opposing factions.
2. On the Paladin, cast *Hand of Freedom* (`.cast 1044`).
3. With the Death Knight, cast *Chains of Ice* (`.cast 45524`) on the Paladin:
   - **Before fix:** Target showed "Immune" and no debuff was applied.
   - **After fix:** Target shows "Immune" to the slow, but *Frost Fever* debuff is applied to the Paladin.
4. Mount a Demolisher or target a snare-immune boss creature, and cast *Chains of Ice*:
   - **Result:** *Frost Fever* is applied.
5. Cast *Chains of Ice* on a Paladin with *Divine Shield* (`.cast 642`):
   - **Result:** Immune, no *Frost Fever* is applied.

## Known Issues and TODO List:

None.