### PR TITLE
fix(DB/Creature): Add movement to Balnazzar skeletons

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1788180958859934364.sql
+++ b/data/sql/updates/pending_db_world/rev_1788180958859934364.sql
@@ -1,0 +1,22 @@
+-- Skeletal Guardian
+DELETE FROM `smart_scripts` WHERE (`entryorguid` = 10390) AND (`source_type` = 0);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(10390,0,0,1,60,0,100,769,0,0,0,0,0,0,31,1,3,0,0,0,0,1,0,0,0,0,0,0,0,0,'Skeletal Guardian - On Update - Set Phase Random Between 1-3 (No Repeat)'),
+(10390,0,1,0,61,0,100,512,0,0,0,0,0,0,211,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Skeletal Guardian - On Update - Flag reset 0 (No Repeat)'),
+(10390,0,2,0,1,1,100,0,1000,5000,600000,600000,0,0,11,13787,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Skeletal Guardian - Out of Combat - Cast \'Demon Armor\' (Phase 1)'),
+(10390,0,3,0,0,1,100,0,0,1000,3000,4500,0,0,11,9613,64,0,0,0,0,2,0,0,0,0,0,0,0,0,'Skeletal Guardian - In Combat - Cast \'Shadow Bolt\' (Phase 1)'),
+(10390,0,4,0,0,2,100,0,5000,11000,17000,24500,0,0,11,8364,64,0,0,0,0,5,20,0,0,0,0,0,0,0,'Skeletal Guardian - In Combat - Cast \'Blizzard\' (Phase 2)'),
+(10390,0,5,0,0,2,100,0,0,1000,3000,4500,0,0,11,9672,64,0,0,0,0,2,0,0,0,0,0,0,0,0,'Skeletal Guardian - In Combat - Cast \'Frostbolt\' (Phase 2)'),
+(10390,0,6,0,0,4,100,0,4000,11000,13000,24500,0,0,11,11975,64,0,0,0,0,1,0,0,0,0,0,0,0,0,'Skeletal Guardian - In Combat - Cast \'Arcane Explosion\' (Phase 3)'),
+(10390,0,7,0,0,4,100,0,0,1000,2000,3500,0,0,11,37361,64,0,0,0,0,2,0,0,0,0,0,0,0,0,'Skeletal Guardian - In Combat - Cast \'Arcane Bolt\' (Phase 3)'),
+(10390,0,8,0,54,0,100,1,0,0,0,0,0,0,89,2,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Skeletal Guardian - On Just Summoned - Start Random Movement');
+
+-- Skeletal Berserker
+DELETE FROM `smart_scripts` WHERE (`entryorguid` = 10391) AND (`source_type` = 0);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(10391,0,0,0,0,0,100,0,3000,7000,6000,10000,0,0,11,11976,0,0,0,0,0,2,0,0,0,0,0,0,0,0,'Skeletal Berserker - In Combat - Cast Strike'),
+(10391,0,1,0,0,0,100,0,4000,11000,10000,20000,0,0,11,9080,0,0,0,0,0,2,0,0,0,0,0,0,0,0,'Skeletal Berserker - In Combat - Cast Hamstring'),
+(10391,0,2,0,0,0,100,0,1000,6000,9000,18000,0,0,11,15496,0,0,0,0,0,2,0,0,0,0,0,0,0,0,'Skeletal Berserker - In Combat - Cast Cleave'),
+(10391,0,3,0,105,0,25,0,10000,10000,10000,10000,0,5,11,12555,0,0,0,0,0,7,0,0,0,0,0,0,0,0,'Skeletal Berserker - Victim Casting - Cast Pummel'),
+(10391,0,4,0,1,0,100,257,0,0,0,0,0,0,11,29651,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Skeletal Berserker - On Reset - Cast Dual Wield'),
+(10391,0,5,0,54,0,100,1,0,0,0,0,0,0,89,2,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Skeletal Berserker - On Just Summoned - Start Random Movement');

--- a/data/sql/updates/pending_db_world/rev_1788180958859934364.sql
+++ b/data/sql/updates/pending_db_world/rev_1788180958859934364.sql
@@ -18,5 +18,5 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 (10391,0,1,0,0,0,100,0,4000,11000,10000,20000,0,0,11,9080,0,0,0,0,0,2,0,0,0,0,0,0,0,0,'Skeletal Berserker - In Combat - Cast Hamstring'),
 (10391,0,2,0,0,0,100,0,1000,6000,9000,18000,0,0,11,15496,0,0,0,0,0,2,0,0,0,0,0,0,0,0,'Skeletal Berserker - In Combat - Cast Cleave'),
 (10391,0,3,0,105,0,25,0,10000,10000,10000,10000,0,5,11,12555,0,0,0,0,0,7,0,0,0,0,0,0,0,0,'Skeletal Berserker - Victim Casting - Cast Pummel'),
-(10391,0,4,0,1,0,100,257,0,0,0,0,0,0,11,29651,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Skeletal Berserker - On Reset - Cast Dual Wield'),
+(10391,0,4,0,25,0,100,1,0,0,0,0,0,0,11,29651,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Skeletal Berserker - On Reset - Cast Dual Wield'),
 (10391,0,5,0,54,0,100,1,0,0,0,0,0,0,89,2,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Skeletal Berserker - On Just Summoned - Start Random Movement');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
Add wandering movement to the skellies of Stratholme live after Balnazzard kill

Can provide a test realm on https://test.expanded.space/ hit me up for credentials

<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [X] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [ ] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used:
- [ ] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #26554 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [X] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [X] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [X] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
