### PR TITLE
docs(agents): require upstream author credit for mirrored code

### DIFF
--- a/.agents/docs/self-review-rules.md
+++ b/.agents/docs/self-review-rules.md
@@ -24,6 +24,12 @@ Every change gets the full review; go deeper the farther it can reach:
 - SQL: beyond the usual review, watch for the classic side effect — a DELETE/UPDATE whose
   WHERE clause catches rows it shouldn't.
 
+## Upstream attribution
+
+Any changed code, mechanism, or data mirrored from another core must carry that upstream commit's
+author via `--author` (extras as `Co-authored-by`) with the template's cherry-pick box checked; a
+missing credit is a finding.
+
 ## In-game testing
 
 PRs are expected to be tested in-game, which the reviewer cannot do. Never guess what the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@ AzerothCore is a C++ MMORPG server emulator for World of Warcraft 3.3.5a (WotLK)
 - **Prefer live-stack e2e to debug/validate player-visible behaviour** when a local auth+world+MySQL stack is available (protocol, combat, quests, loot, death, multi-bot). See `e2e/README.md` and AzerothGhost `e2e/LLM_GUIDE.md`. Do not invent e2e for pure unit-sized logic — see `.agents/docs/e2e-policy.md`.
 - **Scratch e2e only under `e2e/local/`** (gitignored). Never commit throwaway debug tests. Promote keepers into `e2e/suites/` or `e2e/smoke/`.
 - Planning docs go in `.agents/plans/<task-slug>/` (gitignored), named `<task-slug>.<TYPE>.md` (`PLAN`, `REQUIREMENTS`, `ANALYSIS`, …).
+- **Credit upstream authors.** Code, a mechanism, or data mirrored from another core (TrinityCore, cMaNGOS, …) is committed with `--author` naming the original commit's author (extra sources as `Co-authored-by`), even when rewritten against AC or confirmed by own sniffs; find them in the upstream file's commit history.
 
 ## Mandatory reading per task
 


### PR DESCRIPTION
## Changes Proposed:

Adds an agent rule to `AGENTS.md`: code, a mechanism, or data mirrored from another core is committed with `--author` naming the upstream commit's author (extra sources as `Co-authored-by`), even when rewritten against AC or confirmed by own sniffs. `.agents/docs/self-review-rules.md` gets a matching check so a missing credit is a self-review finding.

Motivated by https://github.com/azerothcore/azerothcore-wotlk/pull/27503, where the aura-driven switch mirrored cmangos and the beam toggle mirrored TrinityCore but the first commit went out without credit. The PR template already states the requirement; this puts it where the agent reads before committing and where the review enforces it.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Agent documentation only.

### AI-assisted Pull Requests

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Claude Fable 5.1)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- None

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Not applicable, documentation only.

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Not applicable, documentation only.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

Read the two changed docs.

## Known Issues and TODO List:

- None

## How to Test AzerothCore PRs

When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
