### PR TITLE
fix(Scripts/Spells): Prevent Combustion proc stacks from getting stuck without Combustion active

### DIFF
--- a/src/server/scripts/Spells/spell_mage.cpp
+++ b/src/server/scripts/Spells/spell_mage.cpp
@@ -1060,6 +1060,8 @@ class spell_mage_combustion : public AuraScript
 {
     PrepareAuraScript(spell_mage_combustion);
 
+    std::shared_ptr<bool> _aliveToken = std::make_shared<bool>(true);
+
     bool Validate(SpellInfo const* /*spellInfo*/) override
     {
         return ValidateSpellInfo({ SPELL_MAGE_COMBUSTION_PROC });
@@ -1075,13 +1077,20 @@ class spell_mage_combustion : public AuraScript
             // invalidate the live iterator (aura containers are flat_multimaps).
             Unit* actor = eventInfo.GetActor();
             ObjectGuid actorGuid = actor->GetGUID();
-            actor->m_Events.AddEventAtOffset([actorGuid]()
+            std::weak_ptr<bool> token = _aliveToken;
+            actor->m_Events.AddEventAtOffset([actorGuid, token]()
             {
-                if (Player* actor = ObjectAccessor::FindPlayer(actorGuid))
+                if (auto locked = token.lock())
                 {
-                    if (actor->HasAura(SPELL_MAGE_COMBUSTION))
+                    if (*locked)
                     {
-                        actor->CastSpell(static_cast<Unit*>(nullptr), SPELL_MAGE_COMBUSTION_PROC, true);
+                        if (Player* actor = ObjectAccessor::FindPlayer(actorGuid))
+                        {
+                            if (actor->HasAura(SPELL_MAGE_COMBUSTION))
+                            {
+                                actor->CastSpell(static_cast<Unit*>(nullptr), SPELL_MAGE_COMBUSTION_PROC, true);
+                            }
+                        }
                     }
                 }
             }, 1ms);
@@ -1093,6 +1102,7 @@ class spell_mage_combustion : public AuraScript
 
     void OnRemove(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
     {
+        *_aliveToken = false;
         GetTarget()->RemoveAurasDueToSpell(SPELL_MAGE_COMBUSTION_PROC);
     }
 

--- a/src/server/scripts/Spells/spell_mage.cpp
+++ b/src/server/scripts/Spells/spell_mage.cpp
@@ -415,10 +415,18 @@ class spell_mage_glyph_of_eternal_water : public AuraScript
     {
         PrepareAuraScript(spell_mage_combustion_proc);
 
-    bool Validate(SpellInfo const* /*spellInfo*/) override
-    {
-        return ValidateSpellInfo({ SPELL_MAGE_COMBUSTION });
-    }
+        bool Validate(SpellInfo const* /*spellInfo*/) override
+        {
+            return ValidateSpellInfo({ SPELL_MAGE_COMBUSTION });
+        }
+
+        void OnApply(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
+        {
+            if (!GetTarget()->HasAura(SPELL_MAGE_COMBUSTION))
+            {
+                GetAura()->Remove();
+            }
+        }
 
         void OnRemove(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
         {
@@ -427,7 +435,10 @@ class spell_mage_glyph_of_eternal_water : public AuraScript
 
         void Register() override
         {
-            AfterEffectRemove += AuraEffectRemoveFn(spell_mage_combustion_proc::OnRemove, EFFECT_0, SPELL_AURA_ADD_FLAT_MODIFIER, AURA_EFFECT_HANDLE_REAL);
+            AfterEffectApply += AuraEffectApplyFn(spell_mage_combustion_proc::OnApply, EFFECT_0,
+                SPELL_AURA_ADD_FLAT_MODIFIER, AURA_EFFECT_HANDLE_REAL);
+            AfterEffectRemove += AuraEffectRemoveFn(spell_mage_combustion_proc::OnRemove, EFFECT_0,
+                SPELL_AURA_ADD_FLAT_MODIFIER, AURA_EFFECT_HANDLE_REAL);
         }
     };
 
@@ -1065,7 +1076,10 @@ class spell_mage_combustion : public AuraScript
             Unit* actor = eventInfo.GetActor();
             actor->m_Events.AddEventAtOffset([actor]()
             {
-                actor->CastSpell(static_cast<Unit*>(nullptr), SPELL_MAGE_COMBUSTION_PROC, true);
+                if (actor->HasAura(SPELL_MAGE_COMBUSTION))
+                {
+                    actor->CastSpell(static_cast<Unit*>(nullptr), SPELL_MAGE_COMBUSTION_PROC, true);
+                }
             }, 1ms);
             return false;
         }
@@ -1073,9 +1087,16 @@ class spell_mage_combustion : public AuraScript
         return true;
     }
 
+    void OnRemove(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
+    {
+        GetTarget()->RemoveAurasDueToSpell(SPELL_MAGE_COMBUSTION_PROC);
+    }
+
     void Register() override
     {
         DoCheckProc += AuraCheckProcFn(spell_mage_combustion::CheckProc);
+        AfterEffectRemove += AuraEffectRemoveFn(spell_mage_combustion::OnRemove, EFFECT_0,
+            SPELL_AURA_DUMMY, AURA_EFFECT_HANDLE_REAL);
     }
 };
 

--- a/src/server/scripts/Spells/spell_mage.cpp
+++ b/src/server/scripts/Spells/spell_mage.cpp
@@ -1100,7 +1100,7 @@ class spell_mage_combustion : public AuraScript
     {
         DoCheckProc += AuraCheckProcFn(spell_mage_combustion::CheckProc);
         AfterEffectRemove += AuraEffectRemoveFn(spell_mage_combustion::OnRemove, EFFECT_0,
-            SPELL_AURA_DUMMY, AURA_EFFECT_HANDLE_REAL);
+            SPELL_AURA_ADD_PCT_MODIFIER, AURA_EFFECT_HANDLE_REAL);
     }
 };
 

--- a/src/server/scripts/Spells/spell_mage.cpp
+++ b/src/server/scripts/Spells/spell_mage.cpp
@@ -1074,11 +1074,15 @@ class spell_mage_combustion : public AuraScript
             // it (this hook runs from Aura::GetProcEffectMask); defer it so the insert can't
             // invalidate the live iterator (aura containers are flat_multimaps).
             Unit* actor = eventInfo.GetActor();
-            actor->m_Events.AddEventAtOffset([actor]()
+            ObjectGuid actorGuid = actor->GetGUID();
+            actor->m_Events.AddEventAtOffset([actorGuid]()
             {
-                if (actor->HasAura(SPELL_MAGE_COMBUSTION))
+                if (Player* actor = ObjectAccessor::FindPlayer(actorGuid))
                 {
-                    actor->CastSpell(static_cast<Unit*>(nullptr), SPELL_MAGE_COMBUSTION_PROC, true);
+                    if (actor->HasAura(SPELL_MAGE_COMBUSTION))
+                    {
+                        actor->CastSpell(static_cast<Unit*>(nullptr), SPELL_MAGE_COMBUSTION_PROC, true);
+                    }
                 }
             }, 1ms);
             return false;


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
- [ ] Core (units, players, creatures, game systems).
- [x] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests
- [x] AI tools were partially used in preparing this pull request.
   - Tools/models used: Claude / Gemini

### Problem & Blizzlike Mechanics Explained:

1. **Combustion Stacks Getting Stuck Permanently on Multi-Target / AoE:**
   In retail WotLK, Mage's talent *Combustion* (spell 11129) grants 3 critical strike charges. Each non-critical Fire damage hit applies one stack of the *Combustion* proc aura (spell 28682), granting +10% Fire critical strike chance per stack. Once 3 critical strikes are caused, *Combustion* (11129) expires and is removed, which in turn removes the critical strike stacking buff (28682).
   
   In commit `fd04d94`, the application of spell 28682 on non-critical hits was deferred by 1ms via `actor->m_Events.AddEventAtOffset` to prevent mutating the aura container during proc iteration.
   However, during multi-target AoE hits (e.g. Living Bomb explosions hitting 4+ targets, or Flamestrike):
   - Some targets would critically strike and consume the remaining charges of *Combustion* (11129), removing spell 11129.
   - Meanwhile, targets that did not critically strike had already enqueued the 1ms deferred event to cast spell 28682.
   - 1 millisecond later, the deferred event executed `actor->CastSpell(nullptr, SPELL_MAGE_COMBUSTION_PROC, true)` unconditionally, applying spell 28682 onto the Mage when *Combustion* (11129) was **already gone**.
   - Because spell 11129 was no longer present, no future critical hits could consume charges, leaving the stacking crit buff permanently stuck on the player.

2. **The Fix:**
   - In `spell_mage_combustion::CheckProc`: Added a check `if (actor->HasAura(SPELL_MAGE_COMBUSTION))` inside the deferred event lambda, so that if *Combustion* was consumed or removed before the event executes, spell 28682 is not cast.
   - In `spell_mage_combustion_proc`: Added an `AfterEffectApply` validation hook ensuring that if spell 28682 is ever applied without spell 11129 active on the target, it immediately removes itself.
   - In `spell_mage_combustion`: Added an `AfterEffectRemove` hook to explicitly clean up any remaining applications of spell 28682 when *Combustion* is removed.

## Issues Addressed:

- Closes #26895
- Closes chromiecraft/chromiecraft#9965

## SOURCE:

- [Combustion (spell 11129)](https://www.wowhead.com/wotlk/spell=11129/combustion)
- Issue reproduction video: https://dl.dropboxusercontent.com/scl/fi/p0js8tb82zebrwjm01p56/Wow_5aGL7rncck.mp4?rlkey=nembviw8ap1qqc3xnfxz8sju3&dl=0

## Tests Performed:

- [x] Built `worldserver` in Release with 0 errors and 0 warnings.
- [x] Verified code formatting adheres to AzerothCore's $\le 120$ column standard.
- [x] Verified that non-critical hits properly increase Combustion stacks when Combustion is active.
- [x] Verified that causing 3 critical hits removes both Combustion and all proc stacks, leaving no orphaned buff.
- [x] Verified that simultaneous multi-target hits (AoE Living Bomb explosions / Flamestrike) do not leave lingering stacks when charges expire.

## How to Test the Changes:

1. Create a Level 70–80 Mage (`.learn all my class`).
2. Teleport to a cluster of mobs (e.g. `.go c 97075`).
3. Enable `.cheat god on`.
4. Cast *Combustion* (`.cast 11129`).
5. Apply *Living Bomb* (`.cast 44457`) to 4 nearby mobs and wait for them to explode simultaneously.
6. Verify that once 3 critical strikes occur, the Combustion buff and all stacks are completely removed from the player buff bar.

## Known Issues and TODO List:

None.