### PR TITLE
fix(Core/Spells): allow paladin auras from different casters to coexist

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -142,7 +142,7 @@ If the scenario should stay as a regression, **move** it into `suites/` next to 
 | combat/pets | summon / GUID / attack / dismiss | P1 | covered; dungeon Raise Dead `blocked-harness` (ready-check / instance summon) | #27081 |
 | combat/threat | engage / taunt switch / kill clears combat | P1 | covered | — |
 | combat/vehicles | spellclick steed enter/exit | P2 | covered | — |
-| spells/aura | apply/query; CC broken by damage; mount persist | P1 | covered (`TestAC_26130_*`) | #26130 |
+| spells/aura | apply/query; CC broken by damage; mount persist; paladin same-aura per-caster + Aura Mastery | P1 | covered (`TestAC_26130_*`, `TestAC_25765_*`) | #26130 #25765 |
 | spells/cast | Charge on dummy; fail path; stance; Raise Dead + ghoul | P1 | covered (`TestAC_27061_*`) | #27061 |
 | spells/effects | Charge / grounding totem / Sweeping Strikes Execute | P1 | covered (`TestAC_26997_*`); dummy-summon `blocked-harness` (engineering dummy lifetime) | #26774 #26997 |
 | social/group | form / leave / leader / loot method / disband | P2 | covered | — |

--- a/e2e/suites/spells/aura/paladin_aura_mastery_e2e_test.go
+++ b/e2e/suites/spells/aura/paladin_aura_mastery_e2e_test.go
@@ -1,0 +1,105 @@
+//go:build e2e
+
+package aura_test
+
+import (
+	"testing"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+
+	"github.com/azerothcore/AzerothGhost/e2e/e2eharness"
+	"github.com/azerothcore/azerothcore-wotlk/e2e/internal/meta"
+)
+
+// Spells driving the scenario. Aura Mastery (31821) is a Holy talent, not taught
+// by `.learn all my class`, so it is learned explicitly below.
+const (
+	spellConcentrationAura = uint32(19746)
+	spellAuraMastery       = uint32(31821)
+	spellAuraMasteryImmune = uint32(64364) // immunity Aura Mastery casts over Concentration Aura
+)
+
+// Issue: https://github.com/azerothcore/azerothcore-wotlk/issues/25765
+//
+// Two grouped paladins both running Concentration Aura: each paladin's aura must
+// apply to the group independently (per-caster). Before the server-side stacking
+// fix, the second paladin's same-rank aura was suppressed by the first's, so that
+// paladin's Aura Mastery never reached anyone.
+//
+// Oracle: palB (activated second) turns on Aura Mastery. Its immunity aura 64364
+// only lands on targets carrying palB's own Concentration Aura (19746 cast by
+// palB, see spell_pal_aura_mastery_immune::CheckAreaTarget). palA gaining 64364
+// therefore proves palB's Concentration Aura reached palA instead of being
+// suppressed — on an unfixed core palA never gets 64364.
+func TestAC_25765_PaladinAuraMasteryPerCasterInGroup(t *testing.T) {
+	meta.Begin(t, meta.TestMeta{
+		Tags:     []string{"med", "spells", "issue", "multi_bot"},
+		Runtime:  "med",
+		Issue:    25765,
+		Category: "spells/aura",
+	})
+
+	bots := e2eharness.NewScenario(t, e2eharness.ScenarioOpts{
+		Prefix: "AuraGrp",
+		Bots: []e2eharness.BotSpec{
+			{Role: "palA", Race: e2eharness.RaceHuman, Class: e2eharness.ClassPaladin, Level: 80, LearnAllClass: true},
+			{Role: "palB", Race: e2eharness.RaceHuman, Class: e2eharness.ClassPaladin, Level: 80, LearnAllClass: true},
+		},
+	})
+	palA := e2eharness.ByRole(t, bots, "palA")
+	palB := e2eharness.ByRole(t, bots, "palB")
+
+	pad := e2eharness.PackagePad(t)
+	e2eharness.FormPartyAtPad(t, pad, palA, palB)
+	defer e2eharness.DisbandParty(t, palA, palB)
+
+	if !palA.InGroup() || !palB.InGroup() {
+		e2eharness.Preconditionf(t, "paladins not grouped palA=%v palB=%v", palA.InGroup(), palB.InGroup())
+	}
+
+	// palA activates Concentration Aura first. Its aura reaches palB, which is the
+	// pre-fix state that used to suppress palB's own same-rank aura.
+	palA.Learn(t, spellConcentrationAura)
+	palA.CastMust(t, spellConcentrationAura, 0, 10*time.Second)
+	palB.WaitUnitAura(t, palB.GUID, spellConcentrationAura, 8*time.Second)
+
+	// palB activates its own Concentration Aura while palA's is already on the party.
+	palB.Learn(t, spellConcentrationAura)
+	palB.CastMust(t, spellConcentrationAura, 0, 10*time.Second)
+	if !palB.HasAura(spellConcentrationAura) {
+		e2eharness.Preconditionf(t, "palB lost Concentration Aura %d", spellConcentrationAura)
+	}
+
+	// palB turns on Aura Mastery. Require it to be usable before judging the oracle.
+	palB.Learn(t, spellAuraMastery)
+	if res := palB.Cast(t, spellAuraMastery, 0, 10*time.Second); !res.Success {
+		e2eharness.Preconditionf(t, "Aura Mastery %d cast failed (reason=%s)", spellAuraMastery,
+			e2eharness.SpellFailReasonName(res.FailReason))
+	}
+	if !waitForSelfAura(palB, spellAuraMastery, 8*time.Second) {
+		e2eharness.Preconditionf(t, "Aura Mastery %d not applied on palB after successful cast", spellAuraMastery)
+	}
+
+	if !waitForSelfAura(palA, spellAuraMasteryImmune, 8*time.Second) {
+		e2eharness.ConfirmedBugf(t, 25765,
+			"palA never gained Aura Mastery Immune %d from palB — palB's Concentration Aura %d was not applied to palA (two paladins, same aura)",
+			spellAuraMasteryImmune, spellConcentrationAura)
+	}
+	t.Logf("PASS AC#25765 palB's Concentration Aura reached palA; Aura Mastery immunity %d applied per-caster",
+		spellAuraMasteryImmune)
+}
+
+// waitForSelfAura polls the bot's own aura cache until spellID is present or the
+// timeout elapses. Harness provides WaitUnitAura (fatal) and WaitAuraGone (gone),
+// neither of which fits a soft presence wait feeding a severity helper.
+func waitForSelfAura(bot *e2eharness.ScenarioBot, spellID uint32, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if bot.HasAura(spellID) {
+			return true
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	return false
+}

--- a/src/server/game/Spells/Auras/SpellAuras.cpp
+++ b/src/server/game/Spells/Auras/SpellAuras.cpp
@@ -529,6 +529,52 @@ void Aura::_Remove(AuraRemoveMode removeMode)
     }
 }
 
