### PR TITLE
fix(Core/Mail): correct the declared size of mail list entries

### DIFF
--- a/src/server/game/Handlers/MailHandler.cpp
+++ b/src/server/game/Handlers/MailHandler.cpp
@@ -708,7 +708,8 @@ void WorldSession::HandleGetMailList(WorldPacket& recvData)
 
         uint8 item_count = uint8(mail->items.size());            // max count is MAX_MAIL_ITEMS (12)
 
-        std::size_t next_mail_size = 2 + 4 + 1 + (mail->messageType == MAIL_NORMAL ? 8 : 4) + 4 * 8 + (mail->subject.size() + 1) + (mail->body.size() + 1) + 1 + item_count * (1 + 4 + 4 + MAX_INSPECTED_ENCHANTMENT_SLOT * 3 * 4 + 4 + 4 + 4 + 4 + 4 + 4 + 1);
+        // The run of fixed-size fields below is six uint32 and one float, not eight of anything
+        std::size_t next_mail_size = 2 + 4 + 1 + (mail->messageType == MAIL_NORMAL ? 8 : 4) + 7 * 4 + (mail->subject.size() + 1) + (mail->body.size() + 1) + 1 + item_count * (1 + 4 + 4 + MAX_INSPECTED_ENCHANTMENT_SLOT * 3 * 4 + 4 + 4 + 4 + 4 + 4 + 4 + 1);
 
         if (data.wpos() + next_mail_size > MAX_NETCLIENT_PACKET_SIZE)
         {

--- a/src/server/game/Handlers/MailHandler.cpp
+++ b/src/server/game/Handlers/MailHandler.cpp
@@ -708,8 +708,27 @@ void WorldSession::HandleGetMailList(WorldPacket& recvData)
 
         uint8 item_count = uint8(mail->items.size());            // max count is MAX_MAIL_ITEMS (12)
 
-        // The run of fixed-size fields below is six uint32 and one float, not eight of anything
-        std::size_t next_mail_size = 2 + 4 + 1 + (mail->messageType == MAIL_NORMAL ? 8 : 4) + 7 * 4 + (mail->subject.size() + 1) + (mail->body.size() + 1) + 1 + item_count * (1 + 4 + 4 + MAX_INSPECTED_ENCHANTMENT_SLOT * 3 * 4 + 4 + 4 + 4 + 4 + 4 + 4 + 1);
+        // prevent client crash
+        std::string subject = mail->subject;
+        std::string body = mail->body;
+
+        if (subject.find("| |") != std::string::npos)
+        {
+            subject = "";
+        }
+        if (body.find("| |") != std::string::npos)
+        {
+            body = "";
+        }
+
+        // Declared length of this entry. Must match the bytes written below: the uint16 size itself,
+        // uint32 id, uint8 type, the sender as a guid or an entry, six uint32 fields and one float,
+        // both null terminated strings, the uint8 item count and the items. The strings are measured
+        // after sanitisation, because the sanitised ones are what gets written
+        std::size_t const sender_size = mail->messageType == MAIL_NORMAL ? 8 : 4;
+        std::size_t const item_size = 1 + 4 + 4 + MAX_INSPECTED_ENCHANTMENT_SLOT * 3 * 4 + 4 + 4 + 4 + 4 + 4 + 4 + 1;
+        std::size_t next_mail_size = 2 + 4 + 1 + sender_size + 7 * 4
+            + (subject.size() + 1) + (body.size() + 1) + 1 + item_count * item_size;
 
         if (data.wpos() + next_mail_size > MAX_NETCLIENT_PACKET_SIZE)
         {
@@ -732,19 +751,6 @@ void WorldSession::HandleGetMailList(WorldPacket& recvData)
             case MAIL_CALENDAR:
                 data << uint32(mail->sender);            // creature/gameobject entry, auction id, calendar event id?
                 break;
-        }
-
-        // prevent client crash
-        std::string subject = mail->subject;
-        std::string body = mail->body;
-
-        if (subject.find("| |") != std::string::npos)
-        {
-            subject = "";
-        }
-        if (body.find("| |") != std::string::npos)
-        {
-            body = "";
         }
 
         data << uint32(mail->COD);                                      // COD


### PR DESCRIPTION
## Changes Proposed:

Each entry in `SMSG_MAIL_LIST_RESULT` declares its own length. Two terms of that computation did not match the bytes actually written, and both made the entry over-declare itself.

**1. The run of fixed-size fields** was written as `4 * 8`, but only **seven** such fields are written — six `uint32` plus one `float`:

```cpp
data << uint32(mail->COD);
data << uint32(0);                  // probably changed in 3.3.3
data << uint32(mail->stationery);
data << uint32(mail->money);
data << uint32(mail->checked);
data << float(...);                 // days left
data << uint32(mail->mailTemplateId);
```

So every entry over-declared by 4 bytes. Corrected to `7 * 4`.

**2. The subject and body were measured before sanitisation.** `next_mail_size` used `mail->subject` / `mail->body`, but the packet writes copies that are emptied when they contain `"| |"` — the sequence guarded against to stop the client crashing. A mail carrying that sequence over-declared by the length of the original strings on top of the fixed-field error. They are now sanitised first and measured afterwards.

The 3.3.5 client tolerates over-declaration — verified below — so this is a correctness fix, not a fix for an observed symptom. The value is also used locally for the `MAX_NETCLIENT_PACKET_SIZE` guard on the next line, which was conservative as a result.

The sender and per-item sizes move into named locals, which keeps the expression inside the 120 column limit and lets it be read against the fields it describes.

**Provenance:** the corrected fixed-field computation is mirrored from TrinityCore [93f6e7431a73](https://github.com/TrinityCore/TrinityCore/commit/93f6e7431a73) by **Shauren**, which spells each field out as `sizeof()` while converting mail to packet classes. That commit is authored accordingly (`--author`) per `.agents/docs/self-review-rules.md`.

The second commit is **not** from TrinityCore — the `"| |"` sanitisation is AzerothCore-specific, so its interaction with the size calculation does not exist upstream. It is authored normally and credits CodeRabbit, which spotted it in review.

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Claude Opus 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:

None.

## SOURCE:

The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [x] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Server-side packet capture (`PacketLogFile`) decoded before and after. Before, every entry reported `declared = actual + 4`; after, all entries report `declared == actual` with the packet fully consumed and zero trailing bytes:

```
before:  #1 'ten'  declared=54  actual=50   MISMATCH (+4)
after:   #1 T5     declared=166 actual=166  OK   (with attachment)
         #5 T1     declared=58  actual=58   OK
         bytes consumed=495 of 495 (trailing 0)
```

## Tests Performed:

- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Tested on Windows, 3.3.5a client. Mails with and without attachments, single-entry and 10-entry inboxes, before and after the change.

Worth noting for reviewers: **10 mails in one packet displayed correctly on the unpatched build**, so the client evidently parses entries sequentially and does not use this field for framing. I could not construct a case where the old value produced visible breakage. Reviewers who know of one should say so — it would change how this is described.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes.

1. Set `PacketLogFile = "packets.pkt"` in worldserver.conf and restart.
2. Send several mails, some with attachments, to a character and open their mailbox.
3. Decode `SMSG_MAIL_LIST_RESULT` in the capture and check each entry's leading `uint16` against the bytes actually consumed by that entry. They should now match exactly, with no trailing bytes in the packet.

## Known Issues and TODO List:

- [ ] No automated test. The e2e harness (AzerothGhost v1.0.8) has no mail opcode support, so this could not be encoded as a regression test per `.agents/docs/e2e-policy.md`. Mail support in the harness would be a worthwhile addition.
