### PR TITLE
fix(Core/Mail): deliver mail to online receivers addressed only by guid

### DIFF
--- a/src/server/game/Mails/Mail.cpp
+++ b/src/server/game/Mails/Mail.cpp
@@ -25,6 +25,7 @@
 #include "Item.h"
 #include "Log.h"
 #include "MailMgr.h"
+#include "ObjectAccessor.h"
 #include "ObjectMgr.h"
 #include "Player.h"
 #include "ScriptMgr.h"
@@ -198,6 +199,12 @@ void MailDraft::SendMailTo(CharacterDatabaseTransaction trans, MailReceiver cons
     if (pReceiver)
         prepareItems(pReceiver, trans);                            // generate mail template items
 
+    // Callers that only know the receiver's guid must still reach an online receiver's in-memory
+    // mailbox, otherwise the mail is written to the database only and stays invisible (and
+    // unannounced) until that character relogs
+    if (!pReceiver)
+        pReceiver = ObjectAccessor::FindConnectedPlayer(ObjectGuid::Create<HighGuid::Player>(receiver.GetPlayerGUIDLow()));
+
     uint32 mailId = sObjectMgr->GenerateMailID();
 
     time_t deliver_time = GameTime::GetGameTime().count() + deliver_delay;
@@ -290,6 +297,11 @@ void MailDraft::SendMailTo(CharacterDatabaseTransaction trans, MailReceiver cons
             {
                 pReceiver->AddMItem(mailItemIter->second);
             }
+
+            // The receiver owns the items now, so drop them from the draft without deleting them.
+            // The offline path below does the same through deleteIncludedItems, and a draft reused
+            // for another receiver must not attach them a second time
+            m_items.clear();
         }
     }
     else if (!m_items.empty())


### PR DESCRIPTION
## Changes Proposed:

`MailDraft::SendMailTo` only updated the receiver's in-memory mailbox when the caller happened to build `MailReceiver` with a `Player*`. Callers that only have a guid wrote the `mail` row and nothing else, so an **online** receiver got no `SMSG_RECEIVED_MAIL` and the mail was absent from `SMSG_MAIL_LIST_RESULT` until that character relogged.

Affected senders in tree:

| Sender | Call site |
|---|---|
| Calendar event deleted → invitees mailed | `CalendarMgr.cpp:196` |
| Scourge Invasion mail | `WorldState.cpp:1290` |
| ~~`.item restore` / `.quest` GM commands~~ | ~~`cs_item.cpp:338`, `cs_quest.cpp:380,624,632`~~ |

Calendar invitees in particular are usually online guild members, so this is easy to hit.

`SendMailTo` now resolves the receiver itself when the caller did not supply one. The lookup is placed **after** `prepareItems` so mail-template item generation is byte-identical for the offline path — otherwise `WorldState.cpp`, which adds its item manually to work around this exact gap, would hand online players a duplicate.

### Second defect, found while testing this

Resolving online receivers also makes those callers take the `if (pReceiver)` branch, which **never cleared `MailDraft::m_items`** — only the offline branch does, via `deleteIncludedItems()`. A draft reused across receivers then accumulates items. `WorldState::SendScourgeInvasionMail` builds one draft outside its loop and calls `AddItem()` + `SendMailTo()` per character, so with one online character mid-loop:

- the next receiver gets `mail_items` rows for the previous receiver's item as well, attaching one item guid to two mails;
- and when a later receiver is offline, `deleteIncludedItems()` calls `delete` on an `Item` still stored in the online player's `mMitems` — a use-after-free when that player opens their mailbox.

The draft is now consumed on both paths: `clear()` on the online branch (ownership has passed to the receiver via `AddMItem`, so the `Item`s must not be deleted) and `deleteIncludedItems()` on the offline one as before. Other draft-reuse sites were checked: `CalendarMgr` reuses a draft but attaches no items, and the `cs_item`/`cs_quest` commands build a fresh draft per receiver.

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Claude Opus 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:

None.

## SOURCE:

The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [x] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Reproduced on an unpatched build with a server-side packet capture. A calendar event was created, an online character invited, then the event deleted:

```
GET_MAIL_LIST -> TotalNumRecords=0  ShownMails=0
GET_MAIL_LIST -> TotalNumRecords=0  ShownMails=0
   -- relog --
GET_MAIL_LIST -> 1 mail, type=5 (CALENDAR), '<player>:My Event!'
```

No `SMSG_RECEIVED_MAIL`, two mailbox opens returning an empty inbox while the `mail` row existed, and the mail only surfaced after logout. `.mail list <character>`, which dumps the server's in-memory `m_mail` for an online player, showed nothing while the DB row was present — confirming the mail never reached the in-memory mailbox.

## Tests Performed:

- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Tested on Windows, 3.3.5a client: the calendar repro above before and after; mail with attachments to online and offline receivers, confirming attachments can still be taken without relogging and that offline delivery is unchanged; auction house mail with items, as the highest-volume caller that already passed an online `Player*`.

Not tested in-game: the Scourge Invasion path, which is event-gated and hard to trigger on demand. It is the caller the `m_items` defect actually lived in, so a reviewer able to trigger that event would be valuable.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes.

1. Character A creates a calendar event and invites character B. Keep **B online** throughout.
2. A deletes the event. B should get the minimap mail notification immediately.
3. B opens a mailbox: the calendar mail is there without relogging. On an unpatched build the mailbox is empty and only a relog reveals it.
4. Cross-check with `.mail list B` (server-side in-memory list) against `SELECT id, subject FROM mail WHERE receiver = <B guid>` — both should agree immediately.
5. Regression check: mail an item to an online character and take the attachment without relogging; repeat to an offline character and confirm the item is there after they log in.

## Known Issues and TODO List:

- [ ] No automated test. The e2e harness (AzerothGhost v1.0.8) has no mail opcode support, so this could not be encoded as a regression test per `.agents/docs/e2e-policy.md`.
- [ ] `WorldState::SendScourgeInvasionMail` reuses a single `MailDraft` across every receiver, which is fragile regardless of this fix. Building the draft inside the loop would be more robust; left alone here to keep the change focused.
