### PR TITLE
fix(DB/Creature): Thorim's Thunder Orbs can no longer enter combat

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1788483826535107900.sql
+++ b/data/sql/updates/pending_db_world/rev_1788483826535107900.sql
@@ -1,0 +1,2 @@
+-- Thunder Orb never enters combat; its charged zap and player AoE must not leave combat refs behind
+UPDATE `creature_template` SET `flags_extra` = `flags_extra`|8192 WHERE `entry` = 33378;


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Thunder Orb 33378 (the seven static orbs on the arena pillars) can currently pick up combat references from player AoE and from its charged zap aura. It runs a NullCreatureAI that never evades, so those references outlive the encounter and keep the raid in combat after Thorim's defeat. The issue's own `.debug combat` dump lists two Thunder Orbs as the remaining references.

This sets `CREATURE_FLAG_EXTRA_CANNOT_ENTER_COMBAT` on the template so the reference is refused at creation instead of being cleaned up afterwards. The flag's only consumer is `CombatManager::CanBeginCombat`, so the orb still receives Charge Orb, still casts its visual and zap, and player AoE still damages it. The threat manager already handles the refused combat state gracefully. Thorim Event Bunny 32892 runs the whole pillar chain under the same restriction today, because NullCreatureAI applies it to trigger creatures.

The same template serves 10 and 25 man, there is no heroic entry. The Lightning Orb that sweeps the tunnel on a wipe is a different creature and is untouched.

This complements #27367, which clears the references held by the golem hand bunnies and Sif. The two do not overlap: with this flag the orb sweep in that PR becomes a no-op.

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Claude Fable 5.1)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Related to #27280

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [x] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

A retail sniff of a full Thorim pull (gauntlet, arena, jump-down, wipe and reset) shows the Thunder Orbs never receive a single in-combat flag update at any point, while the golem hand bunny, the trap bunny and Sif all do. Their only spell targets a source location and hits no unit. The orb's unit flags, faction, display and speeds in the sniff match the AC template, so the combat state is the only difference.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. `.tele BossThorim`, start the encounter and stand in the arena lightning from a charged pillar, or AoE the orbs from the balcony. `.debug combat` on yourself must not list any Thunder Orb.
2. Play the encounter through and defeat Thorim. With #27367 not applied you may still see golem hand bunny or Sif references, but no Thunder Orb ones.
3. Regression: the pillar lightning visuals in phase 1 and the lightning charge in the arena phase must still fire and damage as before.

## Known Issues and TODO List:

- [ ] The hand bunny and Sif references from the same issue are handled by #27367.
- [ ] The sniff also shows a second set of seven Thunder Orbs at arena floor level below the pillar orbs, where AC spawns Thorim Event Bunny 32892 instead. Realigning that touches the pillar spell scripts and is left for a separate PR.

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
