### PR TITLE
fix(Core/Groups): finalize timed-out loot votes

### DIFF
--- a/src/server/game/Groups/Group.cpp
+++ b/src/server/game/Groups/Group.cpp
@@ -1550,7 +1550,18 @@ void Group::EndRoll(Loot* pLoot)
     {
         if ((*itr)->getLoot() == pLoot)
         {
-            CountTheRoll(itr);           //i don't have to edit player votes, who didn't vote ... he will pass
+            Roll* roll = *itr;
+            for (auto& [playerGuid, vote] : roll->playerVote)
+            {
+                if (vote != NOT_EMITED_YET)
+                    continue;
+
+                vote = PASS;
+                ++roll->totalPass;
+                SendLootRoll(ObjectGuid::Empty, playerGuid, 128, ROLL_PASS, *roll);
+            }
+
+            CountTheRoll(itr);
             itr = RollId.begin();
         }
         else


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
When a group loot timer expires, `EndRoll` resolves the item without recording PASS for unanswered votes. The existing result packets already include those players, but the issue reports that their roll window remains visible.

This PR converts only `NOT_EMITED_YET` votes to PASS, updates the pass count, and broadcasts a timeout PASS before the existing result logic. The packet uses `roll->itemGUID`, matching the roll ID sent in `SMSG_LOOT_START_ROLL` and the existing automatic-pass broadcasts. This gives the client a PASS event tied to the particular roll; closing the stock-client window still needs runtime verification.

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Codex desktop, GPT
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #27299

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

The linked issue includes reproduction video from clients with and without addons. The timeout packet uses the roll GUID from the existing automatic-pass paths in `GroupLoot`, `NeedBeforeGreed`, and `MasterLoot`.

## Tests Performed:

The previous revision `a21e28186` passed all executed CI checks, including the [full live-stack e2e suite](https://github.com/azerothcore/azerothcore-wotlk/actions/runs/34604633513/job/103282205863). That suite does not establish that the stock client's unanswered loot window closes.

Follow-up `6c5312482` addresses the review by replacing the empty source GUID in the timeout PASS with `roll->itemGUID`. C++ codestyle and `git diff --check` pass for this change. All executed CI checks on `6c5312482` now pass, including the [full live-stack e2e suite](https://github.com/azerothcore/azerothcore-wotlk/actions/runs/34750038924/job/103705119484). The stock-client timeout window still needs manual verification.

<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Static checks performed:
- `git diff --check`
- AzerothCore C++ codestyle linter
- Manual review of explicit passes, timeout handling, roll packet broadcasting, player removal, and all result branches

No local core build or manual in-game test was performed. The timeout packet and stock-client window behavior have not been captured or verified in game.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. In a GROUP_LOOT group, have one player choose NEED and another leave the popup unanswered. After timeout, confirm the need roller wins, the unanswered player's window closes, and exactly one timeout PASS is shown for that player. If capturing packets, check that its GUID and slot match `SMSG_LOOT_START_ROLL`.
2. Let every eligible player time out. Confirm the ALL_PASSED result, closed windows, and that the item can be looted afterward.
3. With at least three players and disenchant available, choose GREED and DISENCHANT while another player times out. Confirm the usual winner handling and closure for the timed-out player.
4. Repeat those cases with NEED_BEFORE_GREED, and with a rollable chest instead of a corpse.
5. Include a player with pass-on-loot enabled beside a player who times out. Check the initial automatic pass and the timeout pass separately, with one pass line per player and no second timeout pass for an already-PASS vote.
6. Repeat after a rolling player disconnects or leaves the group before timeout. Check the remaining participants and item result.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ] In-game verification is still required.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
