### PR TITLE
fix(Core/Mail): announce every delayed mail, not just the first

### DIFF
--- a/src/server/game/Entities/Player/PlayerUpdates.cpp
+++ b/src/server/game/Entities/Player/PlayerUpdates.cpp
@@ -61,11 +61,10 @@ void Player::Update(uint32 p_time)
     if (m_nextMailDelivereTime && m_nextMailDelivereTime <= GameTime::GetGameTime().count())
     {
         SendNewMail();
-        ++unReadMails;
 
-        // It will be recalculate at mailbox open (for unReadMails important
-        // non-0 until mailbox open, it also will be recalculated)
-        m_nextMailDelivereTime = time_t(0);
+        // Recount from the mailbox instead of clearing the timer: any mail that is still
+        // undelivered keeps its own delivery time and gets announced when it arrives
+        UpdateNextMailTimeAndUnreads();
     }
 
     // Update cinematic camera (if needed)


### PR DESCRIPTION
## Changes Proposed:

`Player::Update` cleared `m_nextMailDelivereTime` after delivering a mail and relied on the next mailbox open to recalculate it:

```cpp
SendNewMail();
++unReadMails;

// It will be recalculate at mailbox open (for unReadMails important
// non-0 until mailbox open, it also will be recalculated)
m_nextMailDelivereTime = time_t(0);
```

With two or more mails pending delivery, `AddNewMailDeliverTime` keeps only the earliest deadline. When that one fires the timer is zeroed and nothing re-arms it, so **every later mail arrives with no notification at all** until the player happens to open a mailbox (which runs `UpdateNextMailTimeAndUnreads` and rescues it) or relogs.

The auction house reaches this through **"sale successful"** mails, which are the ones actually sent on `MailDeliveryDelay`, so a seller with two auctions completing inside that window silently loses the notification for the second.

To be precise about the setting, since the original wording here was wrong: `SendAuctionSalePendingMail` passes **no** `deliver_delay`, so "sale pending" mail is delivered immediately — `MailDeliveryDelay` only shapes its *expiry*, through the `MAIL_AUCTION` branch in `MailDraft::SendMailTo`. Only `SendAuctionSuccessfulMail` passes the delay as a delivery delay. Thanks to @Nyeriah for catching it.

Recounting from the mailbox instead of clearing the timer makes mail that is still undelivered keep its own delivery time, so it is announced when it arrives. `UpdateNextMailTimeAndUnreads` also sets `unReadMails` to the true count, which replaces the blind `++unReadMails` — the just-delivered mail is unread and not expired, so the recount is always at least 1 and the notification state is preserved.

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Claude Opus 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:

None.

## SOURCE:

The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [x] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

A/B tested with a server-side packet capture, same scenario both times — two item mails sent 32 seconds apart, mailbox untouched in between:

| | before | after |
|---|---|---|
| mails delivered (confirmed in `mail` table) | 2 | 2 |
| `SMSG_RECEIVED_MAIL` in capture | **1** | **2** |

An earlier run of the same test showed two notifications on the unpatched build, because the mailbox was opened between the two deliveries and `HandleGetMailList` re-armed the timer through the old path. Keeping the mailbox closed is what makes the defect visible.

## Tests Performed:

- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Tested on Windows, 3.3.5a client, with `MailDeliveryDelay` lowered to 60s to keep the cycle short. Also checked that a single delayed mail still notifies exactly once, and that instant mail (no attachment, same account) is unaffected — that path goes through `AddNewMailDeliverTime` and never sets the timer.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes.

1. Lower `MailDeliveryDelay` to 60 in worldserver.conf to keep the wait short.
2. From character A, mail an **item** to character B on a **different account** — attachments across accounts are what trigger the delivery delay. Keep B online throughout. (Two auctions completing within the delay window is the natural in-game equivalent; hand-sent item mail is just easier to time.)
3. Wait ~30 seconds, then send a second item mail from A to B.
4. **Do not open B's mailbox at any point** until both delays have elapsed. A single mailbox open re-arms the timer through the old path and hides the defect.
5. B should get two separate "new mail" notifications. On an unpatched build only the first arrives; the second mail lands silently and only appears after a mailbox open or relog.

Note that the minimap envelope stays lit from the first notification, so the second is not visually obvious — confirm with a packet capture (`PacketLogFile`) and count `SMSG_RECEIVED_MAIL`, or watch the second mail appear.

## Known Issues and TODO List:

- [ ] No automated test. The e2e harness (AzerothGhost v1.0.8) has no mail opcode support, so this could not be encoded as a regression test per `.agents/docs/e2e-policy.md`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
