### PR TITLE
perf(Core): derive creature terrain status lazily; cache GetScriptId()

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -57,6 +57,11 @@
 //  see: https://github.com/azerothcore/azerothcore-wotlk/issues/9766
 #include "GridNotifiersImpl.h"
 
+// How far (yards, squared) a wandering creature may travel between refreshes of its swim / fly / hover
+// movement flags. Combat / cell-change / zone-wide-visible creatures refresh immediately in
+// Map::CreatureRelocation() and never use this.
+constexpr float CREATURE_MOVEMENT_FLAGS_REFRESH_DIST_SQ = 2.0f * 2.0f;
+
 CreatureMovementData::CreatureMovementData() : Ground(CreatureGroundMovementType::Run), Flight(CreatureFlightMovementType::None),
                                                Swim(true), Rooted(false), Chase(CreatureChaseMovementType::Run),
                                                Random(CreatureRandomMovementType::Walk), InteractionPauseTimer(sWorld->getIntConfig(CONFIG_CREATURE_STOP_FOR_PLAYER)) {}
@@ -508,6 +513,7 @@ bool Creature::InitEntry(uint32 Entry, CreatureData const* data)
 
     SetEntry(Entry);                                        // normal entry always
     m_creatureInfo = cinfo;                                 // map mode related always
+    m_cachedScriptIdEntry = 0;                              // force GetScriptId() to re-resolve for this (re)init
 
     // equal to player Race field, but creature does not have race
     SetByteValue(UNIT_FIELD_BYTES_0, 0, 0);
@@ -774,6 +780,17 @@ void Creature::Update(uint32 diff)
             // CORPSE/DEAD state will processed at next tick (in other case death timer will be updated unexpectedly)
             if (!IsAlive())
                 break;
+
+            // Swim / fly / hover flags are only refreshed inside UpdatePositionData(), which
+            // Map::CreatureRelocation() throttles for a plain wandering creature. Drive them here: as
+            // soon as it comes to rest, or once it has moved far enough that its liquid / floor state
+            // could have changed. (Creatures in combat, changing grid cell, or zone-wide visible
+            // re-derive immediately in CreatureRelocation and never reach this.)
+            if (IsPositionDataUpdatePending() &&
+                (!isMoving() || GetExactDistSq(m_lastMovementFlagsPos) >= CREATURE_MOVEMENT_FLAGS_REFRESH_DIST_SQ))
+            {
+                UpdatePositionData(); // -> ProcessTerrainStatusUpdate() -> UpdateMovementFlags() re-baselines m_lastMovementFlagsPos
+            }
 
             GetThreatMgr().Update(diff);
 
@@ -3186,14 +3203,25 @@ std::string Creature::GetScriptName() const
 
 uint32 Creature::GetScriptId() const
 {
-    if (CreatureData const* creatureData = GetCreatureData())
-    {
-        uint32 scriptId = creatureData->ScriptId;
-        if (scriptId && GetEntry() == creatureData->id)
-            return scriptId;
-    }
+    uint32 const entry = GetEntry();
 
-    return sObjectMgr->GetCreatureTemplate(GetEntry())->ScriptID;
+    // Cache the resolved id per entry. Re-resolve whenever the entry changes - InitEntry(),
+    // UpdateEntry(), or a bare SetEntry() done by transform / entry-swap scripts.
+    if (entry && m_cachedScriptIdEntry == entry)
+        return m_cachedScriptId;
+
+    uint32 scriptId = 0;
+    if (CreatureData const* creatureData = GetCreatureData())
+        if (creatureData->ScriptId && entry == creatureData->id)
+            scriptId = creatureData->ScriptId;
+
+    if (!scriptId)
+        if (CreatureTemplate const* cInfo = sObjectMgr->GetCreatureTemplate(entry))
+            scriptId = cInfo->ScriptID;
+
+    m_cachedScriptId = scriptId;
+    m_cachedScriptIdEntry = entry;
+    return scriptId;
 }
 
 VendorItemData const* Creature::GetVendorItems() const
