### PR TITLE
fix(Core/Spells): Prevent dual-wield penalty from double dipping on Threat of Thassarian base damage

### DIFF
--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -3648,7 +3648,12 @@ void Spell::EffectWeaponDmg(SpellEffIndex effIndex)
             break;
         }
         float weapon_total_pct = m_caster->GetPctModifierValue(unitMod, TOTAL_PCT);
-        fixed_bonus = int32(fixed_bonus * weapon_total_pct);
+        // Base damage is already halved in DBC for Threat of Thassarian off-hand spells
+        if (m_attackType == OFF_ATTACK && m_spellInfo->SpellFamilyName == SPELLFAMILY_DEATHKNIGHT)
+            fixed_bonus = int32(fixed_bonus * weapon_total_pct * 2.0f);
+        else
+            fixed_bonus = int32(fixed_bonus * weapon_total_pct);
+
         spell_bonus = int32(spell_bonus * weapon_total_pct);
     }
 


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests
- [x] AI tools were partially used in preparing this pull request.
   - Tools/models used: Claude / Gemini

### Problem & Blizzlike Mechanics Explained:

1. **Threat of Thassarian Off-Hand Base Damage Double-Dipping Dual Wield Penalty:**
   In Wrath of the Lich King, Death Knights obtain the talent *Threat of Thassarian* (talent 65661), which allows their main-hand abilities (*Obliterate*, *Blood Strike*, *Death Strike*, *Plague Strike*, *Frost Strike*, and *Rune Strike*) to trigger an off-hand strike when dual-wielding.

   Blizzard designed dedicated off-hand spell records in the client DBC for each of these strikes:
   - **Obliterate:** MH Rank 4 (51425) vs OH Rank 4 (66974)
   - **Blood Strike:** MH Rank 6 (49930) vs OH Rank 6 (66979)
   - **Death Strike:** MH Rank 5 (49924) vs OH Rank 5 (66953)
   - **Plague Strike:** MH Rank 6 (49921) vs OH Rank 6 (66990)
   - **Frost Strike:** MH Rank 6 (55268) vs OH Rank 6 (66962)

   In the client DBC, Blizzard **already halved the flat base bonus damage (`BasePoints`)** of each off-hand ability to account for dual-wielding:
   - Obliterate Rank 4: MH base = **584** -> OH base in DBC = **292** (exactly 584 / 2)
   - Blood Strike Rank 6: MH base = **306** -> OH base in DBC = **153** (exactly 306 / 2)
   - Death Strike Rank 5: MH base = **297** -> OH base in DBC = **148.5** (exactly 297 / 2)
   - Plague Strike Rank 6: MH base = **378** -> OH base in DBC = **189** (exactly 378 / 2)

   However, in `Spell::EffectWeaponDmg` (`SpellEffects.cpp`), physical melee abilities calculate:
   ```cpp
   float weapon_total_pct = m_caster->GetPctModifierValue(unitMod, TOTAL_PCT);
   fixed_bonus = int32(fixed_bonus * weapon_total_pct);
   ```
   For `OFF_ATTACK`, `weapon_total_pct` has a base value of `0.5f` (the standard 50% dual-wield off-hand damage penalty). The off-hand weapon swing itself already applies this 0.5 factor inside `Unit::CalculateDamage(OFF_ATTACK)`.
   
   By also multiplying `fixed_bonus` by `weapon_total_pct`, the already-halved base damage (e.g. 292 for Obliterate) was multiplied by `0.5f` **a second time**:
   292 * 0.5 = 146 (i.e. 584 * 0.25)
   This resulted in a 75% total damage reduction on the base damage portion (25% of Main Hand base damage instead of 50%).
   
   In tests with weak weapons (1–2 damage range) vs a low armor target:
   - Main Hand dealt: ~604 damage.
   - Expected Off Hand: ~303 damage (50%).
   - Actual in-game Off Hand: **184 damage**, matching ((87.5 + 146) * 0.8 * armor) = 184.

2. **The Fix:**
   - In `Spell::EffectWeaponDmg`: For Death Knight off-hand strikes (`m_attackType == OFF_ATTACK && m_spellInfo->SpellFamilyName == SPELLFAMILY_DEATHKNIGHT`), compensate for the pre-halved base damage in the DBC by applying `weapon_total_pct * 2.0f`.
   - Without talents, the modifier on `fixed_bonus` is 0.5 * 2.0 = 1.0, preserving the clean 50% ratio (292 base damage).
   - When talented into *Nerves of Cold Steel* (+25% off-hand weapon damage), `weapon_total_pct` is 0.625, so 0.625 * 2.0 = 1.25, allowing the entire strike to scale by +25% as intended.
   - Other abilities such as Rogue's *Mutilate* (which do not have pre-halved base damage in DBC) continue through the `else` branch and remain untouched.

## Issues Addressed:

- Closes #26873
- Closes chromiecraft/chromiecraft#9944

## SOURCE:

- [Threat of Thassarian (spell 65661)](https://www.wowhead.com/wotlk/spell=65661/threat-of-thassarian)
- [Obliterate Rank 4 (spell 51425)](https://www.wowhead.com/wotlk/spell=51425/obliterate)
- [Obliterate Off-Hand Rank 4 (spell 66974)](https://wowgaming.altervista.org/aowow/?spell=66974)
- DrDamage DeathKnight calculation: `--Sigil of Awareness (base damage, not modified by offhand penalty)`
- Issue reproduction video: https://dl.dropboxusercontent.com/scl/fi/eovg81oh4r2chgu92q978/k3EyGLuAna.mp4?rlkey=dae8rw9y3vyxdh2qx4nssa3mu&dl=0

## Tests Performed:

- [x] Built `worldserver` in Release mode with 0 errors and 0 warnings.
- [x] Verified code formatting adheres to AzerothCore's <= 120 column standard.
- [x] Tested with weak 1-handed weapons (1–2 damage range) against level 1 target dummy:
  - Main Hand Obliterate deals ~604 damage.
  - Off Hand Obliterate correctly deals ~303 damage (~50% of Main Hand) instead of being crippled at ~184 damage.
- [x] Verified that *Nerves of Cold Steel* (+25% off-hand damage) scales the off-hand damage proportionally.
- [x] Verified Rogue's *Mutilate* and Shaman's *Lava Lash* are unaffected.

## How to Test the Changes:

1. Create a Level 80 Death Knight.
2. Equip two low-damage 1-handed weapons (e.g. item 753 with 1–2 damage range) in both Main Hand and Off Hand.
3. Learn *Threat of Thassarian* (`.learn 65661`).
4. Attack a low level target dummy with *Obliterate* (`.cast 51425`).
5. Open the combat log:
   - Observe both Main Hand and Off Hand hits.
   - The off-hand damage will now be approximately 50% of the main-hand damage, rather than suffering an extra 50% penalty on the base damage.

## Known Issues and TODO List:

None.