### PR TITLE
fix(Core/Events): Snapshot map before AI hooks

### DIFF
--- a/src/server/game/Events/GameEventMgr.cpp
+++ b/src/server/game/Events/GameEventMgr.cpp
@@ -1879,16 +1879,48 @@ public:
 
     void Visit(std::unordered_map<ObjectGuid, Creature*>& creatureMap)
     {
+        // Snapshot the pointers before dispatching anything.
+        //
+        // sOnGameEvent() runs arbitrary SmartAI actions for whichever creature
+        // the callback lands on. An action such as a same-map
+        // SMART_ACTION_SUMMON_CREATURE reaches Creature::AddToWorld(), which
+        // does GetMap()->GetObjectsStore().Insert<Creature>(...) synchronously
+        // -- inserting into this very container. Inserting into an
+        // std::unordered_map may rehash it, and a rehash invalidates every
+        // iterator into it, including the one a range-based for over
+        // creatureMap would still be holding. That is undefined behaviour and
+        // the observed crash signature.
+        //
+        // Copying the raw pointers is safe against use-after-free: object
+        // destruction is deferred to Map::RemoveAllObjectsInRemoveList(),
+        // which is called from Map::DelayedUpdate(), a different phase from
+        // the World::Update() -> GameEventMgr::Update() -> RunSmartAIScripts()
+        // path this runs on. Nothing is freed mid-sweep, so the per-element
+        // guards below remain sufficient for objects that were logically
+        // removed during the sweep.
+        std::vector<Creature*> creatures;
+        creatures.reserve(creatureMap.size());
         for (auto const& p : creatureMap)
-            if (p.second->IsInWorld() && !p.second->IsDuringRemoveFromWorld() && p.second->FindMap() && p.second->IsAIEnabled && p.second->AI())
-                p.second->AI()->sOnGameEvent(_activate, _eventId);
+            creatures.push_back(p.second);
+
+        for (Creature* creature : creatures)
+            if (creature->IsInWorld() && !creature->IsDuringRemoveFromWorld() && creature->FindMap() && creature->IsAIEnabled && creature->AI())
+                creature->AI()->sOnGameEvent(_activate, _eventId);
     }
 
     void Visit(std::unordered_map<ObjectGuid, GameObject*>& gameObjectMap)
     {
+        // Same hazard and same reasoning as the creature overload above:
+        // GameObjectAI::OnGameEvent() can reach GameObject::AddToWorld(), which
+        // inserts into this container synchronously.
+        std::vector<GameObject*> gameObjects;
+        gameObjects.reserve(gameObjectMap.size());
         for (auto const& p : gameObjectMap)
-            if (p.second->IsInWorld() && p.second->FindMap() && p.second->AI())
-                p.second->AI()->OnGameEvent(_activate, _eventId);
+            gameObjects.push_back(p.second);
+
+        for (GameObject* gameObject : gameObjects)
+            if (gameObject->IsInWorld() && gameObject->FindMap() && gameObject->AI())
+                gameObject->AI()->OnGameEvent(_activate, _eventId);
     }
 
     template<class T>


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Sonnet 5 (Claude Code), for investigation, the fix itself, and this description. I reviewed and understand the change; I'm the one answering questions on it.
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

`GameEventAIHookWorker::Visit` iterates `creatureMap`/`gameObjectMap` by reference while dispatching `sOnGameEvent()`/`OnGameEvent()` callbacks. Those callbacks run arbitrary SmartAI actions. A same-map `SMART_ACTION_SUMMON_CREATURE` reaches `Creature::AddToWorld()`, which calls `GetMap()->GetObjectsStore().Insert<Creature>(...)` synchronously — inserting into the very `std::unordered_map` the range-based `for` is iterating. An insert can trigger a rehash, which invalidates every iterator into the map, including the one the loop holds. Same shape on the gameobject overload.

The fix copies the raw pointers into a local `std::vector` before dispatching, and iterates the copy instead. This is safe against use-after-free, not just iterator invalidation: object destruction in AzerothCore is deferred to `Map::RemoveAllObjectsInRemoveList()`, called only from `Map::DelayedUpdate()` — a different phase from the `World::Update() -> GameEventMgr::Update() -> RunSmartAIScripts()` path this code runs on. Nothing is freed mid-sweep, so the copied pointers can't dangle, and the existing `IsInWorld()`/`IsDuringRemoveFromWorld()`/`FindMap()` guards remain sufficient for anything logically removed during the sweep.

## Issues Addressed:
No open issue in this repo. Related, on TrinityCore (shared ancestor for this file): **TrinityCore#26687, "Crash GameEventMgr::RunSmartAIScripts"** — open since 2021-07-13, directly on point, cited here as evidence this class of defect is real and long-standing, not as something this PR closes there.

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

None of these quite fit — this isn't a content-accuracy fix, it's an engine memory-safety fix, reached by direct code reading (checked how object insertion and object removal both interact with the container this code iterates) rather than an external source. Root cause write-up: https://github.com/nickk02/azerothcore-deploy (private repo; happy to share specific excerpts if useful).

## Tests Performed:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

More precisely than the checkboxes above allow: this fix has been running in production on two of my own self-hosted realms since 2026-08-01 (upstream tree) and 2026-08-07 (a Playerbots-fork build with the identical patch applied to both `Visit` overloads), with the compiled object verified by DWARF line info to confirm the new snapshot code is actually in the binary, not just present in source. Since deploying, the realm that runs 40 AI-controlled bots 24/7 (the traffic pattern most likely to hit this) has crossed roughly 7-8 daily event-boundary windows with zero SIGSEGVs, versus a prior history of a same-shaped crash recurring at that exact boundary.

That's meaningful field evidence the fix doesn't break anything and correlates with the crash disappearing, but I want to be precise about what it isn't: I never captured a backtrace with a rehash on this exact container as the confirmed trigger of the original crash. The hazard itself is real and provable by code inspection independent of that — this PR closes a genuine iterator-invalidation bug either way — but I can't claim a smoking-gun backtrace tying it to a specific prior incident, only that a real memory-safety hazard existed here and no longer does.

## How to Test the Changes:
- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Set up a realm with Playerbots or another source of sustained SmartAI activity around a game event (WorldState-driven events work too), where at least one participating creature's SmartAI can trigger `SMART_ACTION_SUMMON_CREATURE` onto the same map during the event's activation/deactivation hook.
2. Before this patch: under load, watch for a crash inside `GameEventAIHookWorker::Visit` / `RunSmartAIScripts` with a backtrace touching `std::unordered_map` rehash internals. This is timing-dependent and doesn't reproduce on demand — that's exactly why it's a real iterator-invalidation bug and not something a deterministic unit test can catch.
3. After this patch: the same activity should run without that crash. Also worth exercising a large game event with many participating creatures/gameobjects, to confirm normal event AI callbacks (not just the summon-during-event edge case) still fire during activation and deactivation, since the loop body is otherwise unchanged.

## Known Issues and TODO List:
- [ ] No automated test covers this — the hazard is timing-dependent (whether a rehash happens to occur during the specific loop iteration) and not something a deterministic unit test reproduces cleanly. Open to suggestions if a maintainer has a pattern for this class of bug elsewhere in the codebase.
- [ ] Would appreciate a second look from someone who knows this subsystem better, particularly on whether any other code assumes `GameEventAIHookWorker::Visit` iterates the live container rather than a snapshot (I didn't find one, but I don't know this file's full history).