@@ -3446,6 +3474,10 @@ float Creature::GetAggroRange(Unit const* target) const
 
 void Creature::UpdateMovementFlags()
 {
+    // Track where the flags were last evaluated - Creature::Update() uses this as the throttle
+    // baseline for a wandering creature (see Map::CreatureRelocation).
+    m_lastMovementFlagsPos.Relocate(GetPositionX(), GetPositionY(), GetPositionZ());
+
     // Do not update movement flags if creature is controlled by a player (charm/vehicle)
     if (m_movedByPlayer)
         return;

--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -513,7 +513,7 @@ bool Creature::InitEntry(uint32 Entry, CreatureData const* data)
 
     SetEntry(Entry);                                        // normal entry always
     m_creatureInfo = cinfo;                                 // map mode related always
-    m_cachedScriptIdEntry = 0;                              // force GetScriptId() to re-resolve for this (re)init
+    CachedScriptIdEntry = 0;                              // force GetScriptId() to re-resolve for this (re)init
 
     // equal to player Race field, but creature does not have race
     SetByteValue(UNIT_FIELD_BYTES_0, 0, 0);
@@ -787,7 +787,7 @@ void Creature::Update(uint32 diff)
             // could have changed. (Creatures in combat, changing grid cell, or zone-wide visible
             // re-derive immediately in CreatureRelocation and never reach this.)
             if (IsPositionDataUpdatePending() &&
-                (!isMoving() || GetExactDistSq(m_lastMovementFlagsPos) >= CREATURE_MOVEMENT_FLAGS_REFRESH_DIST_SQ))
+                (!isMoving() || GetExactDistSq(LastMovementFlagsPos) >= CREATURE_MOVEMENT_FLAGS_REFRESH_DIST_SQ))
             {
                 UpdatePositionData(); // -> ProcessTerrainStatusUpdate() -> UpdateMovementFlags() re-baselines m_lastMovementFlagsPos
             }
@@ -3207,8 +3207,8 @@ uint32 Creature::GetScriptId() const
 
     // Cache the resolved id per entry. Re-resolve whenever the entry changes - InitEntry(),
     // UpdateEntry(), or a bare SetEntry() done by transform / entry-swap scripts.
-    if (entry && m_cachedScriptIdEntry == entry)
-        return m_cachedScriptId;
+    if (entry && CachedScriptIdEntry == entry)
+        return CachedScriptId;
 
     uint32 scriptId = 0;
     if (CreatureData const* creatureData = GetCreatureData())
@@ -3219,8 +3219,8 @@ uint32 Creature::GetScriptId() const
         if (CreatureTemplate const* cInfo = sObjectMgr->GetCreatureTemplate(entry))
             scriptId = cInfo->ScriptID;
 
-    m_cachedScriptId = scriptId;
-    m_cachedScriptIdEntry = entry;
+    CachedScriptId = scriptId;
+    CachedScriptIdEntry = entry;
     return scriptId;
 }
 
