### PR TITLE
fix(Core/Spells): Fix autocast conditions and stacking for hunter pet abilities

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -7044,7 +7044,23 @@ bool Spell::CanAutoCast(Unit* target)
         for (Unit::AuraEffectList::const_iterator auraIt = auras.begin(); auraIt != auras.end(); ++auraIt)
         {
             if (GetSpellInfo()->Id == (*auraIt)->GetSpellInfo()->Id)
+            {
+                // Direct-damage attacks (e.g. Acid Spit, Sting, Monstrous Bite) deal primary damage
+                // on each hit and should not be prevented from autocasting by their own debuff.
+                if (m_spellInfo->HasEffect(SPELL_EFFECT_SCHOOL_DAMAGE) ||
+                    m_spellInfo->HasEffect(SPELL_EFFECT_WEAPON_DAMAGE) ||
+                    m_spellInfo->HasEffect(SPELL_EFFECT_WEAPON_DAMAGE_NOSCHOOL) ||
+                    m_spellInfo->HasEffect(SPELL_EFFECT_NORMALIZED_WEAPON_DMG) ||
+                    m_spellInfo->HasEffect(SPELL_EFFECT_WEAPON_PERCENT_DAMAGE))
+                    continue;
+
+                // Stacking auras should continue to be cast until maximum stacks are reached
+                if (GetSpellInfo()->StackAmount > 1 &&
+                    (*auraIt)->GetBase()->GetStackAmount() < GetSpellInfo()->StackAmount)
+                    continue;
+
                 return false;
+            }
 
             switch (sSpellMgr->CheckSpellGroupStackRules(GetSpellInfo(), (*auraIt)->GetSpellInfo()))
             {
@@ -7054,7 +7070,7 @@ bool Spell::CanAutoCast(Unit* target)
                     if (GetCaster() == (*auraIt)->GetCaster())
                         return false;
                     break;
-                case SPELL_GROUP_STACK_RULE_EXCLUSIVE_SAME_EFFECT: // this one has further checks, but i don't think they're necessary for autocast logic
+                case SPELL_GROUP_STACK_RULE_EXCLUSIVE_SAME_EFFECT:
                 case SPELL_GROUP_STACK_RULE_EXCLUSIVE_HIGHEST:
                     if (abs(spellEffectInfo.BasePoints) <= abs((*auraIt)->GetAmount()))
                         return false;
@@ -7066,13 +7082,61 @@ bool Spell::CanAutoCast(Unit* target)
         }
     }
 
+    // Special autocast conditions for pet abilities
+    if (m_caster->IsPet() || m_caster->HasUnitTypeMask(UNIT_MASK_MINION))
+    {
+        uint32 const firstRankSpellId = m_spellInfo->GetFirstRankSpell()->Id;
+        switch (firstRankSpellId)
+        {
+            case 26064: // Shell Shield (Turtle) - only at or below 50% health
+            case 53426: // Lick Your Wounds (Crocolisk) - only at or below 50% health
+                if (m_caster->GetHealthPct() > 50.0f)
+                    return false;
+                break;
+            case 50318: // Serenity Dust (Moth) - only at or below 75% health
+                if (m_caster->GetHealthPct() > 75.0f)
+                    return false;
+                break;
+            case 53480: // Roar of Sacrifice - target must be in combat and at or below 30% health
+                if (!target->IsInCombat() || target->GetHealthPct() > 30.0f)
+                    return false;
+                break;
+            case 53517: // Roar of Recovery - target must have mana and be at or below 20% mana
+                if (target->getPowerType() != POWER_MANA || target->GetPowerPct(POWER_MANA) > 20.0f)
+                    return false;
+                break;
+            case 1742:
+                // Cower - redesigned in 3.3.0+ to a defensive CD with 50% speed penalty; does not autocast
+                return false;
+            case 23145: // Dive
+            case 23146: // Dive (Rank 1 alternative)
+            case 61684: // Dash
+            {
+                // Only autocast to chase target if outside melee range
+                Unit const* chaseTarget = m_caster->GetVictim();
+                if (!chaseTarget)
+                    chaseTarget = m_caster->getAttackerForHelper();
+                if (!chaseTarget)
+                    if (Unit const* owner = m_caster->GetCharmerOrOwner())
+                        chaseTarget = owner->getAttackerForHelper();
+
+                if (!chaseTarget || m_caster->IsWithinMeleeRange(chaseTarget))
+                    return false;
+                break;
+            }
+            default:
+                break;
+        }
+    }
+
     SpellCastResult result = CheckPetCast(target);
 
     if (result == SPELL_CAST_OK || result == SPELL_FAILED_UNIT_NOT_INFRONT)
     {
         SelectSpellTargets();
         //check if among target units, our WANTED target is as well (->only self cast spells return false)
-        for (std::list<TargetInfo>::iterator ihit = m_UniqueTargetInfo.begin(); ihit != m_UniqueTargetInfo.end(); ++ihit)
+        for (std::list<TargetInfo>::iterator ihit = m_UniqueTargetInfo.begin();
+             ihit != m_UniqueTargetInfo.end(); ++ihit)
             if (ihit->targetGUID == targetguid)
                 return true;
     }


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests
- [x] AI tools were partially used in preparing this pull request.
   - Tools/models used: Claude / Gemini

