### PR TITLE
fix(DB/Quest): restrict Flatulate targets

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1788502540567955000.sql
+++ b/data/sql/updates/pending_db_world/rev_1788502540567955000.sql
@@ -1,0 +1,6 @@
+-- Fuel for the Fire: Flatulate only affects Drakkari Skullcrushers, excluding the abomination and players.
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 13 AND `SourceEntry` = 52497;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`,
+    `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`,
+    `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(13, 3, 52497, 0, 0, 31, 0, 3, 28844, 0, 0, 0, 0, '', 'Flatulate - Target Drakkari Skullcrusher');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
Flatulate currently hits and stuns the controlled Bloated Abomination and can affect players. This PR restricts both target effects of spell 52497 to Drakkari Skullcrushers, matching the quest objective and spell tooltip.

This addresses the Flatulate targeting part of #27402. The reported movement speed is left unchanged because the available evidence does not establish a measured speed value.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Codex desktop, GPT
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Addresses #27402

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

The linked issue contains reproduction and WotLK Classic video evidence. The quest text and Flatulate tooltip identify Drakkari Skullcrushers as the intended targets.

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Static checks performed:
- `git diff --check`
- AzerothCore SQL linter
- Verification of the quest, spell, creature entry, effect mask, and related base database conditions

No build or in-game test was performed.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Apply the world database update and start the server.
2. Add quest 12690 and use the Scepter of Command on a Bloated Abomination near Drakkari Skullcrushers.
3. Use Flatulate while the abomination, its controlling player, and several Skullcrushers are in range.
4. Confirm only the Drakkari Skullcrushers take damage and are stunned.
5. Confirm kills continue to count for the quest and the ability still works after controlling another abomination.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ] In-game verification is still required.
- [ ] The movement speed report in #27402 requires a measured expected value.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
