### PR TITLE
fix(Scripts/VaultOfArchavon): Respawn Emalon's minions at the boss and announce them

### DIFF
--- a/src/server/scripts/Northrend/VaultOfArchavon/boss_emalon.cpp
+++ b/src/server/scripts/Northrend/VaultOfArchavon/boss_emalon.cpp
@@ -52,6 +52,10 @@ enum Misc
     MAX_TEMPEST_MINIONS             = 4,
 };
 
+// A minion killed mid-fight is replaced next to the boss, not at one of the four start positions
+float constexpr MINION_RESPAWN_MIN_DIST = 5.0f;
+float constexpr MINION_RESPAWN_MAX_DIST = 10.0f;
+
 struct Position TempestMinions[MAX_TEMPEST_MINIONS] =
 {
     {-203.980103f, -281.287720f, 91.650223f, 1.598807f},
@@ -194,8 +198,20 @@ public:
                     Talk(EMOTE_BERSERK);
                     break;
                 case EVENT_SUMMON_NEXT_MINION:
-                    me->SummonCreature(NPC_TEMPEST_MINION, TempestMinions[urand(0, 3)], TEMPSUMMON_CORPSE_DESPAWN, 0);
+                {
+                    float const dist = frand(MINION_RESPAWN_MIN_DIST, MINION_RESPAWN_MAX_DIST);
+                    Position const pos = me->GetNearPosition(dist, frand(0.0f, static_cast<float>(2 * M_PI)));
+                    // the replacement has to join the fight on its own instead of idling until a
+                    // player walks into its aggro range
+                    if (Creature* minion = me->SummonCreature(NPC_TEMPEST_MINION, pos, TEMPSUMMON_CORPSE_DESPAWN, 0))
+                    {
+                        DoZoneInCombat(minion);
+                        if (Unit* victim = me->GetVictim())
+                            minion->AI()->AttackStart(victim);
+                    }
+                    Talk(EMOTE_MINION_RESPAWN);
                     break;
+                }
                 default:
                     break;
             }


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

A Tempest Minion killed mid-fight was re-summoned at a random one of the four start positions, Emalon never sent "A Tempest Minion appears to defend Emalon!" (the text is in `creature_text` for 33993 but the script never used it), and the replacement idled where it spawned until someone walked into its aggro range, since only the initial four are put into combat on pull.

Now the replacement spawns 5 to 10 yards from Emalon at a random angle, is put into combat and onto the boss's target right where it's summoned (in the `EVENT_SUMMON_NEXT_MINION` handler, so only the mid-fight replacement path is affected), and Emalon announces it on the same raid boss emote channel as the overcharge message.

Rebased on top of #27432, which fixed the wipe stacking in the same script.

Worth a close look: the spawn spot uses `GetNearPosition`, which walks the point back on big height changes, so it stays on the platform. The initial four minions are untouched; they still get engaged by `JustEngagedWith` on pull. The rest is mechanical.

### AI-assisted Pull Requests

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Claude Fable 5.1)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/27397

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Cata Classic footage linked in the issue (1:48 and 2:32) shows the replacement appearing right next to the boss. The emote text was already in `creature_text` for Emalon, just never used by the script.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Tested in-game on current master plus this change: the emote shows up in chat for every replacement, the new minion spawns next to Emalon (8 to 9 yards in my runs, versus 21 yards away on a corner before) and attacks right away, also with the boss kited away from where the fight starts. Wiping and re-pulling still gives exactly four minions, and pulling with only three alive still starts the fight with four.

## How to Test the Changes:
- [x] This pull request can be tested by following the reproduction steps provided in the linked issue

1. `.go creature id 33993`, turn GM off, pull Emalon away from the middle of the room.
2. `.die` one of the Tempest Minions.
3. A few seconds later the raid boss emote "A Tempest Minion appears to defend Emalon!" shows up, the new minion appears a few yards from Emalon rather than on a corner, and it attacks right away.
4. Wipe and re-pull: still exactly four minions, and killing one mid-fight still spawns one replacement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
