### PR TITLE
fix(DB/SAI): Correct Mobile Databank temple line offsets

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1788600981465631000.sql
+++ b/data/sql/updates/pending_db_world/rev_1788600981465631000.sql
@@ -1,0 +1,70 @@
+--
+-- Mobile Databank (entry 30313) narrates quest 12986 "Fate of the Titans" at the four
+-- titan temples. Every SMART_ACTION_TALK in its escort script reads a creature_text
+-- GroupID one higher than the line it should play, so each temple skips its own
+-- "analysis commencing" opener and closes with the next temple's opener instead. The
+-- Temple of Order run then overruns into group 19, a duplicate of group 18, so its
+-- closing line is spoken twice.
+--
+-- Shift all 19 talk GroupIDs down by one (1..19 -> 0..18). That matches creature_text
+-- groups 0..18 and the four unreferenced actionlists 3031300 (Invention, lines 0-4),
+-- 3031301 (Winter, 5-9), 3031302 (Life, 10-14) and 3031303 (Order, 15-18), which
+-- already use the correct numbering and cast the matching kill credit spells. Those
+-- actionlists are dead code and are left untouched here.
+--
+-- Event ids 0..45 are preserved so the four conditions rows (SourceTypeOrReferenceId 22,
+-- SourceEntry 30313, SourceGroup = id + 1) keep gating each temple on its bunny NPC.
+--
+DELETE FROM `smart_scripts` WHERE (`source_type` = 0) AND (`entryorguid` = 30313);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(30313, 0, 0, 0, 60, 0, 100, 513, 2000, 2000, 2000, 2000, 0, 0, 53, 1, 30315, 0, 0, 5000, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mobile Databank - OnCreature In Range (Temple of Invention) - Start wp'),
+(30313, 0, 1, 0, 60, 0, 100, 513, 2000, 2000, 2000, 2000, 0, 0, 53, 1, 30316, 0, 0, 5000, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mobile Databank - OnCreature In Range (Temple of Life) - Start wp'),
+(30313, 0, 2, 0, 60, 0, 100, 513, 2000, 2000, 2000, 2000, 0, 0, 53, 1, 30317, 0, 0, 5000, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mobile Databank - OnCreature In Range (Temple of Winter) - Start wp'),
+(30313, 0, 3, 0, 60, 0, 100, 513, 2000, 2000, 2000, 2000, 0, 0, 53, 1, 30318, 0, 0, 5000, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mobile Databank - OnCreature In Range (Temple of Order) - Start wp'),
+(30313, 0, 4, 5, 40, 0, 100, 512, 2, 30315, 0, 0, 0, 0, 54, 8000, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mobile Databank - On wp_1 - pause'),
+(30313, 0, 5, 0, 61, 0, 100, 512, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mobile Databank - On wp_1 - say_1'),
+(30313, 0, 6, 7, 40, 0, 100, 512, 3, 30315, 0, 0, 0, 0, 54, 8000, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mobile Databank - On wp_2 - pause'),
+(30313, 0, 7, 0, 61, 0, 100, 512, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mobile Databank - On wp_2 - say_2'),
+(30313, 0, 8, 9, 40, 0, 100, 512, 5, 30315, 0, 0, 0, 0, 54, 8000, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mobile Databank - On wp_3 - pause'),
+(30313, 0, 9, 0, 61, 0, 100, 512, 0, 0, 0, 0, 0, 0, 1, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mobile Databank - On wp_3 - say_3'),
+(30313, 0, 10, 11, 40, 0, 100, 512, 6, 30315, 0, 0, 0, 0, 54, 8000, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mobile Databank - On wp_4 - pause'),
+(30313, 0, 11, 0, 61, 0, 100, 512, 0, 0, 0, 0, 0, 0, 1, 3, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mobile Databank - On wp_4 - say_4'),
+(30313, 0, 12, 13, 40, 0, 100, 512, 7, 30315, 0, 0, 0, 0, 54, 8000, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mobile Databank - On wp_5 - pause'),
+(30313, 0, 13, 0, 61, 0, 100, 512, 0, 0, 0, 0, 0, 0, 1, 4, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mobile Databank - On wp_5 - say_5'),
+(30313, 0, 14, 15, 40, 0, 100, 512, 2, 30316, 0, 0, 0, 0, 54, 8000, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mobile Databank - On wp_1 - pause'),
+(30313, 0, 15, 0, 61, 0, 100, 512, 0, 0, 0, 0, 0, 0, 1, 10, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mobile Databank - On wp_1 - say_1'),
+(30313, 0, 16, 17, 40, 0, 100, 512, 3, 30316, 0, 0, 0, 0, 54, 8000, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mobile Databank - On wp_2 - pause'),
+(30313, 0, 17, 0, 61, 0, 100, 512, 0, 0, 0, 0, 0, 0, 1, 11, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mobile Databank - On wp_2 - say_2'),
+(30313, 0, 18, 19, 40, 0, 100, 512, 5, 30316, 0, 0, 0, 0, 54, 8000, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mobile Databank - On wp_3 - pause'),
+(30313, 0, 19, 0, 61, 0, 100, 512, 0, 0, 0, 0, 0, 0, 1, 12, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mobile Databank - On wp_3 - say_3'),
+(30313, 0, 20, 21, 40, 0, 100, 512, 6, 30316, 0, 0, 0, 0, 54, 8000, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mobile Databank - On wp_4 - pause'),
+(30313, 0, 21, 0, 61, 0, 100, 512, 0, 0, 0, 0, 0, 0, 1, 13, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mobile Databank - On wp_4 - say_4'),
+(30313, 0, 22, 23, 40, 0, 100, 512, 7, 30316, 0, 0, 0, 0, 54, 8000, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mobile Databank - On wp_5 - pause'),
+(30313, 0, 23, 0, 61, 0, 100, 512, 0, 0, 0, 0, 0, 0, 1, 14, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mobile Databank - On wp_5 - say_5'),
+(30313, 0, 24, 25, 40, 0, 100, 512, 2, 30317, 0, 0, 0, 0, 54, 8000, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mobile Databank - On wp_1 - pause'),
+(30313, 0, 25, 0, 61, 0, 100, 512, 0, 0, 0, 0, 0, 0, 1, 5, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mobile Databank - On wp_1 - say_1'),
+(30313, 0, 26, 27, 40, 0, 100, 512, 3, 30317, 0, 0, 0, 0, 54, 8000, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mobile Databank - On wp_2 - pause'),
+(30313, 0, 27, 0, 61, 0, 100, 512, 0, 0, 0, 0, 0, 0, 1, 6, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mobile Databank - On wp_2 - say_2'),
+(30313, 0, 28, 29, 40, 0, 100, 512, 5, 30317, 0, 0, 0, 0, 54, 8000, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mobile Databank - On wp_3 - pause'),
+(30313, 0, 29, 0, 61, 0, 100, 512, 0, 0, 0, 0, 0, 0, 1, 7, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mobile Databank - On wp_3 - say_3'),
+(30313, 0, 30, 31, 40, 0, 100, 512, 6, 30317, 0, 0, 0, 0, 54, 8000, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mobile Databank - On wp_4 - pause'),
+(30313, 0, 31, 0, 61, 0, 100, 512, 0, 0, 0, 0, 0, 0, 1, 8, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mobile Databank - On wp_4 - say_4'),
+(30313, 0, 32, 33, 40, 0, 100, 512, 7, 30317, 0, 0, 0, 0, 54, 8000, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mobile Databank - On wp_5 - pause'),
+(30313, 0, 33, 0, 61, 0, 100, 512, 0, 0, 0, 0, 0, 0, 1, 9, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mobile Databank - On wp_5 - say_5'),
+(30313, 0, 34, 35, 40, 0, 100, 512, 2, 30318, 0, 0, 0, 0, 54, 8000, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mobile Databank - On wp_1 - pause'),
+(30313, 0, 35, 0, 61, 0, 100, 512, 0, 0, 0, 0, 0, 0, 1, 15, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mobile Databank - On wp_1 - say_1'),
+(30313, 0, 36, 37, 40, 0, 100, 512, 3, 30318, 0, 0, 0, 0, 54, 8000, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mobile Databank - On wp_2 - pause'),
+(30313, 0, 37, 0, 61, 0, 100, 512, 0, 0, 0, 0, 0, 0, 1, 16, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mobile Databank - On wp_2 - say_2'),
+(30313, 0, 38, 39, 40, 0, 100, 512, 5, 30318, 0, 0, 0, 0, 54, 8000, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mobile Databank - On wp_3 - pause'),
+(30313, 0, 39, 0, 61, 0, 100, 512, 0, 0, 0, 0, 0, 0, 1, 17, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mobile Databank - On wp_3 - say_3'),
+(30313, 0, 40, 41, 40, 0, 100, 512, 6, 30318, 0, 0, 0, 0, 54, 8000, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mobile Databank - On wp_4 - pause'),
+(30313, 0, 41, 0, 61, 0, 100, 512, 0, 0, 0, 0, 0, 0, 1, 18, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mobile Databank - On wp_4 - say_4'),
+(30313, 0, 42, 0, 58, 0, 100, 0, 8, 30315, 0, 0, 0, 0, 11, 56532, 0, 0, 0, 0, 0, 23, 0, 0, 0, 0, 0, 0, 0, 0, 'Mobile Databank - On wp_end_invention - cast killcredit'),
+(30313, 0, 43, 0, 58, 0, 100, 0, 8, 30316, 0, 0, 0, 0, 11, 56534, 0, 0, 0, 0, 0, 23, 0, 0, 0, 0, 0, 0, 0, 0, 'Mobile Databank - On wp_end_life - cast killcredit'),
+(30313, 0, 44, 0, 58, 0, 100, 0, 8, 30317, 0, 0, 0, 0, 11, 56533, 0, 0, 0, 0, 0, 23, 0, 0, 0, 0, 0, 0, 0, 0, 'Mobile Databank - On wp_end_winter - cast killcredit'),
+(30313, 0, 45, 0, 58, 0, 100, 0, 8, 30318, 0, 0, 0, 0, 11, 56535, 0, 0, 0, 0, 0, 23, 0, 0, 0, 0, 0, 0, 0, 0, 'Mobile Databank - On wp_end_order - cast killcredit');
+
+-- creature_text group 19 duplicates group 18 and exists only to absorb the overrun
+-- described above. Nothing references it once the talk ids are corrected.
+DELETE FROM `creature_text_locale` WHERE (`CreatureID` = 30313) AND (`GroupID` = 19);
+DELETE FROM `creature_text` WHERE (`CreatureID` = 30313) AND (`GroupID` = 19);


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

Mobile Databank (30313) narrates quest 12986 "Fate of the Titans" at the four titan
temples. Every `SMART_ACTION_TALK` in its escort script reads a `creature_text` GroupID
one higher than the line it should play, so each temple skips its own "temple of NAME analysis
commencing" opener and closes with the next temple's opener instead. The whole
narration runs one line ahead of itself.

Temple of Order is last, so there's no following opener for it to borrow. It overruns
into `creature_text` group 19, which is a duplicate of group 18. That's why its closing
line about Watcher Tyr plays twice. (I did not check this, but the duplicate was probably done in an effort to avoid a bug/crash)

This shifts all 19 talk GroupIDs down by one, and drops group 19.

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Opus 5 via Claude Code. It produced both the SQL change and this description. Every claim below was verified against the world database, and I tested the result in game myself.
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #27220

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

The strongest evidence is already in the world DB. `smart_scripts` carries four
actionlists that nothing references, and they already use the corrected numbering:

| Actionlist | Say Lines | Cast |
| --- | --- | --- |
| 3031300 | 0,1,2,3,4 | 56532 Temple of Invention Kill Credit |
| 3031301 | 5,6,7,8,9 | 56533 Temple of Winter Kill Credit |
| 3031302 | 10,11,12,13,14 | 56534 Temple of Life Kill Credit |
| 3031303 | 15,16,17,18 | 56535 Temple of Order Kill Credit |

The kill credit spell on each one identifies its temple, so they independently confirm
both the grouping and that Temple of Order genuinely has only four lines. They're dead
code, and this PR leaves them untouched. Wiring them up would be a separate change.

Reading `creature_text` groups 0..18 in order gives four clean blocks whose openers and
closers name the right temple and watcher, and it just reads natural.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Applied to a local 3.3.5a worldserver and run at all four temples. I only took a screenshot of the temple mentioned in the ticket, but I can add more screenshots if needed from my local build. 

<img width="1004" height="446" alt="General" src="https://github.com/user-attachments/assets/7794111b-af05-44cc-b238-0c9be1250051" />

after:

<img width="2920" height="1888" alt="image" src="https://github.com/user-attachments/assets/a5cf7c20-f84b-4db7-96c1-a2d972bbe8d3" />

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. `.quest add 12986`
2. Travel to a temple and use the quest item to summon the Mobile Databank.
3. Follow it for the whole route. The lines are monster say, so they're only audible
   within say range, and at Temple of Order it climbs about 40 yards up the spire and
   out of earshot if you stay in the middle of the temple.

Expected at each temple: opens with "Temple of X analysis commencing", closes with
"Watcher Y verified to no longer be present. Analysis complete." 

## Known Issues and TODO List:

- [ ]
- [ ]

## How to Test AzerothCore PRs

When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
