### PR TITLE
fix(Scripts/SSC): drive Hydross' form and beams from the Cleansing Field aura

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1788549623280142700.sql
+++ b/data/sql/updates/pending_db_world/rev_1788549623280142700.sql
@@ -1,0 +1,9 @@
+-- Hydross' Cleansing Field Helper and both Beam Helpers to their sniffed spawn positions
+UPDATE `creature` SET `position_x` = -239.715, `position_y` = -366.44, `position_z` = -0.744514, `orientation` = 1.23918, `VerifiedBuild` = 69587 WHERE `guid` = 153019 AND `id` = 21934;
+UPDATE `creature` SET `position_x` = -215.753, `position_y` = -375.343, `position_z` = 38.403, `orientation` = 5.0091, `VerifiedBuild` = 69587 WHERE `guid` = 153020 AND `id` = 21933;
+UPDATE `creature` SET `position_x` = -264.165, `position_y` = -357.171, `position_z` = 38.8069, `orientation` = 2.84489, `VerifiedBuild` = 69587 WHERE `guid` = 153021 AND `id` = 21933;
+UPDATE `creature` SET `VerifiedBuild` = 69587 WHERE `guid` = 153018 AND `id` = 21216;
+
+-- The Beam Helpers now toggle Blue Beam straight from the Cleansing Field aura script
+DELETE FROM `spell_script_names` WHERE `spell_id` = 37934 AND `ScriptName` = 'spell_hydross_cleansing_field_command';
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 13 AND `SourceGroup` = 1 AND `SourceEntry` = 37934;

--- a/src/server/scripts/Outland/CoilfangReservoir/SerpentShrine/boss_hydross_the_unstable.cpp
+++ b/src/server/scripts/Outland/CoilfangReservoir/SerpentShrine/boss_hydross_the_unstable.cpp
@@ -35,7 +35,6 @@ enum Talk
 enum Spells
 {
     SPELL_CLEANSING_FIELD_AURA  = 37935,
-    SPELL_CLEANSING_FIELD       = 37934,
     SPELL_BLUE_BEAM             = 38015,
     SPELL_ELEMENTAL_SPAWNIN     = 25035,
     SPELL_PURIFY_ELEMENTAL      = 36461,
@@ -76,7 +75,14 @@ enum Misc
 
     NPC_PURIFIED_WATER_ELEMENTAL    = 21260,
     NPC_PURE_SPAWN_OF_HYDROSS       = 22035,
-    NPC_TAINTED_HYDROSS_ELEMENTAL   = 21253
+    NPC_TAINTED_HYDROSS_ELEMENTAL   = 21253,
+    NPC_HYDROSS_BEAM_HELPER         = 21933
+};
+
+enum Actions
+{
+    ACTION_ENTER_CLEANSING_FIELD    = 1,
+    ACTION_LEAVE_CLEANSING_FIELD    = 2
 };
 
 enum WaterElementalPathIds
@@ -103,13 +109,30 @@ struct boss_hydross_the_unstable : public BossAI
         }, 12s, 12s, GROUP_OOC_PURIFY_ELEMENTALS);
     }
 
-    void JustReachedHome() override
+    void SetBeams(bool enable)
     {
-        BossAI::JustReachedHome();
-        if (!me->HasAura(SPELL_BLUE_BEAM))
+        std::list<Creature*> helpers;
+        me->GetCreatureListWithEntryInGrid(helpers, NPC_HYDROSS_BEAM_HELPER, 200.0f);
+        for (Creature* helper : helpers)
         {
-            me->RemoveAurasDueToSpell(SPELL_CLEANSING_FIELD_AURA);
+            if (!enable)
+                helper->InterruptNonMeleeSpells(false);
+            else if (!helper->HasUnitState(UNIT_STATE_CASTING))
+                helper->CastSpell(helper, SPELL_BLUE_BEAM);
         }
+    }
+
+    void DoAction(int32 action) override
+    {
+        if (action != ACTION_ENTER_CLEANSING_FIELD && action != ACTION_LEAVE_CLEANSING_FIELD)
+            return;
+
+        bool inside = action == ACTION_ENTER_CLEANSING_FIELD;
+        SetBeams(inside);
+
+        // Evade strips the field aura before the engaged flag clears, and on death it lingers on the corpse for a tick
+        if (me->IsAlive() && me->IsEngaged() && !me->IsInEvadeMode() && me->HasAura(SPELL_CORRUPTION) == inside)
+            SetForm(!inside, false);
     }
 
     void SummonMovementInform(Creature* summon, uint32 movementType, uint32 pathId) override
