### PR TITLE
fix(Core/WSG): resolve tied premature endings

### DIFF
--- a/src/server/game/Battlegrounds/Zones/BattlegroundWS.cpp
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundWS.cpp
@@ -573,7 +573,7 @@ TeamId BattlegroundWS::GetPrematureWinner()
     if (GetTeamScore(TEAM_ALLIANCE) > GetTeamScore(TEAM_HORDE))
         return TEAM_ALLIANCE;
 
-    return GetTeamScore(TEAM_HORDE) > GetTeamScore(TEAM_ALLIANCE) ? TEAM_HORDE : Battleground::GetPrematureWinner();
+    return GetTeamScore(TEAM_HORDE) > GetTeamScore(TEAM_ALLIANCE) ? TEAM_HORDE : _lastFlagCaptureTeam;
 }
 
 uint32 BattlegroundWS::GetAssaultSpellId() const


### PR DESCRIPTION
## Changes Proposed:
Warsong Gulch already uses the last flag capture as the tiebreaker when the 20-minute timer expires. When a match ends early because player counts remain too low, tied scores instead use the generic battleground winner based on remaining players.

This PR applies the existing last-capture tiebreaker to tied premature endings. Since `_lastFlagCaptureTeam` is neutral until the first capture, a 0 to 0 game remains a draw.

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Codex desktop, GPT
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #26972

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

The linked issue cites the Patch 3.2.0 rule: tied captures are won by the last team to capture, while no captures produce a tie.

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Static checks performed:
- `git diff --check`
- AzerothCore C++ codestyle linter
- Review of normal timeout, premature timeout, flag capture, constructor, and reset paths

No local build or manual in-game test was performed.

## How to Test the Changes:
- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Queue Alliance and Horde characters into Warsong Gulch and use `.debug bg`.
2. Trigger a premature ending at 0 to 0 and confirm the result is neutral.
3. Reach 1 to 1 with Alliance capturing last, trigger a premature ending, and confirm Alliance wins.
4. Repeat 1 to 1 with Horde capturing last and confirm Horde wins.
5. Repeat at 2 to 2 and verify the same tiebreaker.
6. End early with unequal scores and confirm the team with more captures wins.
7. At 1-1 and 2-2, make the last-capture team leave; verify the selected outcome and obtain maintainer agreement on the intended rule.
8. At 0-0, verify marks, honor, daily-win/arena credit and pvpstats record for the neutral result.

The last-capture tiebreaker also applies when that team is below minimum population or has no players left. That is the literal behavior requested by #26972, whose reproduction explicitly concerns early endings after players leave. It differs from awarding a tied premature game to the remaining populated team; the reviewer has requested a decision on this case.

A 0-0 result uses TEAM_NEUTRAL and gives neither team winner-only rewards or daily-win credit.

## Known Issues and TODO List:
- [ ] Issue-owner decision on awarding a tied premature game to the last-capture team when that team has emptied out; requested in the [latest review](https://github.com/azerothcore/azerothcore-wotlk/pull/27484#issuecomment-5645933478).
- [ ] In-game verification of 0-0, 1-1, 2-2, and the case where the last-capture team leaves.

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
