### PR TITLE
feat(Core/Arena): swap OnGetStartPersonalRating for OnAddMember, add OnArenaWeekReset

### DIFF
--- a/src/server/database/Database/Implementation/CharacterDatabase.cpp
+++ b/src/server/database/Database/Implementation/CharacterDatabase.cpp
@@ -278,7 +278,7 @@ void CharacterDatabaseConnection::DoPrepareStatements()
 
     // Arena teams
     PrepareStatement(CHAR_INS_ARENA_TEAM, "INSERT INTO arena_team (arenaTeamId, name, captainGuid, type, rating, backgroundColor, emblemStyle, emblemColor, borderStyle, borderColor) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", CONNECTION_ASYNC);
-    PrepareStatement(CHAR_INS_ARENA_TEAM_MEMBER, "INSERT INTO arena_team_member (arenaTeamId, guid, personalRating) VALUES (?, ?, ?)", CONNECTION_ASYNC);
+    PrepareStatement(CHAR_INS_ARENA_TEAM_MEMBER, "INSERT INTO arena_team_member (arenaTeamId, guid, weekGames, weekWins, seasonGames, seasonWins, personalRating) VALUES (?, ?, ?, ?, ?, ?, ?)", CONNECTION_ASYNC);
     PrepareStatement(CHAR_DEL_ARENA_TEAM, "DELETE FROM arena_team WHERE arenaTeamId = ?", CONNECTION_ASYNC);
     PrepareStatement(CHAR_DEL_ARENA_TEAM_MEMBERS, "DELETE FROM arena_team_member WHERE arenaTeamId = ?", CONNECTION_ASYNC);
     PrepareStatement(CHAR_UPD_ARENA_TEAM_CAPTAIN, "UPDATE arena_team SET captainGuid = ? WHERE arenaTeamId = ?", CONNECTION_ASYNC);

--- a/src/server/game/Battlegrounds/ArenaTeam.cpp
+++ b/src/server/game/Battlegrounds/ArenaTeam.cpp
@@ -137,8 +137,6 @@ bool ArenaTeam::AddMember(ObjectGuid playerGuid)
     else if (GetRating() >= 1000)
         personalRating = 1000;
 
-    sScriptMgr->OnGetStartPersonalRating(this, playerGuid, personalRating);
-
     // xinef: sync query
     // Try to get player's match maker rating from db and fall back to config setting if not found
     CharacterDatabasePreparedStatement* stmt = CharacterDatabase.GetPreparedStatement(CHAR_SEL_MATCH_MAKER_RATING);
@@ -177,6 +175,8 @@ bool ArenaTeam::AddMember(ObjectGuid playerGuid)
     newMember.MatchMakerRating = matchMakerRating;
     newMember.MaxMMR           = maxMMR;
 
+    sScriptMgr->OnAddMember(this, newMember);
+
     Members.push_back(newMember);
     sCharacterCache->UpdateCharacterArenaTeamId(playerGuid, GetSlot(), GetId());
 
@@ -184,7 +184,11 @@ bool ArenaTeam::AddMember(ObjectGuid playerGuid)
     stmt = CharacterDatabase.GetPreparedStatement(CHAR_INS_ARENA_TEAM_MEMBER);
     stmt->SetData(0, TeamId);
     stmt->SetData(1, playerGuid.GetCounter());
-    stmt->SetData(2, personalRating);
+    stmt->SetData(2, newMember.WeekGames);
+    stmt->SetData(3, newMember.WeekWins);
+    stmt->SetData(4, newMember.SeasonGames);
+    stmt->SetData(5, newMember.SeasonWins);
+    stmt->SetData(6, newMember.PersonalRating);
     CharacterDatabase.Execute(stmt);
 
     // Inform player if online

--- a/src/server/game/Battlegrounds/ArenaTeamMgr.cpp
+++ b/src/server/game/Battlegrounds/ArenaTeamMgr.cpp
@@ -268,6 +268,8 @@ void ArenaTeamMgr::DistributeArenaPoints()
         }
     }
 
+    sScriptMgr->OnArenaWeekReset();
+
     ChatHandler(nullptr).SendWorldText(LANG_DIST_ARENA_POINTS_TEAM_END);
 
     ChatHandler(nullptr).SendWorldText(LANG_DIST_ARENA_POINTS_END);

--- a/src/server/game/Scripting/ScriptDefines/ArenaScript.cpp
+++ b/src/server/game/Scripting/ScriptDefines/ArenaScript.cpp
@@ -54,9 +54,9 @@ bool ScriptMgr::CanSaveArenaStatsForMember(ArenaTeam* team, ObjectGuid playerGui
     CALL_ENABLED_BOOLEAN_HOOKS(ArenaScript, ARENAHOOK_CAN_SAVE_ARENA_STATS_FOR_MEMBER, !script->CanSaveArenaStatsForMember(team, playerGuid));
 }
 