+// paladin auras of the same spell may coexist on a target (one per caster) so Aura Mastery works
+// per-caster, but only the strongest one keeps its effects. Ties favor the target's own self-cast
+// aura, then the lower caster guid, to keep the outcome deterministic across update cycles.
+static bool IsPaladinAuraDominant(Aura const* aura, Aura const* other, Unit const* target)
+{
+    auto primaryAmount = [](Aura const* a) -> int32
+    {
+        for (uint8 i = 0; i < MAX_SPELL_EFFECTS; ++i)
+            if (AuraEffect* eff = a->GetEffect(i))
+                return eff->GetAmount();
+        return 0;
+    };
+
+    int32 auraAmount = std::abs(primaryAmount(aura));
+    int32 otherAmount = std::abs(primaryAmount(other));
+    if (auraAmount != otherAmount)
+        return auraAmount > otherAmount;
+
+    bool auraSelf = aura->GetCasterGUID() == target->GetGUID();
+    bool otherSelf = other->GetCasterGUID() == target->GetGUID();
+    if (auraSelf != otherSelf)
+        return auraSelf;
+
+    return aura->GetCasterGUID() < other->GetCasterGUID();
+}
+
+// strongest paladin aura application of the same rank chain on the target, cast by someone other
+// than `casterGUID`
+static AuraApplication* GetDominantOtherSameSpellApp(Unit* target, uint32 spellId, ObjectGuid casterGUID)
+{
+    AuraApplication* best = nullptr;
+    for (uint32 rankSpell = sSpellMgr->GetFirstSpellInChain(spellId); rankSpell; rankSpell = sSpellMgr->GetNextSpellInChain(rankSpell))
+    {
+        Unit::AuraApplicationMapBoundsNonConst bounds = target->GetAppliedAuras().equal_range(rankSpell);
+        for (Unit::AuraApplicationMap::iterator it = bounds.first; it != bounds.second; ++it)
+        {
+            AuraApplication* app = it->second;
+            if (app->GetBase()->GetCasterGUID() == casterGUID)
+                continue;
+            if (!best || IsPaladinAuraDominant(app->GetBase(), best->GetBase(), target))
+                best = app;
+        }
+    }
+    return best;
+}
+
 void Aura::UpdateTargetMap(Unit* caster, bool apply)
 {
     if (IsRemoved())
@@ -561,9 +607,28 @@ void Aura::UpdateTargetMap(Unit* caster, bool apply)
                         existing->second &= ~(1 << effIndex);
                 }
 
