### PR TITLE
fix(Scripts/ZulAman): Zul'jin no longer stays in troll form when entering Dragonhawk phase

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -157,7 +157,6 @@ If the scenario should stay as a regression, **move** it into `suites/` next to 
 | instances/bind_reset | party tele; ritual summon | P2 | covered; post-reset summon `blocked-harness` (AcceptSummon after reset) | #10708 |
 | instances/classic/stratholme | Timmy remains hidden while a relevant Square Scarlet lives, then emerges after the area is clear | P2 | covered (`TestAC_26363_TimmyEmergesAfterSquareCleared`) | #26363 |
 | instances/ulduar | named tele; Freya wave interval | P2 | covered (`TestAC_27095_*`); Kologarn Charge `blocked-harness` (bridge Z after Charge) | #26266 #27095 |
-| instances/zulaman | Zul'jin has Shape of the Dragonhawk (42608) after the 20% transition, with Claw Rage (43149) and Lynx Rush (43152) gone | P1 | `gap` (no Go toolchain or AzerothGhost checkout locally; needs boss-AI drive to 20% + aura query) | — |
 
 ---
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -157,6 +157,7 @@ If the scenario should stay as a regression, **move** it into `suites/` next to 
 | instances/bind_reset | party tele; ritual summon | P2 | covered; post-reset summon `blocked-harness` (AcceptSummon after reset) | #10708 |
 | instances/classic/stratholme | Timmy remains hidden while a relevant Square Scarlet lives, then emerges after the area is clear | P2 | covered (`TestAC_26363_TimmyEmergesAfterSquareCleared`) | #26363 |
 | instances/ulduar | named tele; Freya wave interval | P2 | covered (`TestAC_27095_*`); Kologarn Charge `blocked-harness` (bridge Z after Charge) | #26266 #27095 |
+| instances/zulaman | Zul'jin has Shape of the Dragonhawk (42608) after the 20% transition, with Claw Rage (43149) and Lynx Rush (43152) gone | P1 | `gap` (no Go toolchain or AzerothGhost checkout locally; needs boss-AI drive to 20% + aura query) | — |
 
 ---
 

--- a/src/server/scripts/EasternKingdoms/ZulAman/boss_zuljin.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulAman/boss_zuljin.cpp
@@ -227,6 +227,8 @@ struct boss_zuljin : public BossAI
         // Phase 5: Dragonhawk Form.
         ScheduleHealthCheckEvent({ 20 }, [&] {
             me->m_Events.CancelEventGroup(GROUP_LYNX);
+            me->RemoveAurasDueToSpell(SPELL_CLAW_RAGE_AURA);
+            me->RemoveAurasDueToSpell(SPELL_LYNX_RUSH_HASTE);
             EnterPhase(PHASE_DRAGONHAWK);
 
             ScheduleTimedEvent(12s, 26s, [&] {


### PR DESCRIPTION
Zul'jin could fail to apply Shape of the Dragonhawk (42608) on the 20% transition. He entered phase 5 behaviorally and used the correct abilities but remained visually in base troll form.

Claw Rage (43149) is a 6s aura Zul'jin self-casts during Lynx phase that ticks twice a second, each tick casting 43150 on the charge target as a non-triggered cast. The transform is not cast until MovementInform fires a 2s delayed event, several seconds after the health check, so a tick landing in that window interrupts the 1s 42608 cast.

Strip 43149 at the health check so the transform completes. Also strip Lynx Rush (43152): it is not part of the interrupt, but a Lynx-form melee attack-speed aura should not persist into Dragonhawk form. This matches the aura removal at the end of Eagle form.

Record the missing e2e coverage as a gap in the inventory; no local AzerothGhost harness is available to write the test.

<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Opus 5
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

I tested with the Playerbots fork, though I did so without bots present.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. .go c name zul'jin
2. .damage 350000 to get him through each phase transition
3. In Phase 4, wait until he starts Claw Rage, then immediately .damage enough to push him past 20%

Before: Zul'jin drops into troll form, Claw Rage continues (visible aura), Zul'jin walks to center and starts transformation sequence (Claw Rage still continuing), Phase 5 starts but Zul'jin remains in troll form
Now: Zul'jin drops into troll form, Claw Rage is immediately removed, Zul'jin walks to center and transforms into Dragonhawk

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