-void ScriptMgr::OnGetStartPersonalRating(ArenaTeam* team, ObjectGuid playerGuid, uint32& personalRating)
+void ScriptMgr::OnAddMember(ArenaTeam* team, ArenaTeamMember& member)
 {
-    CALL_ENABLED_HOOKS(ArenaScript, ARENAHOOK_ON_GET_START_PERSONAL_RATING, script->OnGetStartPersonalRating(team, playerGuid, personalRating));
+    CALL_ENABLED_HOOKS(ArenaScript, ARENAHOOK_ON_ADD_MEMBER, script->OnAddMember(team, member));
 }
 
 ArenaScript::ArenaScript(char const* name, std::vector<uint16> enabledHooks)

--- a/src/server/game/Scripting/ScriptDefines/ArenaScript.h
+++ b/src/server/game/Scripting/ScriptDefines/ArenaScript.h
@@ -22,6 +22,8 @@
 #include "ScriptObject.h"
 #include <vector>
 
+struct ArenaTeamMember;
+
 enum ArenaHook
 {
     ARENAHOOK_CAN_ADD_MEMBER,
@@ -31,7 +33,7 @@ enum ArenaHook
     ARENAHOOK_ON_ARENA_START,
     ARENAHOOK_ON_BEFORE_TEAM_MEMBER_UPDATE,
     ARENAHOOK_CAN_SAVE_ARENA_STATS_FOR_MEMBER,
-    ARENAHOOK_ON_GET_START_PERSONAL_RATING,
+    ARENAHOOK_ON_ADD_MEMBER,
     ARENAHOOK_END
 };
 
@@ -59,9 +61,10 @@ public:
 
     [[nodiscard]] virtual bool CanSaveArenaStatsForMember(ArenaTeam* /*team*/, ObjectGuid /*playerGuid*/) { return true; }
 
-    // Called with the personal rating the core computed for a player joining the team, before it is
-    // stored on the member and written to arena_team_member.
-    virtual void OnGetStartPersonalRating(ArenaTeam* /*team*/, ObjectGuid /*playerGuid*/, uint32& /*personalRating*/) { }
+    // Called with the fully built member right before it is added to the team and written to
+    // arena_team_member. Whatever the hook leaves on the struct, rating and counters alike, is what
+    // the team holds and what is stored. Cannot veto the join, CanAddMember does that.
+    virtual void OnAddMember(ArenaTeam* /*team*/, ArenaTeamMember& /*member*/) { }
 };
 
 #endif

--- a/src/server/game/Scripting/ScriptDefines/ArenaScript.h
+++ b/src/server/game/Scripting/ScriptDefines/ArenaScript.h
@@ -62,8 +62,11 @@ public:
     [[nodiscard]] virtual bool CanSaveArenaStatsForMember(ArenaTeam* /*team*/, ObjectGuid /*playerGuid*/) { return true; }
 
     // Called with the fully built member right before it is added to the team and written to
-    // arena_team_member. Whatever the hook leaves on the struct, rating and counters alike, is what
-    // the team holds and what is stored. Cannot veto the join, CanAddMember does that.
+    // arena_team_member. The personal rating and the week/season counters left on the struct are
+    // what the team holds and what is stored. MatchMakerRating and MaxMMR are held in memory but
+    // not written here, only by the next ArenaTeam::SaveToDB; Guid, Name and Class are identity,
+    // and changing them desyncs the member from its row and the character cache.
+    // Cannot veto the join, CanAddMember does that.
     virtual void OnAddMember(ArenaTeam* /*team*/, ArenaTeamMember& /*member*/) { }
 };
 

--- a/src/server/game/Scripting/ScriptDefines/GlobalScript.cpp
+++ b/src/server/game/Scripting/ScriptDefines/GlobalScript.cpp
@@ -74,6 +74,11 @@ void ScriptMgr::OnBeforeUpdateArenaPoints(ArenaTeam* at, std::map<ObjectGuid, ui
     CALL_ENABLED_HOOKS(GlobalScript, GLOBALHOOK_ON_BEFORE_UPDATE_ARENA_POINTS, script->OnBeforeUpdateArenaPoints(at, ap));
 }
 
