### PR TITLE
fix(Scripts/Onyxia): respawn warders on engage

### DIFF
--- a/src/server/scripts/Kalimdor/OnyxiasLair/boss_onyxia.cpp
+++ b/src/server/scripts/Kalimdor/OnyxiasLair/boss_onyxia.cpp
@@ -16,10 +16,15 @@
  */
 
 #include "CreatureScript.h"
+#include "Map.h"
 #include "Player.h"
 #include "ScriptedCreature.h"
 #include "SpellInfo.h"
 #include "onyxias_lair.h"
+
+#include <array>
+
+std::array<ObjectGuid::LowType, 4> constexpr OnyxianWarderSpawnIds = { 12550, 12551, 12552, 12553 };
 
 enum Spells
 {
@@ -195,6 +200,25 @@ public:
     {
         Talk(SAY_AGGRO);
         SetPhase(PHASE_GROUNDED);
+
+        for (ObjectGuid::LowType spawnId : OnyxianWarderSpawnIds)
+        {
+            bool hasAliveSpawn = false;
+            auto bounds = me->GetMap()->GetCreatureBySpawnIdStore().equal_range(spawnId);
+            for (auto itr = bounds.first; itr != bounds.second; ++itr)
+            {
+                if (!itr->second->IsAlive())
+                    itr->second->Respawn();
+                hasAliveSpawn |= itr->second->IsAlive();
+            }
+
+            // Dynamic respawns remove the dead object from the map, so force its database spawn as well.
+            if (!hasAliveSpawn)
+            {
+                me->GetMap()->RemoveCreatureRespawnTime(spawnId);
+                me->GetMap()->ProcessCreatureRespawn(spawnId);
+            }
+        }
 
         instance->DoStopTimedAchievement(ACHIEVEMENT_TIMED_TYPE_EVENT, ACHIEV_TIMED_START_EVENT); // just in case at reset some players already left the instance
         instance->DoStartTimedAchievement(ACHIEVEMENT_TIMED_TYPE_EVENT, ACHIEV_TIMED_START_EVENT);

--- a/src/server/scripts/Kalimdor/OnyxiasLair/boss_onyxia.cpp
+++ b/src/server/scripts/Kalimdor/OnyxiasLair/boss_onyxia.cpp
@@ -16,7 +16,9 @@
  */
 
 #include "CreatureScript.h"
+#include "GameTime.h"
 #include "Map.h"
+#include "ObjectMgr.h"
 #include "Player.h"
 #include "ScriptedCreature.h"
 #include "SpellInfo.h"
@@ -201,22 +203,28 @@ public:
         Talk(SAY_AGGRO);
         SetPhase(PHASE_GROUNDED);
 
+        Map* map = me->GetMap();
         for (ObjectGuid::LowType spawnId : OnyxianWarderSpawnIds)
         {
-            bool hasAliveSpawn = false;
-            auto bounds = me->GetMap()->GetCreatureBySpawnIdStore().equal_range(spawnId);
-            for (auto itr = bounds.first; itr != bounds.second; ++itr)
-            {
-                if (!itr->second->IsAlive())
-                    itr->second->Respawn();
-                hasAliveSpawn |= itr->second->IsAlive();
-            }
+            CreatureData const* data = sObjectMgr->GetCreatureData(spawnId);
+            if (!data || data->id != NPC_ONYXIAN_WARDER || data->mapid != map->GetId())
+                continue;
 
-            // Dynamic respawns remove the dead object from the map, so force its database spawn as well.
-            if (!hasAliveSpawn)
+            auto bounds = map->GetCreatureBySpawnIdStore().equal_range(spawnId);
+            if (bounds.first != bounds.second)
             {
-                me->GetMap()->RemoveCreatureRespawnTime(spawnId);
-                me->GetMap()->ProcessCreatureRespawn(spawnId);
+                for (auto itr = bounds.first; itr != bounds.second; ++itr)
+                {
+                    // Preserve fresh corpses for looting and skinning.
+                    if (itr->second->getDeathState() == DeathState::Dead)
+                        itr->second->Respawn();
+                }
+            }
+            else
+            {
+                // Despawned dynamic spawns must return through the normal respawn queue.
+                time_t respawnTime = GameTime::GetGameTime().count();
+                map->SaveCreatureRespawnTime(spawnId, respawnTime);
             }
         }
 

--- a/src/server/scripts/Kalimdor/OnyxiasLair/onyxias_lair.h
+++ b/src/server/scripts/Kalimdor/OnyxiasLair/onyxias_lair.h
@@ -36,6 +36,7 @@ enum eCreatures
 {
     NPC_ONYXIA                  = 10184,
     NPC_ONYXIAN_WHELP           = 11262,
+    NPC_ONYXIAN_WARDER          = 12129,
     NPC_ONYXIA_TRIGGER          = 12758,
     NPC_ONYXIAN_LAIR_GUARD      = 36561,
 };


### PR DESCRIPTION
## Changes Proposed:
Draft implementation of the pull-triggered respawn proposed in #23221; the correct trigger and corpse/reset behavior remain unresolved. Loaded warders now respawn only after their corpse has decayed, preserving fresh corpses for looting and skinning. Despawned warders are scheduled through the map's normal respawn queue. Each GUID is validated against creature entry 12129 and the current map before it can be used.

This PR proposes changes to:
- [ ] Core (units, players, creatures, game systems).
- [x] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests
- [x] AI tools were used to prepare this pull request.
   - Codex desktop assisted implementation and review; this follow-up used GPT-6 (exact backend snapshot unavailable).
- [ ] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Addresses #23221

## SOURCE:
The changes have been validated through:
- [ ] Live research
- [ ] Sniffs
- [x] Video evidence, knowledge databases or other public sources
- [ ] The changes come from another project

The linked issue proposes a pull trigger, but its discussion distinguishes Vanilla/TBC footage and modern retail observations from Wrath-era behavior. I have not established whether Wrath uses a pull trigger, an evade trigger or a timer.

## Tests Performed:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by another community member.
- [x] Further testing is required.

On current revision `f33529415`, the C++ codestyle check, C++ build matrix and dashboard integration passed. The [full e2e job](https://github.com/azerothcore/azerothcore-wotlk/actions/runs/34027519821/job/101471625826) failed in `TestAC_26997_SweepingStrikesExecuteNoCrash` because its Sweeping Strikes aura precondition was not met. This is outside the Onyxia diff; these checks do not verify the warder mechanic.

`git diff --check` and local C++ codestyle passed. Traced Creature::Respawn, SaveCreatureRespawnTime and ProcessRespawns in the PR base: dynamic respawns are no longer cancelled or invoked outside the queue. Gameplay verification and the trigger/lifetime decision remain outstanding.

## How to Test the Changes:
1. Kill the four entrance warders, let their corpses decay, then engage Onyxia. Confirm they return.
2. Repeat with fresh unlooted/skinnable corpses and confirm pulling Onyxia preserves them.
3. Repeat with living warders and confirm no duplicates appear.
4. Test both compatibility and dynamic respawn modes, including an unloaded warder grid.
5. In an isolated test DB, repoint one listed GUID to a different entry or map; confirm the encounter does not summon it.

Current limitation: these are persistent DB spawns, not entries in Onyxia's summons list. Restored warders remain after boss reset or death; this patch adds no despawn for them. The corpse guard skips fresh corpses entirely, so it does not fulfill an unconditional “all dead warders respawn on pull” rule. Both policies need evidence before changing them. Creature formation GroupAI supports respawn on evade, which would be appropriate only if evade is the confirmed trigger.

## Known Issues and TODO List:

- [ ] In-game verification is still required.

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