@@ -3476,7 +3476,7 @@ void Creature::UpdateMovementFlags()
 {
     // Track where the flags were last evaluated - Creature::Update() uses this as the throttle
     // baseline for a wandering creature (see Map::CreatureRelocation).
-    m_lastMovementFlagsPos.Relocate(GetPositionX(), GetPositionY(), GetPositionZ());
+    LastMovementFlagsPos.Relocate(GetPositionX(), GetPositionY(), GetPositionZ());
 
     // Do not update movement flags if creature is controlled by a player (charm/vehicle)
     if (m_movedByPlayer)

--- a/src/server/game/Entities/Creature/Creature.h
+++ b/src/server/game/Entities/Creature/Creature.h
@@ -511,12 +511,15 @@ protected:
 
     Position m_homePosition;
     Position m_transportHomePosition;
+    Position m_lastMovementFlagsPos; // where UpdateMovementFlags() last ran while wandering (swim/fly flag refresh cadence)
 
     bool DisableReputationReward;
     bool DisableLootReward;
 
     CreatureTemplate const* m_creatureInfo;   // in difficulty mode > 0 can different from sObjectMgr->GetCreatureTemplate(GetEntry())
     CreatureData const* m_creatureData;
+    mutable uint32 m_cachedScriptId = 0;      // GetScriptId() cache
+    mutable uint32 m_cachedScriptIdEntry = 0; // GetEntry() the cache was resolved for (0 = unresolved)
 
     float m_detectionDistance;
     uint16 m_LootMode;  // bitmask, default LOOT_MODE_DEFAULT, determines what loot will be lootable

--- a/src/server/game/Entities/Creature/Creature.h
+++ b/src/server/game/Entities/Creature/Creature.h
@@ -511,15 +511,15 @@ protected:
 
     Position m_homePosition;
     Position m_transportHomePosition;
-    Position m_lastMovementFlagsPos; // where UpdateMovementFlags() last ran while wandering (swim/fly flag refresh cadence)
+    Position LastMovementFlagsPos; // where UpdateMovementFlags() last ran while wandering (swim/fly flag refresh cadence)
 
     bool DisableReputationReward;
     bool DisableLootReward;
 
     CreatureTemplate const* m_creatureInfo;   // in difficulty mode > 0 can different from sObjectMgr->GetCreatureTemplate(GetEntry())
     CreatureData const* m_creatureData;
-    mutable uint32 m_cachedScriptId = 0;      // GetScriptId() cache
-    mutable uint32 m_cachedScriptIdEntry = 0; // GetEntry() the cache was resolved for (0 = unresolved)
+    mutable uint32 CachedScriptId = 0;      // GetScriptId() cache
+    mutable uint32 CachedScriptIdEntry = 0; // GetEntry() the cache was resolved for (0 = unresolved)
 
     float m_detectionDistance;
     uint16 m_LootMode;  // bitmask, default LOOT_MODE_DEFAULT, determines what loot will be lootable

--- a/src/server/game/Entities/Object/Object.h
+++ b/src/server/game/Entities/Object/Object.h
@@ -661,6 +661,7 @@ public:
 
     void SetPositionDataUpdate();
     void UpdatePositionData();
+    [[nodiscard]] bool IsPositionDataUpdatePending() const { return _updatePositionData; }
 
     void AddToObjectUpdate() override;
     void RemoveFromObjectUpdate() override;

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -828,7 +828,9 @@ void Map::CreatureRelocation(Creature* creature, float x, float y, float z, floa
     Cell old_cell = creature->GetCurrentCell();
     Cell new_cell(x, y);
 
-    if (old_cell.DiffGrid(new_cell) || old_cell.DiffCell(new_cell))
+    bool const cellChanged = old_cell.DiffGrid(new_cell) || old_cell.DiffCell(new_cell);
+
+    if (cellChanged)
     {
         if (old_cell.DiffGrid(new_cell))
             EnsureGridLoaded(new_cell);
@@ -841,7 +843,29 @@ void Map::CreatureRelocation(Creature* creature, float x, float y, float z, floa
     creature->Relocate(x, y, z, o);
     if (creature->IsVehicle())
         creature->GetVehicleKit()->RelocatePassengers();
-    creature->UpdatePositionData();
+
+    // Terrain status (zone / area / floor / liquid) is derived lazily: the getters recompute it on
+    // demand, the same as for GameObjects. GetFullTerrainStatusForPosition() is VMAP-heavy and used to
+    // run on every spline sub-step, so a wandering creature that nothing is querying now costs no
+    // raycast. Re-derive eagerly here only when the result must be exact immediately and nothing is
+    // guaranteed to read it:
+    //  - the creature changed grid cell;
+    //  - it is in combat or evading home (a mob chasing / returning through water must have the
+    //    correct swim state at once);
+    //  - it is zone-wide visible (world boss / event NPC) - ProcessPositionDataChanged() moves it
+    //    between zone visibility maps only on a real derive, so throttling could hide it from players
+    //    after it crosses a zone border.
+    // For a plain wandering creature, Creature::Update() keeps the swim / fly / hover flags in step
+    // with the terrain it moves over.
+    if (cellChanged || creature->IsInCombat() || creature->IsInEvadeMode() || creature->IsZoneWideVisible())
+    {
+        creature->UpdatePositionData();
+    }
+    else
+    {
+        creature->SetPositionDataUpdate();
+    }
+
     creature->UpdateObjectVisibility(false);
 }
 

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -862,9 +862,7 @@ void Map::CreatureRelocation(Creature* creature, float x, float y, float z, floa
         creature->UpdatePositionData();
     }
     else
-    {
         creature->SetPositionDataUpdate();
-    }
 
     creature->UpdateObjectVisibility(false);
 }


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

I profiled a worldserver with nobody connected and it was still pinning about 0.9 of a core, with
a 5-6 ms mean map-update tick. `perf` put ~37% of the on-CPU time in VMAP BIH raycasts. Two things on
the creature update path account for almost all of it, and this PR addresses both.

## Where the time was going

Every tick, for each moving creature, `Map::CreatureRelocation()` called
`creature->UpdatePositionData()`, which runs `GetFullTerrainStatusForPosition()` - two VMAP BIH
raycasts (static + dynamic collision tree) plus grid area/height lookups. `MoveSpline` updates the
position every tick (the old 400 ms throttle is commented out on purpose so movement generators see
the exact position), so a wandering creature recomputed its whole zone/area/floor/liquid/outdoors
state ~10 times a second. It's memory-latency bound - IPC 0.46, ~5% branch-miss on the tree walk.

Why this happens with zero players: the ~125 always-active transports (boats, zeppelins, elevators)
keep grids loaded across all four continents around the clock, and every wandering creature in those
grids does this.

The second cost is `Creature::GetScriptId()`, called every tick per creature from
`ScriptMgr::OnCreatureUpdate`. For any creature without a per-spawn script override (nearly all of
them) it did an `unordered_map` lookup over the full ~40k `creature_template` set on every call. It
can't just use the template pointer the creature already holds, because that's the difficulty-mode
template and scripts bind to the base entry - but it can be cached.

## Change 1 - lazy terrain status for creatures

GameObjects and DynamicObjects already avoid the per-tick raycast: `SetPositionDataUpdate()` marks
the data dirty and the getters (`GetZoneId`/`GetAreaId`/`GetLiquidData`/`GetFloorZ`/`IsOutdoors`)
recompute on demand. Creatures were the odd ones out. Now `CreatureRelocation()` re-derives eagerly
only when the answer has to be correct *right now* and nothing is guaranteed to ask for it:

- the creature changed grid cell;
- it's in combat or evading home (`IsInCombat() || IsInEvadeMode()`) - a mob chasing a player into
  water, or swimming back to spawn, needs the right swim state immediately;
- it's zone-wide visible (`IsZoneWideVisible()` - world boss / event NPC) - the per-zone visibility
  index is only re-keyed inside a real derive.

Any other creature just gets its status marked dirty. Player pets and charmed/possessed creatures
still refresh immediately (`SetPositionDataUpdate()` already does that internally).

The one thing that has to be *pushed* rather than pulled is `Creature::UpdateMovementFlags()` (the
swim/fly/hover/falling flags that go to clients). Nothing reads those, so `Creature::Update()` now
runs it explicitly for a plain wandering creature: as soon as it stops, or once it's moved
`CREATURE_MOVEMENT_FLAGS_REFRESH_DIST_SQ` (2 yards) from where the flags were last evaluated.

`Relocate()` still runs every tick, so movement generators, pathing (`PathGenerator` queries the map
directly for water) and clients are unchanged. `PlayerRelocation()` is a different function and isn't
touched - players re-derive every tick exactly as before.

## Change 2 - cache `Creature::GetScriptId()`

Cache the resolved id, keyed on the current `GetEntry()` and cleared in `InitEntry()`. That way it
re-resolves after any entry change - `UpdateEntry`, a transform, or a bare `SetEntry()` from an
entry-swap script (Tag Murloc, a few boss scripts). Also added a null check on the template lookup;
the old code dereferenced it unconditionally.

## Numbers

Isolated dev stack, RelWithDebInfo, same build flags as `acore/ac-wotlk-worldserver:master`, 0 players.

| | stock | patched |
|---|---:|---:|
| idle CPU (perf stat task-clock) | 0.92 cores | 0.75 cores |
| idle instructions retired / 20 s | 20.8 B | 15.9 B (-24%) |
| idle branch-miss rate | 5.1% | 2.3% |
| idle VMAP/BIH self-time | ~37% | ~11% |
| `BIH::intersectRay<GModelRayCallback>` self-time, idle | 11.6% | 2.1% |
| under 40-bot load, VMAP/BIH self-time | ~30% | ~8.5% |
| under 40-bot load, branch-miss rate | 4.5% | 2.6% |

I also ran two long-lived realms (stock ~48 h, patched ~26 h, both idle) and scraped their own
`Update time diff` "Last 500 diffs" summaries: mean **6 ms -> 3 ms**, p95 **16 ms -> 8 ms**, median
1 ms both, occasional 100 ms+ max spikes unchanged (those are grid-load bursts, not something this
touches).

For a live realm: the single map-update thread does roughly half the work per idle tick. The raycast
is gone entirely for a creature nothing is looking at (most of a realm's creatures most of the time)
and for the transport-loaded continent grids that cause the idle cost. For a creature near a player,
the first bit of AI/spell/grid-search code that reads a terrain getter re-derives on that read - same
as GameObjects already do - so there the raycast is less frequent rather than gone.

## AI-assisted Pull Requests

- [x] AI tools were used to prepare this pull request.
  - Tools/models used: **Claude Code (claude-sonnet-5)** for the profiling, the patch, a 7-round
    self-review, and the before/after measurements.
- [x] I have read and understood the AC guidelines for AI Agentic Engineering.

## Issues Addressed:
- Closes <!-- profiling-driven, no linked issue -->

## SOURCE:

- [x] Live research - profiled with Linux `perf` (frame-pointer sampling + `perf stat`) on an
  isolated dev stack, plus each server's own `Update time diff` metric over ~1-2 days on two
  long-running realms.

## Tests Performed:

- [x] Tested in-game by the author.
- [x] Automated e2e (AzerothGhost harness) against the patched build: `smoke`,
  `combat/{charm,death,pets,threat,vehicles}`, `quests/{escort,lifecycle}`,
  `spells/{aura,cast,effects}`, `social/{group,loot,trade}` - all pass. A ~3.5 min run with 40 bots
  teleporting between capitals and meleeing finished with 0 errors and a clean worldserver log.
- [x] Self-reviewed over 7 fresh-eyes review rounds; report posted as a comment.
- [ ] Tested in-game by other community members.
- [x] Has edge cases worth testing - see Known Issues.

## How to Test the Changes:

**Perf**, on a stock realm with no players connected:

1. `perf top -p $(pidof worldserver)` or a flamegraph. On stock, `BIH::intersectRay` and
   `VMAP::IntersectTriangle` are near the top; with the patch they drop into the noise and
   `Map::UpdateNonPlayerObjects` / `Unit::Update` take over.
2. `Server.log` - the idle `Update time diff` "Last 500 diffs" mean should roughly halve (~6 ms ->
   ~3 ms), and p95 with it (~16 ms -> ~8 ms).

**Regression** (creatures only - `PlayerRelocation()` is untouched):

- Pull a mob into deep water and around a shoreline / off a ledge. Its swim/fly/hover state should be
  right for the whole fight (combat forces an eager derive every step).
- Let a mob evade from a fight in a lake - it should swim home correctly (`IsInEvadeMode()` forces it).
- Use the GM command `.tele TwilightShore` and watch the murlocs on the beach. These are out of combat
  so they're on the 2 yards flag cadence. The swim/walk animation state change should have no noticeable
  delay from the current master branch.
- A roaming world boss / event NPC that crosses a zone border should still show up for players in the
  new zone (that's the `IsZoneWideVisible()` case).

## Known Issues and TODO List:

- [ ] **Cosmetic swim/fly animation lag on out-of-combat wanderers.** A creature that isn't in
  combat, isn't evading, isn't zone-wide visible, and that nothing is querying can show a stale
  swim/fly/hover pose for up to ~2 yards of movement past a water line or ledge, and a water feature
  narrower than ~2 yards crossed without stopping might not trigger the flag at all. It corrects on the
  next refresh, on stopping, on entering combat, or on a grid-cell change. Position and pathing are
  unaffected. `CREATURE_MOVEMENT_FLAGS_REFRESH_DIST_SQ` is a one-line constant if a tighter bound is
  wanted.
- [ ] **`GetScriptId()` cache vs `.reload creature_template`.** A runtime
  `.reload creature_template` no longer reaches already-spawned creatures - they keep the pre-reload
  script id until they respawn or change entry. This matches how the command already doesn't apply
  faction/model/flags/npcflags to live creatures. If it's wanted live, the reload handler could
  invalidate `m_cachedScriptIdEntry` for spawned creatures of that entry.