+void ScriptMgr::OnArenaWeekReset()
+{
+    CALL_ENABLED_HOOKS(GlobalScript, GLOBALHOOK_ON_ARENA_WEEK_RESET, script->OnArenaWeekReset());
+}
+
 void ScriptMgr::OnAfterUpdateEncounterState(Map* map, EncounterCreditType type, uint32 creditEntry, Unit* source, Difficulty difficulty_fixed, DungeonEncounterList const* encounters, uint32 dungeonCompleted, bool updated)
 {
     CALL_ENABLED_HOOKS(GlobalScript, GLOBALHOOK_ON_AFTER_UPDATE_ENCOUNTER_STATE, script->OnAfterUpdateEncounterState(map, type, creditEntry, source, difficulty_fixed, encounters, dungeonCompleted, updated));

--- a/src/server/game/Scripting/ScriptDefines/GlobalScript.h
+++ b/src/server/game/Scripting/ScriptDefines/GlobalScript.h
@@ -37,6 +37,7 @@ enum GlobalHook
     GLOBALHOOK_ON_INITIALIZE_LOCKED_DUNGEONS,
     GLOBALHOOK_ON_AFTER_INITIALIZE_LOCKED_DUNGEONS,
     GLOBALHOOK_ON_BEFORE_UPDATE_ARENA_POINTS,
+    GLOBALHOOK_ON_ARENA_WEEK_RESET,
     GLOBALHOOK_ON_AFTER_UPDATE_ENCOUNTER_STATE,
     GLOBALHOOK_ON_BEFORE_WORLDOBJECT_SET_PHASEMASK,
     GLOBALHOOK_ON_IS_AFFECTED_BY_SPELL_MOD_CHECK,
@@ -72,6 +73,10 @@ public:
 
     // On Before arena points distribution
     virtual void OnBeforeUpdateArenaPoints(ArenaTeam* /*at*/, std::map<ObjectGuid, uint32>& /*ap*/) { }
+
+    // Called when the weekly arena point distribution has just reset the week statistics of every
+    // arena team on the realm.
+    virtual void OnArenaWeekReset() { }
 
     // Called when a dungeon encounter is updated.
     virtual void OnAfterUpdateEncounterState(Map* /*map*/, EncounterCreditType /*type*/,  uint32 /*creditEntry*/, Unit* /*source*/, Difficulty /*difficulty_fixed*/, std::list<DungeonEncounter const*> const* /*encounters*/, uint32 /*dungeonCompleted*/, bool /*updated*/) { }

--- a/src/server/game/Scripting/ScriptMgr.h
+++ b/src/server/game/Scripting/ScriptMgr.h
@@ -520,6 +520,7 @@ public: /* GlobalScript */
     void OnGlobalItemDelFromDB(CharacterDatabaseTransaction trans, ObjectGuid::LowType itemGuid);
     void OnGlobalMirrorImageDisplayItem(Item const* item, uint32& display);
     void OnBeforeUpdateArenaPoints(ArenaTeam* at, std::map<ObjectGuid, uint32>& ap);
+    void OnArenaWeekReset();
     void OnAfterRefCount(Player const* player, Loot& loot, bool canRate, uint16 lootMode, LootStoreItem* LootStoreItem, uint32& maxcount, LootStore const& store);
     void OnAfterCalculateLootGroupAmount(Player const* player, Loot& loot, uint16 lootMode, uint32& groupAmount, LootStore const& store);
     void OnBeforeDropAddItem(Player const* player, Loot& loot, bool canRate, uint16 lootMode, LootStoreItem* LootStoreItem, LootStore const& store);
@@ -673,7 +674,7 @@ public: /* ArenaScript */
     void OnArenaStart(Battleground* const bg);
     bool OnBeforeArenaTeamMemberUpdate(ArenaTeam* team, Player* player, bool won, uint32 opponentMatchmakerRating, int32 matchmakerChange);
     bool CanSaveArenaStatsForMember(ArenaTeam* team, ObjectGuid playerGuid);
-    void OnGetStartPersonalRating(ArenaTeam* team, ObjectGuid playerGuid, uint32& personalRating);
+    void OnAddMember(ArenaTeam* team, ArenaTeamMember& member);
 
 public: /* MiscScript */
 

--- a/src/test/server/game/Battlegrounds/ArenaHookDefaultsTest.cpp
+++ b/src/test/server/game/Battlegrounds/ArenaHookDefaultsTest.cpp
@@ -99,7 +99,7 @@ TEST_F(ArenaHookDefaultsTest, OnAddMemberLeavesMemberUntouched)
 {
     ArenaTeam team;
 
-    ArenaTeamMember member;
+    ArenaTeamMember member{};
     member.PersonalRating = 1000;
     member.WeekGames      = 6;
     member.WeekWins       = 3;

--- a/src/test/server/game/Battlegrounds/ArenaHookDefaultsTest.cpp
+++ b/src/test/server/game/Battlegrounds/ArenaHookDefaultsTest.cpp
@@ -92,14 +92,27 @@ TEST_F(ArenaHookDefaultsTest, CanSaveArenaStatsForMemberDefaultsTrue)
     EXPECT_TRUE(sScriptMgr->CanSaveArenaStatsForMember(&team, ObjectGuid::Empty));
 }
 
-// OnGetStartPersonalRating must leave the rating untouched by default so a new
-// arena team member keeps the value ArenaTeam::AddMember computed for them.
-TEST_F(ArenaHookDefaultsTest, OnGetStartPersonalRatingKeepsCoreValue)
+// OnAddMember must leave the member untouched by default so a new arena team
+// member keeps the rating and counters ArenaTeam::AddMember built for them,
+// which are also what is written to arena_team_member.
+TEST_F(ArenaHookDefaultsTest, OnAddMemberLeavesMemberUntouched)
 {
     ArenaTeam team;
-    uint32 personalRating = 1000;
-    sScriptMgr->OnGetStartPersonalRating(&team, ObjectGuid::Empty, personalRating);
-    EXPECT_EQ(personalRating, 1000u);
+
+    ArenaTeamMember member;
+    member.PersonalRating = 1000;
+    member.WeekGames      = 6;
+    member.WeekWins       = 3;
+    member.SeasonGames    = 40;
+    member.SeasonWins     = 22;
+
+    sScriptMgr->OnAddMember(&team, member);
+
+    EXPECT_EQ(member.PersonalRating, 1000u);
+    EXPECT_EQ(member.WeekGames, 6u);
+    EXPECT_EQ(member.WeekWins, 3u);
+    EXPECT_EQ(member.SeasonGames, 40u);
+    EXPECT_EQ(member.SeasonWins, 22u);
 }
 
 // OnBeforeArenaCheckWinConditions must return true by default so


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Replaces `OnGetStartPersonalRating` (added in #27069, I'm its only consumer) with a hook that hands out the whole member, and adds a realm-wide one for the weekly arena point reset:

```cpp
virtual void OnAddMember(ArenaTeam* team, ArenaTeamMember& member) { }   // ArenaScript
virtual void OnArenaWeekReset() { }                                      // GlobalScript
```

`OnGetStartPersonalRating` only exposed the personal rating, and that turned out to be too narrow. `ArenaTeam::AddMember` hardcodes `WeekGames`, `WeekWins`, `SeasonGames` and `SeasonWins` to 0 and `CHAR_INS_ARENA_TEAM_MEMBER` wrote nothing but `(arenaTeamId, guid, personalRating)`, so a module had no way to seed those counters for a joining member.

`OnAddMember` is called with the fully built `ArenaTeamMember` right before it goes onto the team, so whatever a script leaves on the struct is what the team holds and what lands in `arena_team_member`. It can't veto the join, `CanAddMember` already does that.

The INSERT binds the counters from that struct now. With no script registered the row it writes is identical to the one we wrote before, since the counters are still 0 at that point and the columns already default to 0. No schema change.

`OnArenaWeekReset` fires once in `ArenaTeamMgr::DistributeArenaPoints`, after the loop that calls `FinishWeek()` and saves every team. It's realm-wide and takes no parameters, for modules that keep their own copy of week statistics and need to clear it when the core clears its own. It fires even if no team played that week.

Both hooks do nothing on their own, the default implementations are empty.

I'm using them in [mod-arena-rating-memory](https://github.com/azerothcore/mod-arena-rating-memory), which gives a player back their old rating and played games when they rejoin a team they used to be in, but neither hook assumes anything about that.

### AI-assisted Pull Requests

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Opus 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:

None.

## SOURCE:

Not applicable, these are scripting hooks and not a behaviour fix.

## Tests Performed:

- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Builds clean with `-DBUILD_TESTING=1 -DSCRIPTS=static -DMODULES=static` on Linux, GCC. `ArenaHookDefaultsTest.OnGetStartPersonalRatingKeepsCoreValue` is replaced by `OnAddMemberLeavesMemberUntouched`, which pre-fills a member with a rating and counters, calls the hook with no script registered and expects all five values unchanged.

## How to Test the Changes:

- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Build with `-DBUILD_TESTING=1` and run `unit_tests`, `ArenaHookDefaultsTest.OnAddMemberLeavesMemberUntouched` should pass.
2. Without any module registering the hook, create an arena team and invite a player. Their row in `arena_team_member` is the same as before this PR: rating 1000 on a team rated 1000+, 0 below that (or whatever `Arena.ArenaStartPersonalRating` is set to), and all four counters 0.
3. Let the team play a rated match and trigger the weekly distribution (short `Arena.AutoDistributeInterval`). Points are handed out and week stats reset exactly as before, `OnArenaWeekReset` has no listener.
4. With a module implementing `OnAddMember` and writing to the member, the joining player gets those values in `arena_team_member` right away, without a reload.

## Known Issues and TODO List:

- [ ] Nothing pending.
