### PR TITLE
fix(Gnomeregan): improve restart recovery

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1788451047727740346.sql
+++ b/data/sql/updates/pending_db_world/rev_1788451047727740346.sql
@@ -1,0 +1,7 @@
+-- Gnomeregan: place players on the floor when entering through the main entrance.
+UPDATE `areatrigger_teleport` SET
+    `target_position_x` = -329.098,
+    `target_position_y` = -3.20722,
+    `target_position_z` = -152.851,
+    `target_orientation` = 2.96706
+WHERE `ID` = 324;

--- a/src/server/scripts/EasternKingdoms/Gnomeregan/instance_gnomeregan.cpp
+++ b/src/server/scripts/EasternKingdoms/Gnomeregan/instance_gnomeregan.cpp
@@ -91,7 +91,7 @@ public:
         }
 
     private:
-        uint32 _encounters[MAX_ENCOUNTERS];
+        uint32 _encounters[MAX_ENCOUNTERS]{};
     };
 };
 


### PR DESCRIPTION
## Changes Proposed:

- Initialize Gnomeregan encounter state for newly created instances.
- Correct the main entrance destination so players load on the floor instead of falling into place.
- Retain the existing database-backed door and Grubbis-event recovery behavior.

## Issues Addressed:

- Closes #9529.

## Tests Performed:

- AzerothCore SQL codestyle: passed.
- AzerothCore C++ codestyle: passed.
- Git whitespace validation: passed.
- In-game validation will be performed on the PR test realm.

## How to Test the Changes:

1. Enter Gnomeregan through the main entrance and confirm the character appears directly on the floor.
2. Start and complete the Grubbis event, then restart the worldserver while the character remains in the instance.
3. Reconnect and confirm Emi Shortfuse does not respawn and the event cannot be repeated.
4. Open the Workshop Door and Final Chamber door, restart again, and confirm their states persist.

## AI Assistance Disclosure:

- AI assistance was used to investigate the historical fix, compare reference database coordinates, and implement the changes.
- Tool/model: OpenAI Codex.
- The resulting changes were manually inspected and passed the repository code-style checks.