### PR TITLE
fix(Scripts/VoA): respawn Emalon minions nearby

### DIFF
--- a/src/server/scripts/Northrend/VaultOfArchavon/boss_emalon.cpp
+++ b/src/server/scripts/Northrend/VaultOfArchavon/boss_emalon.cpp
@@ -194,7 +194,13 @@ public:
                     Talk(EMOTE_BERSERK);
                     break;
                 case EVENT_SUMMON_NEXT_MINION:
-                    me->SummonCreature(NPC_TEMPEST_MINION, TempestMinions[urand(0, 3)], TEMPSUMMON_CORPSE_DESPAWN, 0);
+                    if (Creature* minion = me->SummonCreature(NPC_TEMPEST_MINION,
+                        me->GetNearPosition(frand(5.0f, 10.0f), frand(0.0f, 2.0f * float(M_PI))),
+                        TEMPSUMMON_CORPSE_DESPAWN, 0))
+                    {
+                        DoZoneInCombat(minion);
+                        Talk(EMOTE_MINION_RESPAWN);
+                    }
                     break;
                 default:
                     break;


### PR DESCRIPTION
## Changes Proposed:
Emalon currently replaces a defeated Tempest Minion at a random starting position. The replacement can appear far from the fight, remain idle, and emits no encounter message.

This PR summons the replacement five to ten yards from Emalon, puts it into zone combat, and sends the existing minion-respawn emote after a successful summon.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools were used entirely or partially to prepare this pull request.
   - Tools/models used: Codex desktop, GPT
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #27397

## SOURCE:
- [ ] Live research
- [ ] Sniffs
- [x] Video evidence, knowledge databases or other public sources
- [ ] The changes come from another project

The linked issue provides encounter footage showing replacement minions appearing close to Emalon and documents the expected message.

## Tests Performed:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by another community member.
- [x] Further testing is required.

Static checks: `git diff --check`, AzerothCore C++ codestyle linter, and manual review of the successful-summon path. No build or in-game test was performed.

## How to Test the Changes:

1. Enter Vault of Archavon and engage Emalon.
2. Move Emalon away from the four initial minion positions.
3. Kill one Tempest Minion and wait for its replacement.
4. Confirm it appears five to ten yards from Emalon, enters combat immediately, and broadcasts the respawn emote.
5. Repeat from several positions and after a wipe.

## Known Issues and TODO List:

- [ ] In-game verification is still required.

## How to Test AzerothCore PRs

Testing instructions: http://www.azerothcore.org/wiki/How-to-test-a-PR
