### PR TITLE
fix(DB/Spells): prevent Frost Breath stun refresh

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1788690324789660000.sql
+++ b/data/sql/updates/pending_db_world/rev_1788690324789660000.sql
@@ -1,0 +1,6 @@
+-- Reconstructed Wyrm: do not refresh Frost Breath's active stun (effect 2).
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 13 AND `SourceGroup` = 4 AND `SourceEntry` = 49342 AND `SourceId` = 0 AND `ElseGroup` = 0 AND `ConditionTypeOrReference` = 1 AND `ConditionTarget` = 0 AND `ConditionValue1` = 49342 AND `ConditionValue2` = 2 AND `NegativeCondition` = 1;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`,
+    `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`,
+    `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+    (13, 4, 49342, 0, 0, 1, 0, 49342, 2, 0, 1, 0, 0, '', 'Frost Breath - effect 2 requires target without active Frost Breath stun');

--- a/src/server/game/Spells/SpellInfoCorrections.cpp
+++ b/src/server/game/Spells/SpellInfoCorrections.cpp
@@ -3923,6 +3923,14 @@ void SpellMgr::LoadSpellInfoCorrections()
         spellInfo->Effects[EFFECT_0].BasePoints = -25;
     });
 
+    // Reconstructed Wyrm - Frost Breath
+    ApplySpellFix({ 49342 }, [](SpellInfo* spellInfo)
+    {
+        spellInfo->Effects[EFFECT_2].ApplyAuraName = SPELL_AURA_MOD_DECREASE_SPEED;
+        spellInfo->Effects[EFFECT_2].BasePoints = -51;
+        spellInfo->Effects[EFFECT_2].Mechanic = MECHANIC_SNARE;
+    });
+
     // Eye of Kilrogg Passive (DND)
     ApplySpellFix({ 2585 }, [](SpellInfo* spellInfo)
     {

--- a/src/server/game/Spells/SpellInfoCorrections.cpp
+++ b/src/server/game/Spells/SpellInfoCorrections.cpp
@@ -3923,14 +3923,6 @@ void SpellMgr::LoadSpellInfoCorrections()
         spellInfo->Effects[EFFECT_0].BasePoints = -25;
     });
 
-    // Reconstructed Wyrm - Frost Breath
-    ApplySpellFix({ 49342 }, [](SpellInfo* spellInfo)
-    {
-        spellInfo->Effects[EFFECT_2].ApplyAuraName = SPELL_AURA_MOD_DECREASE_SPEED;
-        spellInfo->Effects[EFFECT_2].BasePoints = -51;
-        spellInfo->Effects[EFFECT_2].Mechanic = MECHANIC_SNARE;
-    });
-
     // Eye of Kilrogg Passive (DND)
     ApplySpellFix({ 2585 }, [](SpellInfo* spellInfo)
     {


### PR DESCRIPTION
## Changes Proposed:
Frost Breath (49342) can refresh its existing stun when Reconstructed Wyrm applies the spell again. This update adds an implicit-target condition for effect 2 that excludes targets already carrying that effect. It preserves the client DBC's stun type and leaves the other effects unfiltered.

This PR proposes changes to:
- [ ] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests
- [x] AI tools were used to prepare this pull request.
   - Codex desktop assisted implementation and review; this follow-up used GPT-6 (exact backend snapshot unavailable).
- [ ] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #27363 (active aura refresh). Full reproduction still needs in-game verification.

## SOURCE:
Reviewer suggestion in this PR and the installed WotLK Spell.dbc: effect 2 is APPLY_AURA / MOD_STUN with area target 16. ConditionMgr defines implicit spell targets as source type 13; effect mask 4 selects effect 2. The condition tests aura 49342, effect index 2, negatively. No DBC correction remains.

## Tests Performed:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by another community member.
- [x] Further testing is required.

`git diff --check` and all SQL codestyle checks passed. The linter used a temporary copy selecting azerothcore/master because this fork has no origin/master. Inspected the DBC entry, condition validation and per-effect target selection. No local build or in-game test was run for the SQL revision; earlier green build results applied to the previous C++ version.

## How to Test the Changes:
1. Apply the pending world update and restart the server; confirm no condition-loader errors for spell 49342.
2. Use `.go c i 27693` and enter Frost Breath. Confirm its original stun can apply once.
3. Stay in the breath through repeated applications and check that an already-active stun is not refreshed by another cast.
4. Dispel the aura and confirm the client remains responsive; repeat the original report's prolonged exposure scenario.
5. Confirm previously unaffected targets still receive the spell. Verify the other effects remain active.

This change does not claim to turn the stun into a slow or establish that every symptom of #27363 is fixed.

## Known Issues and TODO List:
- In-game verification of repeated casts, dispels and the reported client freeze is still required.

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
