### PR TITLE
fix(DB/Spells): Mimiron's Laser Barrage hits a 10 degree cone instead of a 19yd wide line

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1788473739154281700.sql
+++ b/data/sql/updates/pending_db_world/rev_1788473739154281700.sql
@@ -1,0 +1,4 @@
+--
+-- P3Wx2 Laser Barrage (63293): drop SPELL_ATTR0_CU_CONE_LINE so the 10 degree spell_cone row applies.
+-- The line check used VX-001's 8 yd combat reach as half-width, a 19 yd strip across the whole front half-plane.
+DELETE FROM `spell_custom_attr` WHERE `spell_id` = 63293;


### PR DESCRIPTION
## Changes Proposed:

Mimiron's P3Wx2 Laser Barrage damage (63293) carried `SPELL_ATTR0_CU_CONE_LINE` in `spell_custom_attr`, inherited from the old hardcoded SpellMgr list. With that attribute the cone check takes the `HasInLine` branch, which accepts any target in the caster's front half-plane whose lateral offset is below caster reach plus target reach. VX-001's model has an 8 yd combat reach, so the "beam" was a 19 yd wide strip: everyone in melee range was hit anywhere from straight ahead to 60 to 90 degrees off the visible beam, and since the torso's facing follows the sweep rather than the chassis, that included players behind the boss.

The `spell_cone` row for 63293 already gives the 10 degree cone, but it is never consulted while the line attribute is set. This drops the attribute so the cone applies, in phase 2 and phase 4 alike. TrinityCore 3.3.5 carries the same line attribute (same behaviour); TC master derives the shape from retail data instead.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Fable 5.1)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/27453

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [x] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Sniffs of the encounter (phase 2 and phase 4, 1300+ damage ticks against a stationary player): hits stop at about 8 degrees off the beam at 23 to 38 yd and about 13 degrees at 9 yd, so the real beam is a narrow cone of roughly 10 degrees plus the target's own size, nothing like a 19 yd strip. The 3.3.5 Spell.dbc entry has Effect 1 on TARGET_UNIT_CONE_ENEMY_104 with an unlimited radius.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Phase 2 and phase 4 barrages on Windows: only players the beams pass over take 63293 ticks; players standing 10 to 12 yd from VX-001 at 45 degrees or more off the beam no longer take damage.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. `.tele Mimiron`, `.cheat god`, bring him to phase 2 (or phase 4).
2. During a Laser Barrage stand 10 to 12 yd from VX-001 at roughly 45 degrees off the beam while it sweeps. Before this PR you take every tick; after it you are only hit when the beam crosses you.
3. Stand where the beam sweeps through and check you still take damage.

## Known Issues and TODO List:

- [ ] Nine other spells with `CONE_LINE` custom attributes also have shadowed `spell_cone` rows (26029, 37319, 37433, 43140, 43215, 64619, 68873, 70461, 72133); separate evaluation.
- [ ] Torso facing during the Spinning Up windup is being polished separately.

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
