### PR TITLE
fix(Scripts/SSC): switch Hydross by cleansing field

### DIFF
--- a/src/server/scripts/Outland/CoilfangReservoir/SerpentShrine/boss_hydross_the_unstable.cpp
+++ b/src/server/scripts/Outland/CoilfangReservoir/SerpentShrine/boss_hydross_the_unstable.cpp
@@ -235,10 +235,10 @@ struct boss_hydross_the_unstable : public BossAI
 
         scheduler.Schedule(1s, [this](TaskContext context)
         {
-            if (me->HasAura(SPELL_BLUE_BEAM) == me->HasAura(SPELL_CORRUPTION))
-            {
-                SetForm(!me->HasAura(SPELL_BLUE_BEAM), false);
-            }
+            // The cleansing field determines the phase; its beam is only a visual.
+            bool const cleansed = me->HasAura(SPELL_CLEANSING_FIELD_AURA);
+            if (cleansed == me->HasAura(SPELL_CORRUPTION))
+                SetForm(!cleansed, false);
             context.Repeat(1s);
         }).Schedule(10min, [this](TaskContext)
         {


### PR DESCRIPTION
## Changes Proposed:
Hydross currently uses the blue beam visual to decide whether he is inside the cleansing field. On engage, that visual can disagree with the field state, immediately forcing nature form and preventing later transitions.

This PR uses `SPELL_CLEANSING_FIELD_AURA` as the phase signal while retaining the existing form-change mechanics.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools were used entirely or partially to prepare this pull request.
   - Tools/models used: Codex desktop, GPT
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #27118

## SOURCE:
- [ ] Live research
- [ ] Sniffs
- [x] Video evidence, knowledge databases or other public sources
- [ ] The changes come from another project

The linked issue supplies footage for both crossings of the arena boundary.

## Tests Performed:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by another community member.
- [x] Further testing is required.

Static checks: `git diff --check`, AzerothCore C++ codestyle linter, and manual truth-table review of both aura/form combinations. No build or in-game test was performed.

## How to Test the Changes:

1. Enter Serpentshrine Cavern and engage Hydross at his initial position.
2. Confirm he begins and remains in frost form inside the cleansing field.
3. Pull him beyond the purple boundary and confirm he changes to nature form once.
4. Move him back inside and confirm he returns to frost form.
5. Repeat several crossings and verify marks, immunities, threat resets, and spawned adds.

## Known Issues and TODO List:

- [ ] In-game verification is still required.

## How to Test AzerothCore PRs

Testing instructions: http://www.azerothcore.org/wiki/How-to-test-a-PR