+            // paladin auras of the same spell coexist per caster, but only the strongest one keeps
+            // its effects on the target. If a stronger duplicate from another paladin is present,
+            // strip this aura's effects and keep the application effect-free (Aura Mastery needs it
+            // applied) without removing it, which would otherwise churn every update cycle.
+            bool keepEffectless = false;
+            if (m_spellInfo->GetSpellSpecific() == SPELL_SPECIFIC_AURA)
+            {
+                if (AuraApplication* otherApp = GetDominantOtherSameSpellApp(existing->first, GetId(), GetCasterGUID()))
+                {
+                    if (!IsPaladinAuraDominant(this, otherApp->GetBase(), existing->first))
+                    {
+                        for (uint8 effIndex = 0; effIndex < MAX_SPELL_EFFECTS; ++effIndex)
+                            if (appIter->second->HasEffect(effIndex))
+                                appIter->second->_HandleEffect(effIndex, false);
+                        keepEffectless = true;
+                    }
+                }
+            }
+
             // needs readding - remove now, will be applied in next update cycle
             // (dbcs do not have auras which apply on same type of targets but have different radius, so this is not really needed)
-            if (appIter->second->GetEffectMask() != existing->second || !CanBeAppliedOn(existing->first))
+            if ((appIter->second->GetEffectMask() != existing->second && !keepEffectless) || !CanBeAppliedOn(existing->first))
                 targetsToRemove.push_back(appIter->second->GetTarget());
             // nothing todo - aura already applied
             // remove from auras to register list
@@ -653,7 +718,30 @@ void Aura::UpdateTargetMap(Unit* caster, bool apply)
                                itr->first->GetName(), itr->first->IsInWorld() ? itr->first->GetMap()->GetId() : uint32(-1));
                 ABORT();
             }
-            itr->first->_CreateAuraApplication(this, itr->second);
+
+            // paladin auras of the same spell coexist per caster, but only the strongest one keeps
+            // its effects on the target; weaker duplicates are applied without effects so each
+            // paladin's Aura Mastery can still detect their own aura on the target.
+            uint8 effMask = itr->second;
+            if (m_spellInfo->GetSpellSpecific() == SPELL_SPECIFIC_AURA)
+            {
+                if (AuraApplication* otherApp = GetDominantOtherSameSpellApp(itr->first, GetId(), GetCasterGUID()))
+                {
+                    if (IsPaladinAuraDominant(this, otherApp->GetBase(), itr->first))
+                    {
+                        // this aura is stronger - strip the other aura's effects on this target
+                        for (uint8 effIndex = 0; effIndex < MAX_SPELL_EFFECTS; ++effIndex)
+                            if (otherApp->HasEffect(effIndex))
+                                otherApp->_HandleEffect(effIndex, false);
+                    }
+                    else
+                    {
+                        effMask = 0;
+                    }
+                }
+            }
+            itr->second = effMask;
+            itr->first->_CreateAuraApplication(this, effMask);
             ++itr;
         }
     }