@@ -230,17 +253,10 @@ struct boss_hydross_the_unstable : public BossAI
     {
         BossAI::JustEngagedWith(who);
         Talk(SAY_AGGRO);
-        SetForm(false, true);
+        SetForm(!me->HasAura(SPELL_CLEANSING_FIELD_AURA), true);
         me->m_Events.CancelEventGroup(GROUP_OOC_PURIFY_ELEMENTALS);
 
-        scheduler.Schedule(1s, [this](TaskContext context)
-        {
-            if (me->HasAura(SPELL_BLUE_BEAM) == me->HasAura(SPELL_CORRUPTION))
-            {
-                SetForm(!me->HasAura(SPELL_BLUE_BEAM), false);
-            }
-            context.Repeat(1s);
-        }).Schedule(10min, [this](TaskContext)
+        scheduler.Schedule(10min, [this](TaskContext)
         {
             DoCastSelf(SPELL_ENRAGE, true);
         });
@@ -291,39 +307,19 @@ class spell_hydross_cleansing_field_aura : public AuraScript
     void HandleEffectApply(AuraEffect const*  /*aurEff*/, AuraEffectHandleModes /*mode*/)
     {
         if (GetTarget()->GetEntry() == NPC_HYDROSS_THE_UNSTABLE)
-            if (Unit* caster = GetCaster())
-                caster->CastSpell(caster, SPELL_CLEANSING_FIELD, true);
+            GetTarget()->ToCreature()->AI()->DoAction(ACTION_ENTER_CLEANSING_FIELD);
     }
 
     void HandleEffectRemove(AuraEffect const*  /*aurEff*/, AuraEffectHandleModes /*mode*/)
     {
         if (GetTarget()->GetEntry() == NPC_HYDROSS_THE_UNSTABLE)
-            if (Unit* caster = GetCaster())
-                caster->CastSpell(caster, SPELL_CLEANSING_FIELD, true);
+            GetTarget()->ToCreature()->AI()->DoAction(ACTION_LEAVE_CLEANSING_FIELD);
     }
 
     void Register() override
     {
         AfterEffectApply += AuraEffectApplyFn(spell_hydross_cleansing_field_aura::HandleEffectApply, EFFECT_0, SPELL_AURA_DUMMY, AURA_EFFECT_HANDLE_REAL);
         AfterEffectRemove += AuraEffectRemoveFn(spell_hydross_cleansing_field_aura::HandleEffectRemove, EFFECT_0, SPELL_AURA_DUMMY, AURA_EFFECT_HANDLE_REAL);
-    }
-};
-
-class spell_hydross_cleansing_field_command : public AuraScript
-{
-    PrepareAuraScript(spell_hydross_cleansing_field_command);
-
-    void HandleEffectRemove(AuraEffect const*  /*aurEff*/, AuraEffectHandleModes /*mode*/)
-    {
-        if (GetTarget()->HasUnitState(UNIT_STATE_CASTING))
-            GetTarget()->InterruptNonMeleeSpells(false);
-        else
-            GetTarget()->CastSpell(GetTarget(), SPELL_BLUE_BEAM, true);
-    }
-
-    void Register() override
-    {
-        AfterEffectRemove += AuraEffectApplyFn(spell_hydross_cleansing_field_command::HandleEffectRemove, EFFECT_0, SPELL_AURA_DUMMY, AURA_EFFECT_HANDLE_REAL);
     }
 };
 
@@ -346,6 +342,5 @@ void AddSC_boss_hydross_the_unstable()
 {
     RegisterSerpentShrineAI(boss_hydross_the_unstable);
     RegisterSpellScript(spell_hydross_cleansing_field_aura);
-    RegisterSpellScript(spell_hydross_cleansing_field_command);
     RegisterSpellScript(spell_hydross_mark_of_hydross);
 }


### PR DESCRIPTION
## Changes Proposed:

Hydross the Unstable has been stuck in nature form since the area-target changes in https://github.com/azerothcore/azerothcore-wotlk/pull/26967 and https://github.com/azerothcore/azerothcore-wotlk/pull/27077. This PR fixes the encounter by removing the AC-specific mechanism that broke, replacing it with what the sniffs and the other cores do.

**What was actually broken**

AC's Hydross script did not use the Cleansing Field aura (37935) to switch forms. Instead it relied on a hop: when 37935 landed on or left Hydross, the field helper (21934) cast the entry-area spell 37934 at the two Beam Helpers (21933), and 37934's expiry toggled Blue Beam (38015). The boss then compared Blue Beam against Corruption once per second to decide his form. The Beam Helpers sit 22.1 and 21.0 yards from the field helper on AC, so 37934's 20 yard radius only ever reached them thanks to the helpers' 3 yard combat reach being added to the search. Once area searches went center-to-center, 37934 never hit, Blue Beam never came back, and the 1 second poll pushed Hydross into nature form immediately.

**What the sniffs show**

A fresh retail sniff of the encounter, checked packet by packet:

- Spell 37934 never appears. Not one cast, aura or hit in the whole capture.
- Blue Beam (38015) is cast by the Beam Helpers themselves, 20 ms after the field aura reappears on Hydross, and their channels drop 30 ms after it leaves him. No intermediate spell, no delay.
- Every form switch happens in the same server tick as the 37935 aura change on Hydross: aura removed and Corruption (37961) applied together, aura applied and Corruption removed together, with the matching "Aaghh, the poison..." and "Better, much better." lines 200 ms later. The 4 spawns appear in that same tick.
- The helper spawn positions are different from AC's. The field helper stands at Hydross' feet (z -0.74, AC had it 12 yards up) and the two Beam Helpers are 25.6 and 26.2 yards away horizontally and 39 yards above the floor (AC had them at z 14 and 15). These sniffed coordinates are byte for byte the ones TrinityCore and cmangos ship. With them, even a 25 yard 37934 could never reach the helpers, which is why widening the radius as proposed in https://github.com/azerothcore/azerothcore-wotlk/pull/27290 only works on AC's custom coordinates.
- Beams stay on while Hydross is idle, and the Tainted Elementals walking through the field pick up the same 37935 aura.

**What the other cores do**

- TrinityCore uses center-to-center 2D distance for area targets (no combat reach at all), switches Hydross' form on a distance check, and has the boss script cast or interrupt Blue Beam on the 21933 helpers directly. No reference to 37934 anywhere: https://github.com/TrinityCore/TrinityCore/blob/3.3.5/src/server/scripts/Outland/CoilfangReservoir/SerpentShrine/boss_hydross_the_unstable.cpp
- cmangos (the origin of the center-distance change) has 37935 as a permanent aura on 21934 with an aura script that signals the boss AI on apply and remove, and toggles the beams on the helpers from the script. No reference to 37934 anywhere: https://github.com/cmangos/mangos-tbc/blob/master/src/game/AI/ScriptDevAI/scripts/outland/coilfang_reservoir/serpent_shrine/boss_hydross_the_unstable.cpp

**The change**

- The 37935 aura script now sends an action to the boss AI on apply and remove. Entering the field starts the beams and switches to frost form, leaving it stops the beams and switches to nature form. The 1 second poll is gone and the initial form on engage comes from whether the aura is present at that moment.
- The Beam Helpers are found by entry and cast or interrupt Blue Beam directly, so beams also come back on their own out of combat and after a wipe, which removes the old JustReachedHome hack that stripped the aura to force a re-trigger.
- Spell 37934's aura script, its `spell_script_names` row and its `conditions` row are removed. Nothing else in the code or DB references it.
- The three helper spawns move to the sniffed coordinates, and the Hydross spawn (already matching) gets its VerifiedBuild stamped.
- Form switches are skipped while dead or in evade mode. Evade strips the field aura before the engaged flag clears, and on death the aura lingers on the corpse until the next area-aura tick; without the guard a wipe would trigger the switch line and 4 adds. Beam toggling still runs there.

Supersedes https://github.com/azerothcore/azerothcore-wotlk/pull/27290 (widens 37934 to 25 yards, which fits AC's custom coordinates rather than the mechanic) and https://github.com/azerothcore/azerothcore-wotlk/pull/27492 (uses the aura as the switch signal but leaves the beams broken).

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Claude Fable 5.1)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/27118

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [x] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

