### PR TITLE
fix(DB/Achievement): align arena title criteria

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1788502540643764000.sql
+++ b/data/sql/updates/pending_db_world/rev_1788502540643764000.sql
@@ -1,0 +1,16 @@
+-- Deadly Gladiator is missing from all four lower PvP title achievements.
+-- Add alternatives; retain the existing Season 6-8 and lower-rank criteria.
+DELETE FROM `achievement_criteria_dbc` WHERE `ID` IN (20000, 20001, 20002, 20003);
+INSERT INTO `achievement_criteria_dbc` (`ID`, `Achievement_Id`, `Type`, `Quantity`,
+    `Description_Lang_enUS`, `Flags`, `Ui_Order`) VALUES
+    (20000, 2090, 74, 1, 'Deadly Gladiator', 2, 8),
+    (20001, 2091, 74, 1, 'Deadly Gladiator', 2, 5),
+    (20002, 2092, 74, 1, 'Deadly Gladiator', 2, 6),
+    (20003, 2093, 74, 1, 'Deadly Gladiator', 2, 7);
+
+DELETE FROM `achievement_criteria_data` WHERE `criteria_id` IN (20000, 20001, 20002, 20003);
+INSERT INTO `achievement_criteria_data` (`criteria_id`, `type`, `value1`, `value2`, `ScriptName`) VALUES
+    (20000, 23, 157, 0, ''),
+    (20001, 23, 157, 0, ''),
+    (20002, 23, 157, 0, ''),
+    (20003, 23, 157, 0, '');

--- a/data/sql/updates/pending_db_world/rev_1788502540643764000.sql
+++ b/data/sql/updates/pending_db_world/rev_1788502540643764000.sql
@@ -1,16 +1,16 @@
--- Deadly Gladiator is missing from all four lower PvP title achievements.
--- Add alternatives; retain the existing Season 6-8 and lower-rank criteria.
-DELETE FROM `achievement_criteria_dbc` WHERE `ID` IN (20000, 20001, 20002, 20003);
-INSERT INTO `achievement_criteria_dbc` (`ID`, `Achievement_Id`, `Type`, `Quantity`,
-    `Description_Lang_enUS`, `Flags`, `Ui_Order`) VALUES
-    (20000, 2090, 74, 1, 'Deadly Gladiator', 2, 8),
-    (20001, 2091, 74, 1, 'Deadly Gladiator', 2, 5),
-    (20002, 2092, 74, 1, 'Deadly Gladiator', 2, 6),
-    (20003, 2093, 74, 1, 'Deadly Gladiator', 2, 7);
-
-DELETE FROM `achievement_criteria_data` WHERE `criteria_id` IN (20000, 20001, 20002, 20003);
-INSERT INTO `achievement_criteria_data` (`criteria_id`, `type`, `value1`, `value2`, `ScriptName`) VALUES
-    (20000, 23, 157, 0, ''),
-    (20001, 23, 157, 0, ''),
-    (20002, 23, 157, 0, ''),
-    (20003, 23, 157, 0, '');
+-- Match the existing PvP title criteria to their 3.3.5a client descriptions.
+-- Deadly Gladiator has title 157; Wrathful has no criterion in these achievements.
+-- Gladiator
+UPDATE `achievement_criteria_data` SET `value1` = 42 WHERE `type` = 23 AND `criteria_id` IN (7416, 9718, 9721);
+-- Duelist
+UPDATE `achievement_criteria_data` SET `value1` = 43 WHERE `type` = 23 AND `criteria_id` IN (7415, 9720);
+-- Rival
+UPDATE `achievement_criteria_data` SET `value1` = 44 WHERE `type` = 23 AND `criteria_id` IN (7418, 9719);
+-- Challenger
+UPDATE `achievement_criteria_data` SET `value1` = 45 WHERE `type` = 23 AND `criteria_id` IN (7408);
+-- Deadly Gladiator
+UPDATE `achievement_criteria_data` SET `value1` = 157 WHERE `type` = 23 AND `criteria_id` IN (10878, 10879, 10881, 13001);
+-- Furious Gladiator
+UPDATE `achievement_criteria_data` SET `value1` = 167 WHERE `type` = 23 AND `criteria_id` IN (12999, 13002, 13006);
+-- Relentless Gladiator
+UPDATE `achievement_criteria_data` SET `value1` = 169 WHERE `type` = 23 AND `criteria_id` IN (13000, 13003, 13005);


### PR DESCRIPTION
## Changes Proposed:
The existing arena-title criteria are assigned to the wrong title IDs. Deadly Gladiator (157) is absent, while Wrathful (177) is assigned to criteria whose client descriptions name other titles.

This draft replaces the previous synthetic criteria with updates to 18 existing known-title rows. All 22 criteria for Challenger, Gladiator, Duelist and Rival then match their 3.3.5a DBC descriptions. No new criteria IDs or client-invisible descriptions are introduced.

**Unresolved behavior:** this exact DBC mapping removes the existing Wrathful-only qualification path. Issue #27435 explicitly describes Season 8 as working; this draft is therefore a reviewable mapping proposal, not a merge-ready fix. A maintainer decision is needed on preserving that path before proceeding.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools were used entirely or partially to prepare this pull request.
   - Tools/models used: Codex desktop, GPT
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Addresses #27435

## SOURCE:
- [ ] Live research
- [ ] Sniffs
- [x] Video evidence, knowledge databases or other public sources
- [ ] The changes come from another project

Cross-checked the 22 criteria in local 3.3.5a `Achievement_Criteria.dbc`, their names in `CharTitles.dbc`, and the current upstream `achievement_criteria_data` dump. The DBC contains Deadly/Furious/Relentless criteria but no Wrathful criterion for these four achievements. The issue documents the existing Season 8 behavior that this DBC-only proposal would lose.

## Tests Performed:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by another community member.
- [x] Further testing is required.

On `413bc1120`: SQL codestyle and `git diff --check` passed. In an isolated MySQL 8.4 database loaded with the current upstream criteria table, the update changed exactly 18 rows, left all other rows unchanged, matched all 22 DBC mappings, and produced identical results when applied twice. The SQL linter used official `azerothcore/master` in place of the fork's absent `origin/master`. No server build or in-game test was performed.

## How to Test the Changes:

1. Use a non-GM level 80 character without achievements 2090–2093.
2. Grant achievement 3336, log out, and log back in.
3. Confirm Challenger, Rival, Duelist, and Gladiator are granted.
4. Repeat with a character that already owns some lower achievements and confirm no duplicates or errors.
5. Confirm Furious and Relentless still grant the same lower achievements.
6. On a separate character with only Wrathful (177), verify the changed result: this draft has no matching criterion. Resolve the Season 8 requirement before merging.
7. If testing after the earlier synthetic-criteria revision, restore the affected tables to the upstream baseline first; this replacement migration assumes that baseline.

## Known Issues and TODO List:

- [ ] Resolve whether/how the existing Wrathful qualification must be preserved.
- [ ] In-game verification is still required.

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
