### PR TITLE
fix(Core/Item): unlock openable item on the client when opened while dead

### DIFF
--- a/src/server/game/Handlers/SpellHandler.cpp
+++ b/src/server/game/Handlers/SpellHandler.cpp
@@ -211,13 +211,6 @@ void WorldSession::HandleOpenItemOpcode(WorldPacket& recvPacket)
     if (pUser->m_mover != pUser)
         return;
 
-    // xinef: additional check, client outputs message on its own
-    if (!pUser->IsAlive())
-    {
-        pUser->SendEquipError(EQUIP_ERR_YOU_ARE_DEAD, nullptr, nullptr);
-        return;
-    }
-
     uint8 bagIndex, slot;
 
     recvPacket >> bagIndex >> slot;
@@ -228,6 +221,15 @@ void WorldSession::HandleOpenItemOpcode(WorldPacket& recvPacket)
     if (!item)
     {
         pUser->SendEquipError(EQUIP_ERR_ITEM_NOT_FOUND, nullptr, nullptr);
+        return;
+    }
+
+    // The client locks the item when it sends CMSG_OPEN_ITEM and only unlocks it on a loot
+    // response for that item's guid, so a plain equip error would leave it grayed out until /reload.
+    if (!pUser->IsAlive())
+    {
+        pUser->SendEquipError(EQUIP_ERR_YOU_ARE_DEAD, item, nullptr);
+        pUser->SendLootRelease(item->GetGUID());
         return;
     }
 


### PR DESCRIPTION
## Changes Proposed:
Right-clicking a lootable container like Satchel of Helpful Goods while dead left it grayed out in the bag until `/reload`. The client locks the item when it sends `CMSG_OPEN_ITEM` and only unlocks it on a loot response for that item's guid, but the server answered with an inventory error that carries no guid. Now `HandleOpenItemOpcode` resolves the item first and, if the player is dead, also sends `SMSG_LOOT_RELEASE_RESPONSE` for it, the same refusal `Player::SendLoot` already uses when it can't open an item. The "You can't do that when you're dead" message is unchanged and no loot is generated while dead.

The remote-control early return (`m_mover != player`) has the same shape but is left alone, no report for it and the client blocks opening bags in that state. Same pattern exists in TrinityCore 3.3.5, so this is inherited rather than a regression.

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Claude Fable 5.1)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #27428

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Reporter's video in the linked issue shows the stuck state.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Builds on Windows (MSVC, RelWithDebInfo). Tested in-game: satchel opened while dead shows the dead message, no loot window, and opens normally after `.revive` without `/reload`. Also checked a wrapped gift (`.additem 5042`, wrap and open) and opening the satchel while alive, both unchanged.

## How to Test the Changes:
- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. `.additem 52005`, then `.die`
2. Right-click the satchel: dead message, no loot window
3. `.revive` and right-click it again: it should open without a `/reload`

## Known Issues and TODO List:

- [ ] No e2e test yet: the AzerothGhost harness can't send `CMSG_OPEN_ITEM` or read an inventory item's guid at v1.0.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
