### PR TITLE
fix(DB/Creature): restore Forest Swarmer patrol

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1788502540748671000.sql
+++ b/data/sql/updates/pending_db_world/rev_1788502540748671000.sql
@@ -1,0 +1,16 @@
+-- Ulduar: make the left riverside Forest Swarmers patrol with their Guardian Lasher.
+UPDATE `creature` SET `wander_distance` = 0, `MovementType` = 0
+WHERE `id` = 33431 AND `guid` BETWEEN 136611 AND 136620;
+DELETE FROM `creature_formations` WHERE `memberGUID` IN (136607, 136611, 136612, 136613, 136614, 136615, 136616, 136617, 136618, 136619, 136620);
+INSERT INTO `creature_formations` (`leaderGUID`, `memberGUID`, `dist`, `angle`, `groupAI`, `point_1`, `point_2`) VALUES
+(136607, 136607, 0, 0, 515, 0, 0),
+(136607, 136611, 20.038, 109.498, 515, 0, 0),
+(136607, 136612, 11.422, 141.135, 515, 0, 0),
+(136607, 136613, 14.308, 118.254, 515, 0, 0),
+(136607, 136614, 8.199, 164.137, 515, 0, 0),
+(136607, 136615, 9.308, 165.012, 515, 0, 0),
+(136607, 136616, 6.042, 63.470, 515, 0, 0),
+(136607, 136617, 6.040, 122.801, 515, 0, 0),
+(136607, 136618, 12.079, 210.404, 515, 0, 0),
+(136607, 136619, 10.914, 85.590, 515, 0, 0),
+(136607, 136620, 15.625, 124.750, 515, 0, 0);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
The left riverside Forest Swarmer pack near Freya currently moves as independent creatures. This PR assigns the ten Swarmers to their nearby Guardian Lasher's formation and disables their independent random movement, so they move together while preserving their current spawn layout.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Codex desktop, GPT
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #27292

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

The linked issue includes screenshots and video evidence of the pack moving together. The base database spawn positions were used to calculate each formation offset.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Static checks performed:
- `git diff --check`
- AzerothCore SQL linter
- Verification of all affected spawn GUIDs
- Independent recalculation of every formation distance and relative angle from the base spawn data

No build or in-game test was performed.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Apply the world database update and start the server.
2. Enter Ulduar, enable `.cheat god`, and use `.tele Freya`.
3. Find the Guardian Lasher and ten Forest Swarmers beside the left river.
4. Observe the group for several movement cycles and confirm all ten Swarmers move with the Guardian Lasher.
5. Pull and reset the pack, then confirm the formation resumes without followers becoming detached.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ] In-game verification is still required.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
