### PR TITLE
fix(Scripts/BWL): keep disarmed suppression devices

### DIFF
--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_broodlord_lashlayer.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/BlackwingLair/boss_broodlord_lashlayer.cpp
@@ -170,6 +170,7 @@ struct go_suppression_device : public GameObjectAI
     {
         if (action == ACTION_DEACTIVATE)
         {
+            Deactivate();
             _events.CancelEvent(EVENT_SUPPRESSION_RESET);
         }
         else if (action == ACTION_DISARMED)
@@ -180,6 +181,16 @@ struct go_suppression_device : public GameObjectAI
             if (_instance->GetBossState(DATA_BROODLORD_LASHLAYER) != DONE)
                 _events.ScheduleEvent(EVENT_SUPPRESSION_RESET, 30s, 120s);
         }
+    }
+
+    void OnStateChanged(uint32 state, Unit* /*unit*/) override
+    {
+        if (state != GO_JUST_DEACTIVATED)
+            return;
+
+        // Disarm Trap must disable the device without despawning it.
+        me->SetLootState(GO_READY);
+        DoAction(ACTION_DISARMED);
     }
 
     void Activate()


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
Rogue Disarm Trap currently sets BWL suppression devices to `GO_JUST_DEACTIVATED`, which follows the normal despawn path while the scripted suppression aura continues.

This PR intercepts that state change, keeps the device in place, runs the existing scripted disarm action, and lets its existing 30–120 second reset timer reactivate it. Broodlord death retains the cancel-only behavior from #11082: devices that are already disarmed stay down, while devices that are still active keep working.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools were used entirely or partially to prepare this pull request.
   - Tools/models used: Codex desktop, GPT
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #27274
- Related to #26307

## SOURCE:
The changes have been validated through:
- [ ] Live research
- [ ] Sniffs
- [x] Video evidence, knowledge databases or other public sources
- [ ] The changes come from another project

The linked issue includes reproduction footage showing that Disarm Trap removes the device while its slow continues. Its source footage shows the device disabled in place before it resets.

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by another community member.
- [x] This pull request requires further testing.

Static checks performed:
- `git diff --check`
- AzerothCore C++ codestyle linter
- AzerothCore SQL codestyle linter
- Manual review of disarm, reset, and boss-death paths against #10768 and #11082

No local build or in-game test was performed. CI results should be checked on the current head; passing generic checks does not verify suppression-device gameplay.

## How to Test the Changes:

- [x] Follow the reproduction steps in the linked issue.
- [x] Further testing is required.

1. Enter Blackwing Lair with a rogue who knows Disarm Trap.
2. Approach an active suppression device and confirm it applies the slow aura.
3. Disarm it and confirm the device remains visible but becomes unselectable and stops applying the aura.
4. Wait through its randomized reset interval and confirm it becomes active again.
5. Leave one device active and disarm another, then defeat Broodlord Lashlayer before the reset deadline. Confirm the active device still applies suppression and the disarmed device does not reactivate.
6. Disarm a device after the kill and confirm it remains visible and disabled.

## Known Issues and TODO List:

- [ ] In-game verification is still required.
- [ ] The reset deadline remains in the AI EventMap and is not persisted through a full instance unload or server restart. This limitation is still open; ordinary movement out of a grid does not unload it in the current core.
- [ ] The pre-existing behavior that deactivates all devices when loading a completed instance is tracked separately in #27670 and is unchanged here.

## How to Test AzerothCore PRs

When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback on the PR page. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