The aura-driven transition follows cmangos (https://github.com/cmangos/mangos-tbc/commit/0f00508d2, killerwife) and the beam helper handling follows TrinityCore (https://github.com/TrinityCore/TrinityCore/commit/5649e4e76, offl); the commit carries killerwife as author and offl as co-author. The helper spawn coordinates come from the sniff and match both projects' DB rows.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Builds without errors or warnings (MSVC, Release). SQL and C++ codestyle linters pass.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Enter Serpentshrine Cavern and go to Hydross: `.go xyz -239.84 -366.49 -0.74 548`. Both blue beams should be on him while he idles.
2. Engage him inside the field. He stays in frost form with the beams on.
3. Drag him past the purple flags. In the same moment the beams stop, he says "Aaghh, the poison...", gains Corruption and summons 4 Tainted Spawns.
4. Bring him back. The beams resume, he says "Better, much better.", loses Corruption and summons 4 Pure Spawns. Repeat a few times.
5. Wipe or evade him outside the field. He must walk home without a switch line or extra adds, and the beams must be back on once he is home.
6. Kill him in either form and check no switch line or adds trigger on death. After a kill in frost form the beams stay off until the helpers respawn with the instance; the sniff does not cover this case.

## Known Issues and TODO List:

- [ ] The sniff is a solo run and only covers a pull from inside the field. If pulled from outside, the script starts him in nature form silently rather than switching a second later.
- [ ] The Tainted Elementals in the sniff never change entry to Purified Water Elemental (21260) after purification; AC still does an UpdateEntry. Worth a separate look.

## How to Test AzerothCore PRs

When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
