### PR TITLE
fix(Core/EotS): handle simultaneous score draws

### DIFF
--- a/src/server/game/Battlegrounds/Zones/BattlegroundEY.cpp
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundEY.cpp
@@ -68,6 +68,9 @@ void BattlegroundEY::PostUpdateImpl(uint32 diff)
                         AddPoints(TEAM_ALLIANCE, BG_EY_TickPoints[_ownedPointsCount[TEAM_ALLIANCE] - 1]);
                     if (_ownedPointsCount[TEAM_HORDE] > 0)
                         AddPoints(TEAM_HORDE, BG_EY_TickPoints[_ownedPointsCount[TEAM_HORDE] - 1]);
+                    CheckVictory();
+                    if (GetStatus() != STATUS_IN_PROGRESS)
+                        return;
                     _bgEvents.ScheduleEvent(BG_EY_EVENT_ADD_POINTS, BG_EY_FPOINTS_TICK_TIME - (GameTime::GetGameTimeMS() % BG_EY_FPOINTS_TICK_TIME));
                     break;
                 case BG_EY_EVENT_FLAG_ON_GROUND:
@@ -121,8 +124,19 @@ void BattlegroundEY::AddPoints(TeamId teamId, uint32 points)
         RewardHonorToTeam(GetBonusHonorFromKill(1), teamId);
 
     UpdateWorldState(teamId == TEAM_ALLIANCE ? WORLD_STATE_BATTLEGROUND_EY_ALLIANCE_RESOURCES : WORLD_STATE_BATTLEGROUND_EY_HORDE_RESOURCES, std::min<uint32>(m_TeamScores[teamId], _configurableMaxTeamScore));
-    if (m_TeamScores[teamId] >= static_cast<int32>(_configurableMaxTeamScore))
-        EndBattleground(teamId);
+}
+
+void BattlegroundEY::CheckVictory()
+{
+    if (GetStatus() != STATUS_IN_PROGRESS)
+        return;
+
+    bool const allianceWon = GetTeamScore(TEAM_ALLIANCE) >= _configurableMaxTeamScore;
+    bool const hordeWon = GetTeamScore(TEAM_HORDE) >= _configurableMaxTeamScore;
+    if (allianceWon && hordeWon)
+        EndBattleground(TEAM_NEUTRAL);
+    else if (allianceWon || hordeWon)
+        EndBattleground(allianceWon ? TEAM_ALLIANCE : TEAM_HORDE);
 }
 
 void BattlegroundEY::UpdatePointsState()
@@ -556,6 +570,7 @@ void BattlegroundEY::EventPlayerCapturedFlag(Player* player, uint32 BgObjectType
     UpdatePlayerScore(player, SCORE_FLAG_CAPTURES, 1);
     if (_ownedPointsCount[player->GetTeamId()] > 0)
         AddPoints(player->GetTeamId(), BG_EY_FlagPoints[_ownedPointsCount[player->GetTeamId()] - 1]);
+    CheckVictory();
 }
 
 bool BattlegroundEY::UpdatePlayerScore(Player* player, uint32 type, uint32 value, bool doAddHonor)

--- a/src/server/game/Battlegrounds/Zones/BattlegroundEY.h
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundEY.h
@@ -399,6 +399,7 @@ private:
 
     /* Scorekeeping */
     void AddPoints(TeamId teamId, uint32 points);
+    void CheckVictory();
 
     struct CapturePointInfo
     {


### PR DESCRIPTION
## Changes Proposed:
Eye of the Storm currently checks victory inside each team's `AddPoints` call. A periodic tick awards Alliance first, so a simultaneous 1600 to 1600 result ends as an Alliance win before Horde's points are applied; the second AddPoints still runs, but its attempt to end the match is ignored.

This PR awards both teams their periodic points before evaluating victory. If both reach the score cap in that tick, the battleground ends with `TEAM_NEUTRAL`. Flag capture scoring still checks victory immediately. Both teams' final periodic honor is now applied before the end scoreboard is built, including ordinary cap wins. A neutral result uses the existing non-winner reward path for both teams: no daily-win credit, winner bonus honor/arena points or win criteria, and no faction victory announcement.

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Codex desktop, GPT
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #22330

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

The linked issue reports the 1600-to-1600 result. Its example video is identified in the issue discussion as MoP 5.3 and its blog source is Cataclysm; neither establishes a 3.3.5a-specific rule. The proposed draw follows the issue's expected behavior; WotLK-era evidence is still missing.

## Tests Performed:

On `5616cf896`, the C++ build matrix and [full live-stack e2e suite](https://github.com/azerothcore/azerothcore-wotlk/actions/runs/34604634067/job/103281732799) passed. The remaining red [dashboard integration check on Ubuntu 26.04](https://github.com/azerothcore/azerothcore-wotlk/actions/runs/34604633590/job/103279970770) times out in `Test authserver with startup scripts`: authserver repeatedly reports `No valid realms specified`, and the failure handler then streams PM2 logs instead of returning after its 300-second timeout. The GitHub rerun request was refused because this account lacks the required repository rights. A maintainer rerun or CI-fixture investigation is needed; gameplay verification remains outstanding.


This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Static checks performed:
- `git diff --check`
- AzerothCore C++ codestyle linter
- Review of every Eye of the Storm `AddPoints` caller and end condition

No local build or manual in-game test was performed.

## How to Test the Changes:
- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Queue one Alliance and one Horde character into Eye of the Storm and use `.debug bg`.
2. Arrange equal base ownership so the same periodic tick takes both teams to the score cap.
3. Confirm a 1600 to 1600 result ends as a draw and neither faction receives the win.
4. Repeat with only Alliance reaching the cap and only Horde reaching the cap; confirm the correct faction wins.
5. Capture the flag for the decisive points and confirm flag scoring still ends the match immediately.
6. Check a draw's marks, honor, daily-win/arena rewards, win criteria, lack of faction victory announcement, and recorded pvpstats winner.
7. Check both teams' final honor in the scoreboard after an ordinary cap win.

## Known Issues and TODO List:
- [ ] In-game verification is still required.

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
