### PR TITLE
fix(Scripts/VaultOfArchavon): despawn Emalon's Tempest Minions on hard reset

### DIFF
--- a/src/server/scripts/Northrend/VaultOfArchavon/boss_emalon.cpp
+++ b/src/server/scripts/Northrend/VaultOfArchavon/boss_emalon.cpp
@@ -124,6 +124,13 @@ public:
             events.ScheduleEvent(EVENT_SUMMON_NEXT_MINION, 4s);
         }
 
+        // Called by Creature::DespawnOnEvade (CREATURE_FLAG_EXTRA_HARD_RESET) after Reset() already
+        // summoned a fresh set of minions; without this they outlive the boss and stack up per wipe.
+        void SummonedCreatureDespawnAll() override
+        {
+            summons.DespawnAll();
+        }
+
         void SpellHitTarget(Unit* target, SpellInfo const* spellInfo) override
         {
             // restore minions health


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Emalon has `CREATURE_FLAG_EXTRA_HARD_RESET`, so on evade the core runs `Reset()` first and then `Creature::DespawnOnEvade()`. `Reset()` despawns the old Tempest Minions and summons four fresh ones; `DespawnOnEvade()` then relies on the `SummonedCreatureDespawnAll()` hook to clear the boss's summons before the boss itself despawns. `boss_emalon` is a `ScriptedAI` and never overrode that hook (only `BossAI` does), so the fresh set survived. The respawned boss gets a new AI with an empty `SummonList` and summons four more: 8 minions after one wipe, 12 after two.

The fix overrides `SummonedCreatureDespawnAll()` to despawn the tracked summons, the same thing `BossAI` does.

Verified with a live e2e run locally (not included): 0 minions survive the boss despawn and exactly 4 are up after the respawn, against 4 and 8 on master.

### AI-assisted Pull Requests

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Claude Fable 5.1)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/27394

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:
- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. `.go creature id 33993`, turn GM off, pull Emalon.
2. Die or vanish so the boss evades; it despawns and respawns after about 20 seconds.
3. Exactly four Tempest Minions should be up after the respawn (previously eight), and killing minions mid-fight should still spawn replacements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