### Problem & Blizzlike Mechanics Explained:

1. **Defensive & Utility Pet Abilities Autocasting at Full Health/Mana:**
   In AzerothCore, `PetAI::UpdateAI` triggers positive abilities on a pet's autocast bar via `Spell::CanAutoCast(Unit* target)`. Previously, `CanAutoCast` only verified line of sight, range, cooldown, and aura presence, but lacked any health, resource, or distance threshold checks for pet abilities:
   - **Shell Shield (26064)** (Turtle): Turtles would cast Shell Shield immediately upon entering combat at 100% health, wasting a 1-minute defensive cooldown. In retail WotLK, Shell Shield on autocast triggers only when the pet falls to or below 50% health.
   - **Lick Your Wounds (53426)** (Crocolisk): Pets would channel this self-heal immediately at 100% health instead of reserving it for low health ($\le 50\%$).
   - **Serenity Dust (50318)** (Moth): Moths would cast Serenity Dust at 100% health instead of waiting until losing a quarter of their health ($\le 75\%$).
   - **Roar of Sacrifice (53480)**: Pets would cast this on the hunter/ally at full health and even out of combat. In retail, it only autocasts on a friendly target who is in combat and has low health ($\le 30\%$).
   - **Roar of Recovery (53517)**: Pets would cast this when the hunter was at 100% mana. In retail, it only autocasts when the hunter has $\le 20\%$ mana.
   - **Dash (61684) / Dive (23145)**: Pets would pop their sprint on cooldown even while already standing in melee contact attacking their victim. In retail, pets only autocast sprint when chasing a target that is outside melee reach.
   - **Cower (1742)**: In Patch 3.3.0, Cower was redesigned from a threat reduction tool to a defensive cooldown that imposes a 50% movement speed penalty. In retail 3.3.0+, Cower was never triggered by pet autocast. In AzerothCore, it was being cast on cooldown at 100% health, constantly slowing the pet down.

2. **Offensive & Stacking Pet Attacks Blocked by Existing Debuffs:**
   In `Spell::CanAutoCast`, if the target already had the spell's aura (`GetSpellInfo()->Id == (*auraIt)->GetSpellInfo()->Id`), `CanAutoCast` returned `false`. This caused major bugs for primary DPS and stacking pet attacks:
   - **Acid Spit (55749)** (Worm): Deals direct Nature damage and applies an armor-reducing debuff that stacks up to 2 times. Because the aura check returned `false` after the first application, the worm would never cast it to reach 2 stacks, and would wait 30 seconds for the debuff to completely expire before attacking with it again.
   - **Sting (56631)** (Wasp) and **Monstrous Bite (54680)** (Devilsaur): Damaging attacks on short cooldowns were prevented from autocasting while their debuffs were active on the target, severely degrading pet DPS.
   - *Fix:* In `Spell::CanAutoCast`, spells dealing direct damage (`SPELL_EFFECT_SCHOOL_DAMAGE`, weapon damage, etc.) bypass the duplicate aura prevention check, allowing pets to use their signature attacks on cooldown. Stacking auras are also permitted to continue autocasting until maximum stacks (`StackAmount`) are reached.

*Note: Manual player casting via action bar or `/cast` macros is unaffected as it does not pass through `CanAutoCast`.*

