### PR TITLE
fix(Scripts/Ulduar): resume bots after Magnetic Core

### DIFF
--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_mimiron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_mimiron.cpp
@@ -1612,7 +1612,7 @@ struct npc_ulduar_aerial_command_unit : public ScriptedAI
                 me->RemoveUnitMovementFlag(MOVEMENTFLAG_HOVER);
                 me->GetMotionMaster()->MoveFall();
                 me->SetHover(false);
-                _events.DelayEvents(25s);
+                _events.DelayEvents(23s);
                 break;
             case DO_ENABLE_AERIAL:
                 if (_isDefeated)
@@ -1684,7 +1684,7 @@ struct npc_ulduar_aerial_command_unit : public ScriptedAI
 
     void UpdateAI(uint32 diff) override
     {
-        if (me->HasUnitFlag(UNIT_FLAG_NOT_SELECTABLE) || me->HasAura(SPELL_MAGNETIC_CORE))
+        if (me->HasUnitFlag(UNIT_FLAG_NOT_SELECTABLE))
             return;
 
         if (!UpdateVictim())
@@ -1727,7 +1727,8 @@ struct npc_ulduar_aerial_command_unit : public ScriptedAI
                 break;
         }
 
-        DoSpellAttackIfReady(_phase == 3 ? SPELL_PLASMA_BALL_P1 : SPELL_PLASMA_BALL_P2);
+        if (!me->HasAura(SPELL_MAGNETIC_CORE))
+            DoSpellAttackIfReady(_phase == 3 ? SPELL_PLASMA_BALL_P1 : SPELL_PLASMA_BALL_P2);
     }
 
     void MoveInLineOfSight(Unit* /*mover*/) override {}


### PR DESCRIPTION
## Changes Proposed:
While Magnetic Core grounds Mimiron's Aerial Command Unit, its AI returns before updating phase-three bot timers. The core downtime is therefore added on top of the explicit event delay, leaving a long gap after the head recovers.

This PR keeps the event clock running while the unit is grounded, blocks only its Plasma Ball attack, and aligns the explicit delay with the Magnetic Core's three-second activation and 25-second lifetime.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools were used entirely or partially to prepare this pull request.
   - Tools/models used: Codex desktop, GPT
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #27303

## SOURCE:
The changes have been validated through:
- [ ] Live research
- [ ] Sniffs
- [x] Video evidence, knowledge databases or other public sources
- [ ] The changes come from another project

The linked issue identifies the recovery and first post-recovery bot spawn in encounter footage. Repository SmartAI gives the core a three-second cast delay and a 25-second despawn time.

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by another community member.
- [x] This pull request requires further testing.

Static checks performed:
- `git diff --check`
- AzerothCore C++ codestyle linter
- Manual timing review of the Magnetic Core aura and phase-three EventMap

No build or in-game test was performed.

## How to Test the Changes:

- [x] Follow the reproduction steps in the linked issue.
- [x] Further testing is required.

1. Start Mimiron and reach phase three.
2. Kill an Assault Bot, loot Magnetic Core, and use it below the Aerial Command Unit.
3. Confirm the head falls, stops casting Plasma Ball, and remains damageable.
4. Observe bot spawn lights after the head lifts; they should resume within a few seconds instead of after roughly 30 seconds.
5. Repeat with Magnetic Core used at different points in the existing Assault, Junk, and Bomb Bot timers.

## Known Issues and TODO List:

- [ ] In-game timing verification is still required.

## How to Test AzerothCore PRs

Testing instructions: http://www.azerothcore.org/wiki/How-to-test-a-PR
