### PR TITLE
fix(DB/Quest): correct quest 7703 directions

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1788502540762936000.sql
+++ b/data/sql/updates/pending_db_world/rev_1788502540762936000.sql
@@ -1,0 +1,9 @@
+-- Quest 7703: remove POIs incorrectly pointing to Silverpine Forest instead of Dire Maul.
+DELETE FROM `quest_poi_points` WHERE `QuestID` = 7703;
+DELETE FROM `quest_poi` WHERE `QuestID` = 7703;
+UPDATE `quest_template` SET `QuestCompletionLog` = 'Return to Captain Kromcrush in Dire Maul.' WHERE `ID` = 7703;
+UPDATE `quest_template_locale` SET `CompletedText` = 'Kehrt zu Hauptmann Krombruch in Düsterbruch zurück.' WHERE `ID` = 7703 AND `locale` = 'deDE';
+UPDATE `quest_template_locale` SET `CompletedText` = 'Vuelve con el capitán Kromcrush en La Masacre.' WHERE `ID` = 7703 AND `locale` IN ('esES', 'esMX');
+UPDATE `quest_template_locale` SET `CompletedText` = 'Retournez voir le Capitaine Kromcrabouille à Hache-Tripes.' WHERE `ID` = 7703 AND `locale` = 'frFR';
+UPDATE `quest_template_locale` SET `CompletedText` = 'Вернитесь к капитану Давигрому в Забытом Городе.' WHERE `ID` = 7703 AND `locale` = 'ruRU';
+UPDATE `quest_template_locale` SET `CompletedText` = '返回厄运之槌的克罗卡斯处。' WHERE `ID` = 7703 AND `locale` = 'zhCN';


### PR DESCRIPTION
## Changes Proposed:
This PR removes the quest 7703 POIs that incorrectly direct players to Silverpine Forest and updates its completion directions to Captain Kromcrush in Dire Maul. Existing localized completion text is corrected for the locales present in the base database.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Codex desktop, GPT
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Addresses #8406

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

The linked issue demonstrates the Silverpine pointer and text problem, but explicitly says the correct marker could be in Dire Maul or absent outside the dungeon. It supplies no sniff or exact replacement POI. Removing the POIs is therefore an unverified proposal, not recovered client data. The translated replacement texts are also proposed corrections, not sniffed strings.

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Static checks performed:
- `git diff --check`
- AzerothCore SQL linter
- Manual inspection of the affected base database rows and every SQL WHERE clause

No build or in-game test was performed.

## How to Test the Changes:
- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Apply the world database update and start the server.
2. Use `.quest add 7703` on a character that can access Dire Maul.
3. Open the quest log and map. Confirm the quest no longer displays POIs in Silverpine Forest.
4. Confirm the completion direction says to return to Captain Kromcrush in Dire Maul.
5. Repeat with deDE, esES, esMX, frFR, ruRU, and zhCN clients where available and confirm the localized direction names Dire Maul.

## Known Issues and TODO List:
- [ ] Obtain source data confirming the expected POIs and exact completion strings before choosing removal or replacement. This PR remains draft.
- [ ] In-game verification is still required.

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