## Issues Addressed:

- Closes #26555
- Closes chromiecraft/chromiecraft#9108

## SOURCE:

The changes have been validated through:
- [x] Official Patch Notes:
  - Patch 3.3.0: *"Cower: This ability has been redesigned. It no longer affects threat, and instead reduces damage taken by the pet by 40% for 6 sec with a 45 sec cooldown. While cowering, the pet's movement speed is reduced by 50%."*
- [x] Retail WotLK behavior and triage verification:
  - Turtle Shell Shield autocasting only at or below 50% health: https://youtu.be/yvmT62otyPs?t=253
  - Worm casting Acid Spit on cooldown to stack regardless of debuff presence: https://www.youtube.com/watch?v=MECrV8NbQgo
  - Dash/Dive and Cower behavior in WotLK PvP video evidence: https://www.youtube.com/watch?v=_BWeGKTnUUg
  - Wowhead comments (WotLK 3.3.5):
    - [Roar of Sacrifice](https://www.wowhead.com/wotlk/spell=53480/roar-of-sacrifice#comments): *"It will use Roar of Sacrifice when you are low HP if it is on auto... ~30% health, give or take."*
    - [Roar of Recovery](https://www.wowhead.com/wotlk/spell=53517/roar-of-recovery#comments): *"If set to autocast, when does it cast? Edit: at 20% mana"*
    - [Lick Your Wounds](https://www.wowhead.com/wotlk/spell=53426/lick-your-wounds#comments): *"Having Lick Your Wounds on autocast will make your pet auto-cast it at or below 50% HP."*
    - [Serenity Dust](https://www.wowhead.com/wotlk/spell=52016/serenity-dust#comments): *"Pet uses this automatically when he loses about a quarter of his life."*

## Tests Performed:

- [x] Built `worldserver` with 0 errors / 0 warnings.
- [x] Tested Turtle Shell Shield on autocast:
  - At 100% pet HP: Shell Shield is not cast.
  - At $\le 50\%$ pet HP: Shell Shield triggers automatically.
- [x] Tested Roar of Sacrifice on autocast:
  - At $> 30\%$ hunter HP: Roar of Sacrifice is not cast.
  - In combat at $\le 30\%$ hunter HP: Roar of Sacrifice triggers automatically.
- [x] Tested Roar of Recovery on autocast:
  - At full mana: Roar of Recovery is not cast.
  - At $\le 20\%$ hunter mana: Roar of Recovery triggers automatically.
- [x] Tested Dash / Dive on autocast:
  - In melee range hitting target: Sprint is not cast.
  - Ordered to attack distant target: Pet casts sprint to close distance.
- [x] Tested Acid Spit, Sting, and Monstrous Bite on autocast:
  - Abilities are used on cooldown as damage attacks and stack debuffs properly without waiting for debuffs to expire.
- [x] Verified manual button/macro activation remains usable at any health or mana percentage.

## How to Test the Changes:

1. Create a Level 70–80 Hunter (`.learn all my class`).
2. **Shell Shield:**
   - Tame a turtle (`.go c i 25482`). Ensure Shell Shield is toggled to autocast.
   - Send it to attack a target while at 100% HP $\rightarrow$ Shell Shield is **not** cast.
   - Allow the turtle to drop to $\le 50\%$ HP $\rightarrow$ Shell Shield casts automatically.
3. **Roar of Sacrifice:**
   - With a Tenacity pet with Roar of Sacrifice on autocast, engage combat.
   - At full HP $\rightarrow$ not cast.
   - Take damage until HP drops below 30% $\rightarrow$ Roar of Sacrifice is cast on you.
4. **Roar of Recovery:**
   - With a Cunning pet with Roar of Recovery on autocast, spend mana until below 20% $\rightarrow$ Roar of Recovery casts automatically.
5. **Dash / Dive:**
   - With pet attacking in melee contact $\rightarrow$ Dash is not used.
   - Target a mob 25 yards away and send pet $\rightarrow$ Dash is cast to chase.
6. **Acid Spit:**
   - Tame a worm and attack a mob with Acid Spit on autocast $\rightarrow$ verify it casts on cooldown and reaches 2 stacks instead of waiting 30s.

## Known Issues and TODO List:

None.