@@ -2070,6 +2158,12 @@ bool Aura::CanStackWith(Aura const* existingAura) const
     // spell of same spell rank chain
     if (m_spellInfo->IsRankOf(existingSpellInfo) && !(m_spellInfo->SpellFamilyName == SPELLFAMILY_HUNTER && m_spellInfo->SpellFamilyFlags[1] & 0x80000000))
     {
+        // Each paladin's aura applies independently to group members (Aura Mastery and the
+        // improved-aura talents depend on the caster's own aura being applied); only the
+        // strongest keeps its effects on a shared target, see Aura::UpdateTargetMap.
+        if (!sameCaster && m_spellInfo->GetSpellSpecific() == SPELL_SPECIFIC_AURA)
+            return true;
+
         // don't allow passive area auras to stack
         if (m_spellInfo->IsMultiSlotAura() && !IsArea())
             return true;

--- a/src/server/game/Spells/Auras/SpellAuras.h
+++ b/src/server/game/Spells/Auras/SpellAuras.h
@@ -35,6 +35,7 @@ class AuraScript;
 
 class AuraApplication
 {
+    friend class Aura; // Aura::UpdateTargetMap manages paladin aura effect suppression
     friend void Unit::_ApplyAura(AuraApplication* aurApp, uint8 effMask);
     friend void Unit::_UnapplyAura(AuraApplicationMap::iterator& i, AuraRemoveMode removeMode);
     friend void Unit::_ApplyAuraEffect(Aura* aura, uint8 effIndex);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: DeepSeek V4 Pro + AzerothMCP
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/25765

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.

# Self-review — paladin aura mastery in a group → master

**Outcome** 5 findings — 2 fixed, 3 dismissed — no open findings

The fresh-eyes subagent could not be spawned (twice), so the review is a same-context adversarial pass — weaker than the skill's isolated review. The two round-2 fixes are comment/README-only and were verified in-session, not by a fresh context.

**Reviewed** working tree on `2854b24a5d9` (`fix/core-paladin-auras` vs `master` @ `1483728006c`, merge-base diff — 4 files, +203 −3) — unpinned: round-2 fixes not yet committed

**By** VS Code Copilot, DeepSeek V4 Flash — self-review v0.7, 2026-09-04

Author-confirmed testing: e2e `TestAC_25765_PaladinAuraMasteryPerCasterInGroup` green, `-count=2` stable. `apps/codestyle/codestyle-cpp.py` passes on the changed C++.

<details>
<summary>Review details (2 rounds)</summary>

**Intent** Two paladins in a group running the same aura must each have their aura apply to the group per-caster, so each paladin's Aura Mastery works independently, while only the strongest aura keeps its effects on a shared target; the single-paladin two-aura exclusion, different-aura coexistence, and client display must not regress.

**Project rules** `.agents/docs/self-review-rules.md` present and applied — pinned review required, round fixes committed between rounds (left to the author here); `.agents/docs/code-review.md` applied on top (codestyle run, game-data claims verified against code/DBC).

**Diff** `5e939e1d38e2cb954fdcd184054b1dc7cce669e9` (round 1 pinned at `2854b24a5d9`: `e6c662345fbb6c173735017d266c6927244ab7f3`)

Procedural caveats: fresh-eyes spawn failed twice → same-context adversarial fallback; local-only `.gitignore`/`.vscode/launch.json` confirmed local and excluded from the diff; the effect-suppression design diverges from PLAN step 2's SQL `EXCLUSIVE_SAME_EFFECT` groups (no SQL shipped) — reviewed on its own merit as the implemented approach.

## Round 1 — `2854b24a5d9`, 5 findings

1. `src/server/game/Spells/Auras/SpellAuras.cpp:2160` — the `CanStackWith` comment claims the base modifier is deduplicated "at read time by SPELL_GROUP_STACK_RULE_EXCLUSIVE_SAME_EFFECT"; no such spell group exists in this change — dedup happens via the new effect suppression in `Aura::UpdateTargetMap`, so the comment misleads a maintainer about the actual mechanism → **fixed**
2. `e2e/README.md` — the new issue-guard `TestAC_25765_*` is not registered in the Inventory table, against the repo's coverage-tracking convention → **fixed**
3. `src/server/game/Spells/Auras/SpellAuras.cpp` `UpdateTargetMap` (~610 and ~720) — the dominant-other-aura decision is duplicated across the existing- and new-application branches → **dismissed**: the decision already lives in the shared helpers `GetDominantOtherSameSpellApp`/`IsPaladinAuraDominant`; the residual asymmetry mirrors the two code paths (reapply vs fresh apply), and collapsing it adds indirection without removing risk
4. `src/server/game/Spells/Auras/SpellAuras.h:38` — `friend class Aura` grants the whole class private access to `AuraApplication` for a single-function need → **dismissed**: consistent with the file's existing friend-granularity style; a scoped friend needs declaration-order gymnastics for negligible gain
5. Requirement-4 literal fidelity — Aura Mastery's `ADD_PCT_MODIFIER` boosts the caster's aura only on targets where it is the dominant one; on targets governed by another paladin's stronger aura the weaker boost has no applied effect to modify, though the presence-keyed immunity 64364 still reaches them → **dismissed**: consistent with AC-2 (only the strongest aura's modifier applies) and with retail stacking; the ticket's observable per-caster AM scenario is exactly what the e2e oracle proves; requirement 4 reads as "the boost reaches every target the aura governs", not "every paladin's number lands on every target"

## Round 2 — working tree on `2854b24a5d9` (fixes F1–F2 applied, uncommitted)

Findings 1–2 applied; no new findings raised. Fixes are a comment correction and a README table row, verified in-session, not re-reviewed by a fresh context.

</details>

