### PR TITLE
fix(Core/IoC): attach hangar teleports to gunships

### DIFF
--- a/src/server/game/Battlegrounds/Zones/BattlegroundIC.cpp
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundIC.cpp
@@ -74,12 +74,36 @@ void BattlegroundIC::DoAction(uint32 action, ObjectGuid guid)
         return;
 
     MotionTransport* transport = player->GetTeamId() == TEAM_ALLIANCE ? gunshipAlliance : gunshipHorde;
-    float x = BG_IC_HangarTrigger[player->GetTeamId()].GetPositionX();
-    float y = BG_IC_HangarTrigger[player->GetTeamId()].GetPositionY();
-    float z = BG_IC_HangarTrigger[player->GetTeamId()].GetPositionZ();
-    transport->CalculatePassengerPosition(x, y, z);
+    Position const& localPosition = BG_IC_HangarTeleport[player->GetTeamId()];
+    float x, y, z, orientation;
+    localPosition.GetPosition(x, y, z, orientation);
+    transport->CalculatePassengerPosition(x, y, z, &orientation);
 
-    player->TeleportTo(GetMapId(), x, y, z, player->GetOrientation(), TELE_TO_NOT_LEAVE_TRANSPORT);
+    Transport* previousTransport = player->GetTransport();
+    auto const previousTransportInfo = player->m_movementInfo.transport;
+    if (previousTransport)
+        previousTransport->RemovePassenger(player);
+
+    // The teleport packet must include the ship and local coordinates, so the client
+    // keeps moving with the ship while acknowledging the teleport.
+    player->SetTransport(transport);
+    player->m_movementInfo.transport.Reset();
+    player->m_movementInfo.transport.guid = transport->GetGUID();
+    player->m_movementInfo.transport.pos = localPosition;
+    player->m_movementInfo.transport.time = transport->GetPathProgress();
+    player->AddUnitMovementFlag(MOVEMENTFLAG_ONTRANSPORT);
+    transport->AddPassenger(player);
+
+    if (!player->TeleportTo(GetMapId(), x, y, z, orientation, TELE_TO_NOT_LEAVE_TRANSPORT))
+    {
+        transport->RemovePassenger(player);
+        player->SetTransport(previousTransport);
+        player->m_movementInfo.transport = previousTransportInfo;
+        if (previousTransport)
+            previousTransport->AddPassenger(player);
+        else
+            player->RemoveUnitMovementFlag(MOVEMENTFLAG_ONTRANSPORT);
+    }
 }
 
 void BattlegroundIC::HandlePlayerResurrect(Player* player)

--- a/src/server/game/Battlegrounds/Zones/BattlegroundIC.h
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundIC.h
@@ -557,6 +557,13 @@ const Position BG_IC_HangarTrigger[2] =
     {7.305609f, -0.095246f, 40.51022f, 3.159046f}
 };
 
+const Position BG_IC_HangarTeleport[2] =
+{
+    {-25.73f, -0.09f, 26.1f, 3.211406f},
+    // Sniffed portal destination; the target trigger is six yards above this position.
+    {7.305609f, -0.095246f, 34.51022f, 3.159046f}
+};
+
 const Position BG_IC_HangarCaptains[4] =
 {
     {825.6667f, -994.00520f, 134.3569f, 3.403392f},

--- a/src/server/scripts/Northrend/isle_of_conquest.cpp
+++ b/src/server/scripts/Northrend/isle_of_conquest.cpp
@@ -400,7 +400,7 @@ class spell_ioc_gunship_portal : public SpellScript
         Player* caster = GetCaster()->ToPlayer();
         if (!caster->IsBeingTeleported())
             if (Battleground* bg = caster->GetBattleground())
-                bg->DoAction(2 /**/, caster->GetGUID());
+                bg->DoAction(ACTION_TELEPORT_PLAYER_TO_TRANSPORT, caster->GetGUID());
     }
 
     void Register() override


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
The Isle of Conquest hangar portal currently converts a transport-local trigger position to world coordinates and teleports the player without first attaching the player to the gunship. The teleport packet therefore lacks the ship GUID and local offset while the ship is moving. The Horde destination also uses the trigger position six yards above the sniffed deck destination.

This PR registers the player as a gunship passenger before teleporting, fills the transport movement data used by the client, and rolls the registration back if teleportation fails. It separates the portal target trigger position from the actual deck destination and uses the stored sniffed Horde z coordinate.

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Codex desktop, GPT
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #23679

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [x] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

The portal script already contains the captured server-to-client teleport data, including Horde local position `7.305609, -0.095246, 34.51022` and the transport GUID fields. The linked issue provides reproduction footage.

## Tests Performed:

On `6dc5e1de9`, the C++ build matrix and [full live-stack e2e suite](https://github.com/azerothcore/azerothcore-wotlk/actions/runs/34604635101/job/103282693983) passed. The remaining red [dashboard integration check on Ubuntu 26.04](https://github.com/azerothcore/azerothcore-wotlk/actions/runs/34604634958/job/103279975561) times out in `Test authserver with startup scripts`: authserver repeatedly reports `No valid realms specified`, and the failure handler then streams PM2 logs instead of returning after its 300-second timeout. The GitHub rerun request was refused because this account lacks the required repository rights. A maintainer rerun or CI-fixture investigation is needed; gameplay verification remains outstanding.


<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Static checks performed:
- `git diff --check`
- AzerothCore C++ codestyle linter
- Review of Player teleport handling, transport passenger handling, existing transport teleport commands, and the stored packet data
- Review of the failure rollback path

No local build or manual in-game test was performed.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Capture the hangar in Isle of Conquest as Alliance.
2. Use each hangar portal while the Alliance gunship is stationary and while it is moving through several parts of its route.
3. Confirm the player appears on the deck, immediately moves with the ship, and does not fall through or become stuck.
4. Leave the deck normally and use the portal again.
5. Repeat all steps as Horde, especially while the gunship is east of the Horde keep above the water.
6. Repeatedly enter the portal during ship movement and confirm no stale transport attachment remains after leaving the ship.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ] In-game verification on both moving gunships is still required.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
