### PR TITLE
fix(Scripts/Dragonblight): restrict temporal ally targets

### DIFF
--- a/src/server/scripts/Northrend/zone_dragonblight.cpp
+++ b/src/server/scripts/Northrend/zone_dragonblight.cpp
@@ -542,9 +542,23 @@ public:
                 me->SetFaction(me->ToTempSummon()->GetSummonerUnit()->GetFaction());
         }
 
+        bool CanAIAttack(Unit const* who) const override
+        {
+            switch (who->GetEntry())
+            {
+                case NPC_INFINITE_ASSAILANT:
+                case NPC_INFINITE_CHRONO_MAGUS:
+                case NPC_INFINITE_DESTROYER:
+                case NPC_INFINITE_TIMERENDER:
+                    return !who->IsFlying();
+                default:
+                    return false;
+            }
+        }
+
         void MoveInLineOfSight(Unit* who) override
         {
-            if (!me->GetVictim() && !who->IsFlying() && who->GetEntry() >= NPC_INFINITE_ASSAILANT && who->GetEntry() <= NPC_INFINITE_TIMERENDER)
+            if (!me->GetVictim() && CanAIAttack(who))
                 AttackStart(who);
         }
 


### PR DESCRIPTION
## Changes Proposed:
The temporal ally's entry restriction currently applies only to line-of-sight acquisition. This PR also applies an explicit allowlist to threat-based victim selection through CanAIAttack, so Future You and Past You can attack only the four intended event enemies.

The old range already excluded Infinite Eradicators (32185) and Timebreakers (32186) from line-of-sight acquisition. The new default branch excludes them from threat selection as well; how they originally enter the ally's threat list and whether this resolves the reported stall remain unverified. IsFlying is only an additional guard for allowed entries, not the mechanism excluding those two NPCs.

The explicit list also excludes Future You (27899), which was accidentally included in the old numeric range. Two players' Future You copies therefore no longer qualify as each other's targets.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools were used entirely or partially to prepare this pull request.
   - Tools/models used: Codex desktop, GPT
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Addresses #23709

## SOURCE:
- [ ] Live research
- [ ] Sniffs
- [x] Video evidence, knowledge databases or other public sources
- [ ] The changes come from another project

The issue includes original-era footage in which the temporal ally ignores a nearby enemy player. The script itself defines the four intended enemy entries.

## Tests Performed:

CI on `54444bf8e` passed all executed checks, including the [full live-stack e2e suite](https://github.com/azerothcore/azerothcore-wotlk/actions/runs/34604634518/job/103282666426). This is a suite result; the gameplay scenarios in this PR still need direct in-game verification.


- [ ] Tested in-game by the author.
- [ ] Tested in-game by another community member.
- [x] Further testing is required.

Static checks: `git diff --check`, AzerothCore C++ codestyle linter, and review of both quest variants' spawn paths. No local build or manual in-game test was performed.

## How to Test the Changes:

1. Start quest 12470 and place the Hourglass of Eternity.
2. Confirm Future You attacks the three normal Infinite attackers and the Timerender.
3. Confirm it ignores the flying Eradicators and Timebreakers overhead.
4. Attack it with an opposite-faction player and confirm it stays focused on event enemies.
5. Repeat the same checks for quest 13343 and Past You.
6. Run the entire event with the flying Infinites nearby; confirm the ally survives and the quest completes. Record the actual target if it still stalls.
7. Run two nearby players through the event and confirm their temporal copies do not attack each other.
8. Test an enemy player as the only attacker, then stop attacking; verify combat clears without a persistent stall.

## Known Issues and TODO List:

- [ ] In-game verification of both quest variants, ally survival and combat cleanup is still required. The acquisition path behind the reported flying-target stall has not been reproduced.

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
