### PR TITLE
fix(Core/Spells): Fix cone spell target check and Mimiron Phase 4 Laser Barrage hitbox

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1788474500000.sql
+++ b/data/sql/updates/pending_db_world/rev_1788474500000.sql
@@ -1,0 +1,1 @@
+DELETE FROM spell_custom_attr WHERE spell_id = 63293;


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).
- [x] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests
- [x] AI tools were partially used in preparing this pull request.
   - Tools/models used: Claude / Gemini

### Problem & Blizzlike Mechanics Explained:

1. **Cone Spells Bypassing Facing Check within Boundary Radius (Issue #27453):**
   In `WorldObjectSpellConeTargetCheck::operator()`, an `!_caster->IsWithinBoundaryRadius(target->ToUnit())` check was previously introduced. Because of this check, any player within the bounding radius / melee reach of the caster was treated as being inside the cone regardless of orientation, causing frontal cone spells (such as Mimiron's *P3Wx2 Laser Barrage*, Dragon Breaths, Shockwaves, and Cleaves) to hit players standing directly behind or underneath the boss.

2. **Mimiron Phase 4 Laser Barrage Server-Side Orientation Desync:**
   In Phase 4 of the Mimiron encounter, VX-001 (Torso) is mounted as a passenger on Leviathan MK II (Chassis). In `FaceBarrageArc`, the script was manually subtracting the vehicle base orientation (`arc = arc - vehicle->GetOrientation()`) before calling `SetFacingTo(arc)`. Because `SetFacingTo` updates the creature's server-side orientation (`m_orientation`) to the passed angle, the server stored the seat-local offset rather than the global world angle. When the cone damage check (`_caster->isInFront(target, _coneAngle)`) ran on the server, it evaluated target positions against the seat-local angle instead of world coordinates, causing the damage cone to be rotated by the vehicle's heading and completely desync from the visual beam and the moving DB Target.

3. **Fix:**
   - Removed `!_caster->IsWithinBoundaryRadius(target->ToUnit())` from `WorldObjectSpellConeTargetCheck::operator()` in `Spell.cpp`. Cone area target checks now strictly require `_caster->isInFront(target, _coneAngle)`.
   - Updated `FaceBarrageArc` in `boss_mimiron.cpp` to call `caster->SetFacingToObject(dbTarget)`. This ensures `MoveSplineInit` automatically transforms the orientation packet for transport passengers while maintaining the true global world orientation on the server, keeping the damage cone 100% aligned with the visual laser sweep in both Phase 2 and Phase 4.

### Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/27453

### SOURCE:
- [YouTube Paragon Mimiron Hard Mode (4:02)](https://www.youtube.com/watch?v=4HYOd-MPToQ)
- [YouTube Mimiron 25 HM PoV (3:15)](https://www.youtube.com/watch?v=kQ43qXFGj7U)
- [YouTube WotLK Classic Mimiron P4 Laser Barrage](https://www.youtube.com/watch?v=1IuAf1Mlgf4)

### Tests Performed:
- [x] Verified `WorldObjectSpellConeTargetCheck` strictly excludes targets behind the caster.
- [x] Built `worldserver` with MSVC in Release mode (0 warnings, 0 errors).
- [x] Tested Mimiron Phase 2 and Phase 4 Laser Barrage in-game:
  - Verified players standing behind/underneath the boss in melee range are safe and no longer take damage.
  - Verified the moving damage cone in Phase 4 accurately tracks the visual laser beams and DB Target rotation.

### How to Test the Changes:
1. `.tele mimiron`
2. `.cheat god`
3. Engage Mimiron and advance to Phase 2 and Phase 4.
4. Stand directly behind/underneath the boss in melee range during Laser Barrage.
5. Verify that you take 0 damage while behind the boss.
6. Stand in front where the laser beam sweeps and verify that damage is only dealt when the moving beam actually passes through you.

### Known Issues and TODO List:
None.