### PR TITLE
fix(DB/Quest): gate Relics of the Snow Leopard Goddess behind Breaking Through Jin'Alai

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1788451659062817600.sql
+++ b/data/sql/updates/pending_db_world/rev_1788451659062817600.sql
@@ -1,0 +1,3 @@
+-- Relics of the Snow Leopard Goddess (12635) was offered on level alone;
+-- retail gated it behind Breaking Through Jin'Alai (12627)
+UPDATE `quest_template_addon` SET `PrevQuestID` = 12627 WHERE (`ID` = 12635);


### PR DESCRIPTION
Adds the missing prerequisite to "Relics of the Snow Leopard Goddess" (12635). It's now gated behind "Breaking Through Jin'Alai" (12627) instead of being offered on level alone.

One world DB update on `quest_template_addon.PrevQuestID` for quest 12635. The value is positive on purpose: in `Player::SatisfyQuestPreviousQuest` a positive `PrevQuestID` requires the previous quest to be rewarded, a negative one only requires it to be active, and here the player has to actually turn 12627 in. `MinLevel` stays at 74.
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Opus 5
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/27407

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**
The Wowhead changelog for the quest (edit from 2008/11/22, patch 3.0.3) lists "Prerequisite quest: Breaking Through Jin'Alai": https://www.wowhead.com/wotlk/quest=12635/relics-of-the-snow-leopard-goddess

The offer text mentions Har'koa, which reads like it follows "To Speak With Har'koa" (12628), but 12628 already requires 12627 anyway, so 12627 is the looser of the two.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
