### PR TITLE
fix(Core/Battlegrounds): fix rated arena matchmaking

### DIFF
--- a/modules/CMakeLists.txt
+++ b/modules/CMakeLists.txt
@@ -375,7 +375,7 @@ if (MOD_ALE_FOUND)
   endif()
 
   if (WIN32)
-    if (MSVC)
+    if(CMAKE_GENERATOR MATCHES "Visual Studio")
       set(MSVC_CONFIGURATION_NAME $(ConfigurationName)/)
     endif()
 

--- a/src/common/Utilities/Util.cpp
+++ b/src/common/Utilities/Util.cpp
@@ -605,7 +605,7 @@ bool StringCompareLessI(std::string_view a, std::string_view b)
     return std::lexicographical_compare(a.begin(), a.end(), b.begin(), b.end(), [](char c1, char c2) { return std::tolower(c1) < std::tolower(c2); });
 }
 
-std::string GetTypeName(std::type_info const& info)
+std::string Acore::GetTypeName(std::type_info const& info)
 {
     return boost::core::demangle(info.name());
 }

--- a/src/common/Utilities/Util.h
+++ b/src/common/Utilities/Util.h
@@ -622,12 +622,15 @@ Ret* Coalesce(T1* first, T*... rest)
         return static_cast<Ret*>(first);
 }
 
-AC_COMMON_API std::string GetTypeName(std::type_info const&);
+namespace Acore
+{
+    AC_COMMON_API std::string GetTypeName(std::type_info const&);
 
-template <typename T>
-std::string GetTypeName() { return GetTypeName(typeid(T)); }
+    template <typename T>
+    std::string GetTypeName() { return GetTypeName(typeid(T)); }
 
-template <typename T>
-std::enable_if_t<!std::is_same_v<std::decay_t<T>, std::type_info>, std::string> GetTypeName(T&& v) { return GetTypeName(typeid(v)); }
+    template <typename T>
+    std::enable_if_t<!std::is_same_v<std::decay_t<T>, std::type_info>, std::string> GetTypeName(T&& v) { return GetTypeName(typeid(v)); }
+}
 
 #endif

--- a/src/server/apps/worldserver/worldserver.conf.dist
+++ b/src/server/apps/worldserver/worldserver.conf.dist
@@ -4088,7 +4088,8 @@ Arena.MaxRatingDifference = 150
 #
 #    Arena.RatingDiscardTimer
 #        Description: Time (in milliseconds) after which rating differences are ignored when
-#                     setting up matches.
+#                     setting up matches. When disabled the rating difference is always
+#                     enforced. To ignore ratings entirely, disable Arena.MaxRatingDifference.
 #        Default:     600000 - (Enabled, 10 minutes)
 #                     0      - (Disabled)
 
@@ -4097,6 +4098,7 @@ Arena.RatingDiscardTimer = 600000
 #
 #    Arena.PreviousOpponentsDiscardTimer
 #        Description: Time (in milliseconds) after which the previous opponents will be ignored.
+#                     When disabled an immediate rematch is allowed.
 #        Default:     120000 - (Enabled, 2 minutes - Blizzlike)
 #                     0      - (Disabled)
 

--- a/src/server/game/Battlegrounds/ArenaMatchmaking.cpp
+++ b/src/server/game/Battlegrounds/ArenaMatchmaking.cpp
@@ -1,0 +1,101 @@
+/*
+ * This file is part of the AzerothCore Project. See AUTHORS file for Copyright information
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "ArenaMatchmaking.h"
+
+#include <algorithm>
+#include <iterator>
+#include <list>
+#include <ranges>
+
+namespace
+{
+    using ArenaMatchmaking::QueuedTeam;
+    using ArenaMatchmaking::Rules;
+
+    uint32 RatingGap(QueuedTeam const& lhs, QueuedTeam const& rhs)
+    {
+        return std::max(lhs.matchmakerRating, rhs.matchmakerRating)
+            - std::min(lhs.matchmakerRating, rhs.matchmakerRating);
+    }
+
+    bool IsRematch(QueuedTeam const& lhs, QueuedTeam const& rhs)
+    {
+        return lhs.previousOpponentsTeamId == rhs.teamId || rhs.previousOpponentsTeamId == lhs.teamId;
+    }
+
+    bool WaitedLonger(QueuedTeam const* lhs, QueuedTeam const* rhs)
+    {
+        return lhs->waited > rhs->waited;
+    }
+}
+
+bool ArenaMatchmaking::CanFaceEachOther(QueuedTeam const& lhs, QueuedTeam const& rhs, Rules const& rules)
+{
+    if (lhs.teamId == rhs.teamId)
+        return false;
+
+    // Both sides must have sat out the rematch timer
+    if (IsRematch(lhs, rhs) && std::min(lhs.waited, rhs.waited) < rules.previousOpponentsDiscardTimer)
+        return false;
+
+    if (!rules.maxRatingDifference)
+        return true;
+
+    // Either side having waited is enough, the gap is a property of the pair
+    if (rules.ratingDiscardTimer && std::max(lhs.waited, rhs.waited) >= *rules.ratingDiscardTimer)
+        return true;
+
+    return RatingGap(lhs, rhs) <= *rules.maxRatingDifference;
+}
+
+std::vector<ArenaMatchmaking::Match> ArenaMatchmaking::SelectMatches(std::span<QueuedTeam const> teams,
+    Rules const& rules)
+{
+    std::list<QueuedTeam const*> pending;
+
+    for (QueuedTeam const& team : teams)
+        pending.push_back(&team);
+
+    // std::list::sort is stable
+    pending.sort(WaitedLonger);
+
+    std::vector<Match> matches;
+
+    for (auto anchor = pending.begin(); anchor != pending.end(); )
+    {
+        auto admissible = std::ranges::subrange(std::next(anchor), pending.end())
+            | std::views::filter([&](QueuedTeam const* team) { return CanFaceEachOther(**anchor, *team, rules); });
+
+        auto const opponent = std::ranges::min_element(admissible, {},
+            [&](QueuedTeam const* team) { return RatingGap(**anchor, *team); });
+
+        // A team nobody can play stays queued, but must not hold up the teams behind it
+        if (opponent == std::ranges::end(admissible))
+        {
+            ++anchor;
+            continue;
+        }
+
+        matches.push_back({ .firstTeamId = (*anchor)->teamId, .secondTeamId = (*opponent)->teamId });
+
+        pending.erase(opponent.base());
+        anchor = pending.erase(anchor);
+    }
+
+    return matches;
+}

--- a/src/server/game/Battlegrounds/ArenaMatchmaking.h
+++ b/src/server/game/Battlegrounds/ArenaMatchmaking.h
@@ -1,0 +1,95 @@
+/*
+ * This file is part of the AzerothCore Project. See AUTHORS file for Copyright information
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef ACORE_ARENA_MATCHMAKING_H
+#define ACORE_ARENA_MATCHMAKING_H
+
+#include "Define.h"
+#include "Duration.h"
+#include <chrono>
+#include <optional>
+#include <span>
+#include <vector>
+
+/**
+ * Rated arena pairing.
+ *
+ * Free of game types, pointers, singletons and the clock, so the rules can be
+ * stated and tested on their own. The caller narrows its queue to the teams that
+ * may play, projects them into QueuedTeam values, and applies the result.
+ */
+namespace ArenaMatchmaking
+{
+    // Milliseconds at the width of the queue clock the wait is measured from
+    using WaitTime = std::chrono::duration<uint32, std::milli>;
+
+    // A team waiting to be paired
+    struct QueuedTeam
+    {
+        uint32   teamId{};
+        uint32   matchmakerRating{};
+        WaitTime waited{};
+        uint32   previousOpponentsTeamId{};     // 0 when the team has not played yet
+    };
+
+    struct Rules
+    {
+        // Largest rating gap two teams may face each other across.
+        // Absent leaves the gap unconstrained.
+        std::optional<uint32> maxRatingDifference;
+
+        // Once either team has waited this long, the rating gap no longer applies to
+        // the pair. Absent never waives the gap, zero waives it at once.
+        std::optional<Milliseconds> ratingDiscardTimer;
+
+        // Two teams that just played each other are not paired again until both have
+        // waited this long. Zero allows the rematch at once.
+        Milliseconds previousOpponentsDiscardTimer{};
+    };
+
+    struct Match
+    {
+        uint32 firstTeamId{};
+        uint32 secondTeamId{};
+
+        [[nodiscard]] friend bool operator==(Match const&, Match const&) = default;
+    };
+
+    /// Return whether @p lhs and @p rhs may be started against each other under @p rules. A team
+    /// never faces itself.
+    [[nodiscard]] bool CanFaceEachOther(QueuedTeam const& lhs, QueuedTeam const& rhs, Rules const& rules);
+
+    /**
+     * @brief Return every match that can be formed out of the specified @p teams under the
+     *        specified @p rules, longest wait first.
+     *
+     * Each match pairs the longest waiting team still unpaired with its closest rated
+     * admissible opponent. A team nobody can play is passed over rather than left blocking
+     * the teams behind it. Faction is not a criterion, and position in @p teams only breaks
+     * equal waits, which keep the order they were given in, so the same queue always yields
+     * the same matches.
+     *
+     * @param teams The teams to pair, each of which the caller is willing to start a match
+     *              for, and each carrying a distinct @c teamId.
+     * @param rules The configured pairing constraints.
+     * @return The matches to start, in the order they were formed. Every @c firstTeamId is
+     *         the longer waiting side of its pair.
+     */
+    [[nodiscard]] std::vector<Match> SelectMatches(std::span<QueuedTeam const> teams, Rules const& rules);
+}
+
+#endif // ACORE_ARENA_MATCHMAKING_H

--- a/src/server/game/Battlegrounds/BattlegroundQueue.cpp
+++ b/src/server/game/Battlegrounds/BattlegroundQueue.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "BattlegroundQueue.h"
+#include "ArenaMatchmaking.h"
 #include "ArenaTeam.h"
 #include "ArenaTeamMgr.h"
 #include "BattlegroundMgr.h"
@@ -32,6 +33,25 @@
 #include <unordered_map>
 
 #include "BattlegroundUtils.h"
+
+namespace
+{
+    ArenaMatchmaking::Rules RatedArenaRules()
+    {
+        ArenaMatchmaking::Rules rules;
+
+        if (uint32 maxRatingDifference = sWorld->getIntConfig(CONFIG_ARENA_MAX_RATING_DIFFERENCE))
+            rules.maxRatingDifference = maxRatingDifference;
+
+        if (uint32 ratingDiscardTimer = sWorld->getIntConfig(CONFIG_ARENA_RATING_DISCARD_TIMER))
+            rules.ratingDiscardTimer = Milliseconds{ ratingDiscardTimer };
+
+        rules.previousOpponentsDiscardTimer =
+            Milliseconds{ sWorld->getIntConfig(CONFIG_ARENA_PREV_OPPONENTS_DISCARD_TIMER) };
+
+        return rules;
+    }
+}
 
 /*********************************************************/
 /***            BATTLEGROUND QUEUE SYSTEM              ***/
@@ -156,16 +176,38 @@ GroupQueueInfo* BattlegroundQueue::AddGroup(Player* leader, Group* group, Battle
     ginfo->Players.clear();
 
     //compute index (if group is premade or joined a rated match) to queues
-    uint32 index = 0;
+    uint32 index = BG_QUEUE_RATED_ARENA;
 
-    if (!isRated && !isPremade)
-        index += PVP_TEAMS_COUNT;
+    if (!isRated)
+    {
+        index = isPremade ? BG_QUEUE_PREMADE_ALLIANCE : BG_QUEUE_NORMAL_ALLIANCE;
 
-    if (ginfo->teamId == TEAM_HORDE)
-        index++;
+        if (ginfo->teamId == TEAM_HORDE)
+            index++;
+    }
+
+    uint32 const chosenIndex = index;
 
     sScriptMgr->OnAddGroup(this, ginfo, index, leader, group, bgTypeId, bracketEntry,
         arenaType, isRated, isPremade, arenaRating, matchmakerRating, arenaTeamId, opponentsArenaTeamId);
+
+    // Sanity checks
+    if (index >= BG_QUEUE_MAX)
+    {
+        LOG_ERROR("bg.battleground", "BattlegroundQueue::AddGroup: a script chose out of range queue index {} for {}, queueing at {} instead",
+            index, leader->GetGUID().ToString(), chosenIndex);
+        index = chosenIndex;
+    }
+    else if (isRated && index != BG_QUEUE_RATED_ARENA)
+    {
+        LOG_ERROR("bg.battleground", "BattlegroundQueue::AddGroup: a script queued rated arena team {} at index {} rather than BG_QUEUE_RATED_ARENA, so it will never be matched",
+            arenaTeamId, index);
+    }
+    else if (!isRated && index == BG_QUEUE_RATED_ARENA)
+    {
+        LOG_ERROR("bg.battleground", "BattlegroundQueue::AddGroup: a script queued an unrated group for {} into BG_QUEUE_RATED_ARENA, so it will never be matched",
+            leader->GetGUID().ToString());
+    }
 
     LOG_DEBUG("bg.battleground", "Adding Group to BattlegroundQueue bgTypeId: {}, bracket_id: {}, index: {}", bgTypeId, bracketId, index);
 
@@ -906,135 +948,67 @@ void BattlegroundQueue::BattlegroundQueueUpdate(uint32 diff, BattlegroundTypeId 
     }
     // check if can start new rated arenas (can create many in single queue update)
     else if (bg_template->isArena())
+        CreateRatedArenaMatches(bgTypeId, bracketEntry, bracket_id, arenaType);
+}
+
+void BattlegroundQueue::CreateRatedArenaMatches(BattlegroundTypeId bgTypeId, PvPDifficultyEntry const* bracketEntry,
+    BattlegroundBracketId bracketId, uint8 arenaType)
+{
+    auto const now = static_cast<uint32>(GameTime::GetGameTimeMS().count());
+
+    GroupsQueueType& queued = m_QueuedGroups[bracketId][BG_QUEUE_RATED_ARENA];
+
+    std::vector<ArenaMatchmaking::QueuedTeam> teams;
+    std::unordered_map<uint32, GroupsQueueType::iterator> slots;
+
+    for (auto itr = queued.begin(); itr != queued.end(); ++itr)
     {
-        // found out the minimum and maximum ratings the newly added team should battle against
-        // arenaRating is the rating of the latest joined team, or 0
-        // 0 is on (automatic update call) and we must set it to team's with longest wait time
-        if (!arenaRating)
+        GroupQueueInfo const& group = **itr;
+
+        if (!group.IsRated || group.IsInvitedToBGInstanceGUID || !group.ArenaTeamId)
+            continue;
+
+        if (!slots.try_emplace(group.ArenaTeamId, itr).second)
         {
-            GroupQueueInfo* front1 = nullptr;
-            GroupQueueInfo* front2 = nullptr;
-
-            if (!m_QueuedGroups[bracket_id][BG_QUEUE_PREMADE_ALLIANCE].empty())
-            {
-                front1 = m_QueuedGroups[bracket_id][BG_QUEUE_PREMADE_ALLIANCE].front();
-                arenaRating = front1->ArenaMatchmakerRating;
-            }
-
-            if (!m_QueuedGroups[bracket_id][BG_QUEUE_PREMADE_HORDE].empty())
-            {
-                front2 = m_QueuedGroups[bracket_id][BG_QUEUE_PREMADE_HORDE].front();
-                arenaRating = front2->ArenaMatchmakerRating;
-            }
-
-            if (front1 && front2)
-            {
-                if (front1->JoinTime < front2->JoinTime)
-                    arenaRating = front1->ArenaMatchmakerRating;
-            }
-            else if (!front1 && !front2)
-                return; // queues are empty
+            LOG_ERROR("bg.battleground", "BattlegroundQueue: arena team {} is queued more than once in bracket {}, ignoring the duplicate",
+                group.ArenaTeamId, bracketId);
+            continue;
         }
 
-        //set rating range
-        uint32 arenaMinRating = (arenaRating <= sBattlegroundMgr->GetMaxRatingDifference()) ? 0 : arenaRating - sBattlegroundMgr->GetMaxRatingDifference();
-        uint32 arenaMaxRating = arenaRating + sBattlegroundMgr->GetMaxRatingDifference();
+        teams.push_back({
+            .teamId = group.ArenaTeamId,
+            .matchmakerRating = group.ArenaMatchmakerRating,
+            .waited = ArenaMatchmaking::WaitTime{ now - group.JoinTime },
+            .previousOpponentsTeamId = group.PreviousOpponentsTeamId });
+    }
 
-        // if max rating difference is set and the time past since server startup is greater than the rating discard time
-        // (after what time the ratings aren't taken into account when making teams) then
-        // the discard time is current_time - time_to_discard, teams that joined after that, will have their ratings taken into account
-        // else leave the discard time on 0, this way all ratings will be discarded
-        // this has to be signed value - when the server starts, this value would be negative and thus overflow
-        int32 discardTime = GameTime::GetGameTimeMS().count() - sBattlegroundMgr->GetRatingDiscardTimer();
+    for (ArenaMatchmaking::Match const& match : ArenaMatchmaking::SelectMatches(teams, RatedArenaRules()))
+    {
+        GroupQueueInfo* aTeam = *slots.at(match.firstTeamId);
+        GroupQueueInfo* hTeam = *slots.at(match.secondTeamId);
 
-        // timer for previous opponents
-        int32 discardOpponentsTime = GameTime::GetGameTimeMS().count() - sWorld->getIntConfig(CONFIG_ARENA_PREV_OPPONENTS_DISCARD_TIMER);
-
-        // we need to find 2 teams which will play next game
-        GroupsQueueType::iterator itr_teams[PVP_TEAMS_COUNT];
-        uint8 found = 0;
-        uint8 team = 0;
-
-        for (uint8 i = BG_QUEUE_PREMADE_ALLIANCE; i < BG_QUEUE_NORMAL_ALLIANCE; i++)
+        Battleground* arena = sBattlegroundMgr->CreateNewBattleground(bgTypeId, bracketEntry, arenaType, true);
+        if (!arena)
         {
-            // take the group that joined first
-            GroupsQueueType::iterator itr2 = m_QueuedGroups[bracket_id][i].begin();
-            for (; itr2 != m_QueuedGroups[bracket_id][i].end(); ++itr2)
-            {
-                // if group match conditions, then add it to pool
-                if (!(*itr2)->IsInvitedToBGInstanceGUID
-                    && (((*itr2)->ArenaMatchmakerRating >= arenaMinRating && (*itr2)->ArenaMatchmakerRating <= arenaMaxRating)
-                        || (int32)(*itr2)->JoinTime < discardTime))
-                {
-                    itr_teams[found++] = itr2;
-                    team = i;
-                    break;
-                }
-            }
+            LOG_ERROR("bg.battleground", "BattlegroundQueue::Update couldn't create arena instance for rated arena match!");
+            continue;
         }
 
-        if (!found)
-            return;
+        aTeam->OpponentsTeamRating = hTeam->ArenaTeamRating;
+        hTeam->OpponentsTeamRating = aTeam->ArenaTeamRating;
+        aTeam->OpponentsMatchmakerRating = hTeam->ArenaMatchmakerRating;
+        hTeam->OpponentsMatchmakerRating = aTeam->ArenaMatchmakerRating;
 
-        if (found == 1)
-        {
-            for (GroupsQueueType::iterator itr3 = itr_teams[0]; itr3 != m_QueuedGroups[bracket_id][team].end(); ++itr3)
-            {
-                if (!(*itr3)->IsInvitedToBGInstanceGUID
-                    && (((*itr3)->ArenaMatchmakerRating >= arenaMinRating && (*itr3)->ArenaMatchmakerRating <= arenaMaxRating) || (int32)(*itr3)->JoinTime < discardTime)
-                    && ((*(itr_teams[0]))->ArenaTeamId != (*itr3)->PreviousOpponentsTeamId || ((int32)(*itr3)->JoinTime < discardOpponentsTime))
-                    && (*(itr_teams[0]))->ArenaTeamId != (*itr3)->ArenaTeamId)
-                {
-                    itr_teams[found++] = itr3;
-                    break;
-                }
-            }
-        }
+        LOG_DEBUG("bg.battleground", "setting oposite teamrating for team {} to {}", aTeam->ArenaTeamId, aTeam->OpponentsTeamRating);
+        LOG_DEBUG("bg.battleground", "setting oposite teamrating for team {} to {}", hTeam->ArenaTeamId, hTeam->OpponentsTeamRating);
 
-        //if we have 2 teams, then start new arena and invite players!
-        if (found == 2)
-        {
-            GroupQueueInfo* aTeam = *(itr_teams[TEAM_ALLIANCE]);
-            GroupQueueInfo* hTeam = *(itr_teams[TEAM_HORDE]);
+        arena->SetArenaMatchmakerRating(TEAM_ALLIANCE, aTeam->ArenaMatchmakerRating);
+        arena->SetArenaMatchmakerRating(TEAM_HORDE, hTeam->ArenaMatchmakerRating);
+        InviteGroupToBG(aTeam, arena, TEAM_ALLIANCE);
+        InviteGroupToBG(hTeam, arena, TEAM_HORDE);
 
-            Battleground* arena = sBattlegroundMgr->CreateNewBattleground(bgTypeId, bracketEntry, arenaType, true);
-            if (!arena)
-            {
-                LOG_ERROR("bg.battleground", "BattlegroundQueue::Update couldn't create arena instance for rated arena match!");
-                return;
-            }
-
-            aTeam->OpponentsTeamRating = hTeam->ArenaTeamRating;
-            hTeam->OpponentsTeamRating = aTeam->ArenaTeamRating;
-            aTeam->OpponentsMatchmakerRating = hTeam->ArenaMatchmakerRating;
-            hTeam->OpponentsMatchmakerRating = aTeam->ArenaMatchmakerRating;
-
-            LOG_DEBUG("bg.battleground", "setting oposite teamrating for team {} to {}", aTeam->ArenaTeamId, aTeam->OpponentsTeamRating);
-            LOG_DEBUG("bg.battleground", "setting oposite teamrating for team {} to {}", hTeam->ArenaTeamId, hTeam->OpponentsTeamRating);
-
-            // now we must move team if we changed its faction to another faction queue, because then we will spam log by errors in Queue::RemovePlayer
-            if (aTeam->teamId != TEAM_ALLIANCE)
-            {
-                aTeam->GroupType = BG_QUEUE_PREMADE_ALLIANCE;
-                m_QueuedGroups[bracket_id][BG_QUEUE_PREMADE_ALLIANCE].push_front(aTeam);
-                m_QueuedGroups[bracket_id][BG_QUEUE_PREMADE_HORDE].erase(itr_teams[TEAM_ALLIANCE]);
-            }
-
-            if (hTeam->teamId != TEAM_HORDE)
-            {
-                hTeam->GroupType = BG_QUEUE_PREMADE_HORDE;
-                m_QueuedGroups[bracket_id][BG_QUEUE_PREMADE_HORDE].push_front(hTeam);
-                m_QueuedGroups[bracket_id][BG_QUEUE_PREMADE_ALLIANCE].erase(itr_teams[TEAM_HORDE]);
-            }
-
-            arena->SetArenaMatchmakerRating(TEAM_ALLIANCE, aTeam->ArenaMatchmakerRating);
-            arena->SetArenaMatchmakerRating(TEAM_HORDE, hTeam->ArenaMatchmakerRating);
-            InviteGroupToBG(aTeam, arena, TEAM_ALLIANCE);
-            InviteGroupToBG(hTeam, arena, TEAM_HORDE);
-
-            LOG_DEBUG("bg.battleground", "Starting rated arena match!");
-            arena->StartBattleground();
-        }
+        LOG_DEBUG("bg.battleground", "Starting rated arena match!");
+        arena->StartBattleground();
     }
 }
 

--- a/src/server/game/Battlegrounds/BattlegroundQueue.h
+++ b/src/server/game/Battlegrounds/BattlegroundQueue.h
@@ -61,6 +61,8 @@ enum BattlegroundQueueGroupTypes
 
     BG_QUEUE_CFBG,
 
+    BG_QUEUE_RATED_ARENA,
+
     BG_QUEUE_MAX = 10
 };
 
@@ -104,10 +106,12 @@ public:
     This two dimensional array is used to store All queued groups
     First dimension specifies the bgTypeId
     Second dimension specifies the player's group types -
-         BG_QUEUE_PREMADE_ALLIANCE  is used for premade alliance groups and alliance rated arena teams
-         BG_QUEUE_PREMADE_HORDE     is used for premade horde groups and horde rated arena teams
+         BG_QUEUE_PREMADE_ALLIANCE  is used for premade alliance groups
+         BG_QUEUE_PREMADE_HORDE     is used for premade horde groups
          BG_QUEUE_NORMAL_ALLIANCE   is used for normal (or small) alliance groups or non-rated arena matches
          BG_QUEUE_NORMAL_HORDE      is used for normal (or small) horde groups or non-rated arena matches
+         BG_QUEUE_RATED_ARENA       is used for rated arena teams, which are not split by faction because
+                                    the side a team plays is chosen when it is invited, not when it queues
     */
     GroupsQueueType m_QueuedGroups[MAX_BATTLEGROUND_BRACKETS][BG_QUEUE_MAX];
 
@@ -133,6 +137,14 @@ public:
     [[nodiscard]] int32 GetQueueAnnouncementTimer(uint32 bracketId) const;
 
 private:
+    // Start every rated arena match the queued teams currently allow.
+    //
+    // @todo Rescans the bracket every update because the scheduler names a bracket, not a team.
+    // Once it carries the joiner this can search once for that team, though a periodic sweep is
+    // still needed for pairs whose discard timer elapses with no join to trigger a search.
+    void CreateRatedArenaMatches(BattlegroundTypeId bgTypeId, PvPDifficultyEntry const* bracketEntry,
+        BattlegroundBracketId bracketId, uint8 arenaType);
+
     uint32 m_WaitTimes[PVP_TEAMS_COUNT][MAX_BATTLEGROUND_BRACKETS][COUNT_OF_PLAYERS_TO_AVERAGE_WAIT_TIME];
     uint32 m_WaitTimeLastIndex[PVP_TEAMS_COUNT][MAX_BATTLEGROUND_BRACKETS];
 

--- a/src/server/game/Chat/ChatCommands/ChatCommandArgs.h
+++ b/src/server/game/Chat/ChatCommands/ChatCommandArgs.h
@@ -61,12 +61,12 @@ namespace Acore::Impl::ChatCommands
             if (Optional<T> v = StringTo<T>(token, 0))
                 val = *v;
             else
-                return FormatAcoreString(handler, LANG_CMDPARSER_STRING_VALUE_INVALID, token, GetTypeName<T>());
+                return FormatAcoreString(handler, LANG_CMDPARSER_STRING_VALUE_INVALID, token, Acore::GetTypeName<T>());
 
             if constexpr (std::is_floating_point_v<T>)
             {
                 if (!std::isfinite(val))
-                    return FormatAcoreString(handler, LANG_CMDPARSER_STRING_VALUE_INVALID, token, GetTypeName<T>());
+                    return FormatAcoreString(handler, LANG_CMDPARSER_STRING_VALUE_INVALID, token, Acore::GetTypeName<T>());
             }
 
             return tail;
@@ -199,7 +199,7 @@ namespace Acore::Impl::ChatCommands
             }
 
             if (next1)
-                return FormatAcoreString(handler, LANG_CMDPARSER_STRING_VALUE_INVALID, strVal, GetTypeName<T>());
+                return FormatAcoreString(handler, LANG_CMDPARSER_STRING_VALUE_INVALID, strVal, Acore::GetTypeName<T>());
             else
                 return next1;
         }

--- a/src/server/game/DataStores/DBCStores.h
+++ b/src/server/game/DataStores/DBCStores.h
@@ -146,6 +146,7 @@ extern DBCStorage <NamesReservedEntry>           sNamesReservedStore;
 extern DBCStorage <NamesProfanityEntry>          sNamesProfanityStore;
 extern DBCStorage <OverrideSpellDataEntry>       sOverrideSpellDataStore;
 extern DBCStorage <PowerDisplayEntry>            sPowerDisplayStore;
+extern DBCStorage <PvPDifficultyEntry>           sPvPDifficultyStore;
 extern DBCStorage <QuestSortEntry>               sQuestSortStore;
 extern DBCStorage <QuestXPEntry>                 sQuestXPStore;
 extern DBCStorage <QuestFactionRewEntry>         sQuestFactionRewardStore;

--- a/src/test/mocks/ArenaMatchmakingPrinters.h
+++ b/src/test/mocks/ArenaMatchmakingPrinters.h
@@ -1,0 +1,56 @@
+/*
+ * This file is part of the AzerothCore Project. See AUTHORS file for Copyright information
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef AZEROTHCORE_ARENA_MATCHMAKING_PRINTERS_H
+#define AZEROTHCORE_ARENA_MATCHMAKING_PRINTERS_H
+
+#include "ArenaMatchmaking.h"
+#include <ostream>
+
+// gtest finds these through ADL, so a failing assertion shows values rather than bytes.
+namespace ArenaMatchmaking
+{
+    inline void PrintTo(Match const& match, std::ostream* os)
+    {
+        *os << "{" << match.firstTeamId << ", " << match.secondTeamId << "}";
+    }
+
+    inline void PrintTo(QueuedTeam const& team, std::ostream* os)
+    {
+        *os << "{id=" << team.teamId << " mmr=" << team.matchmakerRating << " waited=" << team.waited.count()
+            << "ms prev=" << team.previousOpponentsTeamId << "}";
+    }
+
+    inline void PrintTo(Rules const& rules, std::ostream* os)
+    {
+        *os << "{gap=";
+        if (rules.maxRatingDifference)
+            *os << *rules.maxRatingDifference;
+        else
+            *os << "none";
+
+        *os << " discard=";
+        if (rules.ratingDiscardTimer)
+            *os << rules.ratingDiscardTimer->count();
+        else
+            *os << "none";
+
+        *os << " rematch=" << rules.previousOpponentsDiscardTimer.count() << "}";
+    }
+}
+
+#endif // AZEROTHCORE_ARENA_MATCHMAKING_PRINTERS_H

--- a/src/test/mocks/IntegrationTestFixture.cpp
+++ b/src/test/mocks/IntegrationTestFixture.cpp
@@ -1,0 +1,164 @@
+/*
+ * This file is part of the AzerothCore Project. See AUTHORS file for Copyright information
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "IntegrationTestFixture.h"
+#include "DBCStores.h"
+#include "WorldSession.h"
+#include <cstring>
+
+using ::testing::_;
+using ::testing::NiceMock;
+using ::testing::Return;
+using ::testing::ReturnRef;
+
+void IntegrationTestFixture::SetUp()
+{
+    TestMap::EnsureDBC();
+    EnsureFactionTemplates();
+
+    _originalWorld = sWorld.release();
+    _worldMock = new NiceMock<WorldMock>();
+    sWorld.reset(_worldMock);
+
+    static std::string emptyString;
+    ON_CALL(*_worldMock, GetDataPath()).WillByDefault(ReturnRef(emptyString));
+    ON_CALL(*_worldMock, GetRealmName()).WillByDefault(ReturnRef(emptyString));
+    ON_CALL(*_worldMock, GetDefaultDbcLocale()).WillByDefault(Return(LOCALE_enUS));
+    ON_CALL(*_worldMock, getRate(_)).WillByDefault(Return(1.0f));
+    ON_CALL(*_worldMock, getBoolConfig(_)).WillByDefault(Return(false));
+    ON_CALL(*_worldMock, getIntConfig(_)).WillByDefault(Return(0));
+    ON_CALL(*_worldMock, getFloatConfig(_)).WillByDefault(Return(0.0f));
+    ON_CALL(*_worldMock, GetPlayerSecurityLimit()).WillByDefault(Return(SEC_PLAYER));
+
+    _testMap = new TestMap();
+}
+
+void IntegrationTestFixture::TearDown()
+{
+    for (auto* creature : _trackedCreatures)
+    {
+        if (creature->IsInWorld())
+            creature->RemoveFromWorld();
+        delete creature;
+    }
+    _trackedCreatures.clear();
+
+    for (auto* player : _trackedPlayers)
+    {
+        if (player->IsInWorld())
+            player->RemoveFromWorld();
+    }
+    _trackedPlayers.clear();
+
+    for (auto* tmpl : _ownedCreatureTemplates)
+        delete tmpl;
+    _ownedCreatureTemplates.clear();
+
+    delete _testMap;
+    _testMap = nullptr;
+
+    IWorld* currentWorld = sWorld.release();
+    delete currentWorld;
+    _worldMock = nullptr;
+
+    sWorld.reset(_originalWorld);
+    _originalWorld = nullptr;
+
+    // Intentional leaks of session/player to avoid database access in destructors
+}
+
+TestPlayer* IntegrationTestFixture::CreateTestPlayer(ObjectGuid::LowType guidLow, std::string const& name,
+    AccountTypes security)
+{
+    auto* session = new WorldSession(guidLow, std::string(name), 0, nullptr, security,
+        EXPANSION_WRATH_OF_THE_LICH_KING, 0, LOCALE_enUS, 0, false, false, 0);
+    // Pre-allocate RBAC data so Player's ctor (which calls
+    // GetSession()->HasPermission) doesn't try to load from DB.
+    session->InitRBACDataForTest();
+
+    auto* player = new TestPlayer(session);
+    player->ForceInitValues(guidLow);
+    session->SetPlayer(player);
+    player->SetSession(session);
+    player->SetMap(_testMap);
+    player->AddToWorld();
+    _trackedPlayers.push_back(player);
+
+    return player;
+}
+
+TestCreature* IntegrationTestFixture::CreateTestCreature(ObjectGuid::LowType guidLow, uint32 entry, uint32 factionId)
+{
+    // CreatureTemplate must be heap-allocated AFTER WorldMock is installed
+    // because CreatureMovementData() constructor calls sWorld->getIntConfig()
+    auto* tmpl = new CreatureTemplate();
+    tmpl->Entry = entry;
+    tmpl->faction = factionId;
+    tmpl->minlevel = 80;
+    tmpl->maxlevel = 80;
+    tmpl->unit_class = CLASS_WARRIOR;
+    tmpl->DamageModifier = 1.0f;
+    tmpl->BaseAttackTime = 2000;
+    tmpl->RangeAttackTime = 2000;
+    tmpl->BaseVariance = 1.0f;
+    tmpl->RangeVariance = 1.0f;
+    tmpl->ModHealth = 1.0f;
+    _ownedCreatureTemplates.push_back(tmpl);
+
+    auto* creature = new TestCreature();
+    creature->ForceInitValues(guidLow, entry);
+    creature->SetTestMap(_testMap);
+    creature->SetInWorld(true);
+    creature->SetAlive(true);
+    creature->SetPhase(1);
+    creature->SetFaction(factionId);
+    creature->SetLevel(80);
+    creature->SetMaxHealth(10000);
+    creature->SetHealth(10000);
+    creature->InitializeThreatManager();
+    _trackedCreatures.push_back(creature);
+
+    return creature;
+}
+
+/*static*/ void IntegrationTestFixture::EnsureFactionTemplates()
+{
+    static bool initialized = false;
+    if (initialized)
+        return;
+    initialized = true;
+
+    // Faction 90001: "player-like" — ourMask=1 (FACTION_MASK_PLAYER), hostile to monsters (hostileMask=8)
+    auto* f1 = new FactionTemplateEntry();
+    std::memset(f1, 0, sizeof(FactionTemplateEntry));
+    f1->ID = TEST_FACTION_HOSTILE_TO_MONSTERS;
+    f1->faction = TEST_FACTION_HOSTILE_TO_MONSTERS;
+    f1->ourMask = 0x1;       // FACTION_MASK_PLAYER
+    f1->friendlyMask = 0x1;  // friendly to players
+    f1->hostileMask = 0x8;   // hostile to monsters
+    sFactionTemplateStore.SetEntry(TEST_FACTION_HOSTILE_TO_MONSTERS, f1);
+
+    // Faction 90002: "monster" — ourMask=8 (FACTION_MASK_MONSTER), hostile to players (hostileMask=1)
+    auto* f2 = new FactionTemplateEntry();
+    std::memset(f2, 0, sizeof(FactionTemplateEntry));
+    f2->ID = TEST_FACTION_HOSTILE_TO_ALL;
+    f2->faction = TEST_FACTION_HOSTILE_TO_ALL;
+    f2->ourMask = 0x8;       // FACTION_MASK_MONSTER
+    f2->friendlyMask = 0x0;  // friendly to none
+    f2->hostileMask = 0x1;   // hostile to players
+    sFactionTemplateStore.SetEntry(TEST_FACTION_HOSTILE_TO_ALL, f2);
+}

--- a/src/test/mocks/IntegrationTestFixture.h
+++ b/src/test/mocks/IntegrationTestFixture.h
@@ -18,18 +18,15 @@
 #ifndef AZEROTHCORE_INTEGRATION_TEST_FIXTURE_H
 #define AZEROTHCORE_INTEGRATION_TEST_FIXTURE_H
 
+#include "Common.h"
+#include "TestCreature.h"
 #include "TestMap.h"
 #include "TestPlayer.h"
-#include "TestCreature.h"
 #include "WorldMock.h"
-#include "WorldSession.h"
-#include "DBCStores.h"
-#include "SharedDefines.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include <string>
 #include <vector>
-
-using namespace testing;
 
 // Faction template IDs for test creatures
 static constexpr uint32 TEST_FACTION_HOSTILE_TO_MONSTERS = 90001;
@@ -38,151 +35,21 @@ static constexpr uint32 TEST_FACTION_HOSTILE_TO_ALL      = 90002;
 class IntegrationTestFixture : public ::testing::Test
 {
 protected:
-    void SetUp() override
-    {
-        TestMap::EnsureDBC();
-        EnsureFactionTemplates();
+    void SetUp() override;
+    void TearDown() override;
 
-        _originalWorld = sWorld.release();
-        _worldMock = new NiceMock<WorldMock>();
-        sWorld.reset(_worldMock);
+    TestPlayer* CreateTestPlayer(ObjectGuid::LowType guidLow = 1, std::string const& name = "TestPlayer",
+        AccountTypes security = SEC_PLAYER);
+    TestCreature* CreateTestCreature(ObjectGuid::LowType guidLow, uint32 entry, uint32 factionId);
 
-        static std::string emptyString;
-        ON_CALL(*_worldMock, GetDataPath()).WillByDefault(ReturnRef(emptyString));
-        ON_CALL(*_worldMock, GetRealmName()).WillByDefault(ReturnRef(emptyString));
-        ON_CALL(*_worldMock, GetDefaultDbcLocale()).WillByDefault(Return(LOCALE_enUS));
-        ON_CALL(*_worldMock, getRate(_)).WillByDefault(Return(1.0f));
-        ON_CALL(*_worldMock, getBoolConfig(_)).WillByDefault(Return(false));
-        ON_CALL(*_worldMock, getIntConfig(_)).WillByDefault(Return(0));
-        ON_CALL(*_worldMock, getFloatConfig(_)).WillByDefault(Return(0.0f));
-        ON_CALL(*_worldMock, GetPlayerSecurityLimit()).WillByDefault(Return(SEC_PLAYER));
-
-        _testMap = new TestMap();
-    }
-
-    void TearDown() override
-    {
-        for (auto* creature : _trackedCreatures)
-        {
-            if (creature->IsInWorld())
-                creature->RemoveFromWorld();
-            delete creature;
-        }
-        _trackedCreatures.clear();
-
-        for (auto* player : _trackedPlayers)
-        {
-            if (player->IsInWorld())
-                player->RemoveFromWorld();
-        }
-        _trackedPlayers.clear();
-
-        for (auto* tmpl : _ownedCreatureTemplates)
-            delete tmpl;
-        _ownedCreatureTemplates.clear();
-
-        delete _testMap;
-        _testMap = nullptr;
-
-        IWorld* currentWorld = sWorld.release();
-        delete currentWorld;
-        _worldMock = nullptr;
-
-        sWorld.reset(_originalWorld);
-        _originalWorld = nullptr;
-
-        // Intentional leaks of session/player to avoid database access in destructors
-    }
-
-    TestPlayer* CreateTestPlayer(ObjectGuid::LowType guidLow = 1,
-                                 std::string const& name = "TestPlayer",
-                                 AccountTypes security = SEC_PLAYER)
-    {
-        auto* session = new WorldSession(guidLow, std::string(name), 0, nullptr, security,
-            EXPANSION_WRATH_OF_THE_LICH_KING, 0, LOCALE_enUS, 0, false, false, 0);
-        // Pre-allocate RBAC data so Player's ctor (which calls
-        // GetSession()->HasPermission) doesn't try to load from DB.
-        session->InitRBACDataForTest();
-
-        auto* player = new TestPlayer(session);
-        player->ForceInitValues(guidLow);
-        session->SetPlayer(player);
-        player->SetSession(session);
-        player->SetMap(_testMap);
-        player->AddToWorld();
-        _trackedPlayers.push_back(player);
-
-        return player;
-    }
-
-    TestCreature* CreateTestCreature(ObjectGuid::LowType guidLow, uint32 entry, uint32 factionId)
-    {
-        // CreatureTemplate must be heap-allocated AFTER WorldMock is installed
-        // because CreatureMovementData() constructor calls sWorld->getIntConfig()
-        auto* tmpl = new CreatureTemplate();
-        tmpl->Entry = entry;
-        tmpl->faction = factionId;
-        tmpl->minlevel = 80;
-        tmpl->maxlevel = 80;
-        tmpl->unit_class = CLASS_WARRIOR;
-        tmpl->DamageModifier = 1.0f;
-        tmpl->BaseAttackTime = 2000;
-        tmpl->RangeAttackTime = 2000;
-        tmpl->BaseVariance = 1.0f;
-        tmpl->RangeVariance = 1.0f;
-        tmpl->ModHealth = 1.0f;
-        _ownedCreatureTemplates.push_back(tmpl);
-
-        auto* creature = new TestCreature();
-        creature->ForceInitValues(guidLow, entry);
-        creature->SetTestMap(_testMap);
-        creature->SetInWorld(true);
-        creature->SetAlive(true);
-        creature->SetPhase(1);
-        creature->SetFaction(factionId);
-        creature->SetLevel(80);
-        creature->SetMaxHealth(10000);
-        creature->SetHealth(10000);
-        creature->InitializeThreatManager();
-        _trackedCreatures.push_back(creature);
-
-        return creature;
-    }
-
-    NiceMock<WorldMock>* GetWorldMock() { return _worldMock; }
+    ::testing::NiceMock<WorldMock>* GetWorldMock() { return _worldMock; }
     TestMap* GetTestMap() { return _testMap; }
 
 private:
-    static void EnsureFactionTemplates()
-    {
-        static bool initialized = false;
-        if (initialized)
-            return;
-        initialized = true;
-
-        // Faction 90001: "player-like" — ourMask=1 (FACTION_MASK_PLAYER), hostile to monsters (hostileMask=8)
-        auto* f1 = new FactionTemplateEntry();
-        std::memset(f1, 0, sizeof(FactionTemplateEntry));
-        f1->ID = TEST_FACTION_HOSTILE_TO_MONSTERS;
-        f1->faction = TEST_FACTION_HOSTILE_TO_MONSTERS;
-        f1->ourMask = 0x1;       // FACTION_MASK_PLAYER
-        f1->friendlyMask = 0x1;  // friendly to players
-        f1->hostileMask = 0x8;   // hostile to monsters
-        sFactionTemplateStore.SetEntry(TEST_FACTION_HOSTILE_TO_MONSTERS, f1);
-
-        // Faction 90002: "monster" — ourMask=8 (FACTION_MASK_MONSTER), hostile to players (hostileMask=1)
-        auto* f2 = new FactionTemplateEntry();
-        std::memset(f2, 0, sizeof(FactionTemplateEntry));
-        f2->ID = TEST_FACTION_HOSTILE_TO_ALL;
-        f2->faction = TEST_FACTION_HOSTILE_TO_ALL;
-        f2->ourMask = 0x8;       // FACTION_MASK_MONSTER
-        f2->friendlyMask = 0x0;  // friendly to none
-        f2->hostileMask = 0x1;   // hostile to players
-        sFactionTemplateStore.SetEntry(TEST_FACTION_HOSTILE_TO_ALL, f2);
-    }
+    static void EnsureFactionTemplates();
 
     IWorld* _originalWorld = nullptr;
-    NiceMock<WorldMock>* _worldMock = nullptr;
+    ::testing::NiceMock<WorldMock>* _worldMock = nullptr;
     TestMap* _testMap = nullptr;
     std::vector<TestPlayer*> _trackedPlayers;
     std::vector<TestCreature*> _trackedCreatures;

--- a/src/test/mocks/TestPlayer.h
+++ b/src/test/mocks/TestPlayer.h
@@ -33,6 +33,9 @@ public:
     void SaveToDB(bool /*create*/, bool /*logout*/) { }
     void SaveToDB(CharacterDatabaseTransaction /*trans*/, bool /*create*/, bool /*logout*/) { }
 
+    // Bypasses the race lookup, which needs ChrRaces.dbc
+    void SetTeamIdForTest(TeamId team) { m_team = team; }
+
     void ForceInitValues(ObjectGuid::LowType guidLow = 1)
     {
         Object::_Create(guidLow, uint32(0), HighGuid::Player);

--- a/src/test/server/game/Battlegrounds/ArenaMatchmakingPropertyTest.cpp
+++ b/src/test/server/game/Battlegrounds/ArenaMatchmakingPropertyTest.cpp
@@ -1,0 +1,203 @@
+/*
+ * This file is part of the AzerothCore Project. See AUTHORS file for Copyright information
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "ArenaMatchmaking.h"
+#include "ArenaMatchmakingPrinters.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include <algorithm>
+#include <iostream>
+#include <random>
+#include <set>
+#include <span>
+#include <string>
+#include <vector>
+
+using ::testing::ContainerEq;
+using ::testing::PrintToString;
+
+/**
+ * Randomised properties of rated arena pairing.
+ *
+ * The example tests pin what admissible means. This generates queues and checks what the
+ * pass does with admissibility: every started pair passes the unit's own check, nobody plays
+ * twice, the longer waiter is listed first, nothing admissible is left over, and the input
+ * order does not matter.
+ *
+ * The generator is seeded from gtest's own seed, so a failure replays with
+ * --gtest_random_seed=N, and N is printed with every run.
+ */
+namespace
+{
+    using ArenaMatchmaking::CanFaceEachOther;
+    using ArenaMatchmaking::Match;
+    using ArenaMatchmaking::QueuedTeam;
+    using ArenaMatchmaking::Rules;
+
+    struct Generated
+    {
+        std::vector<QueuedTeam> teams;
+        Rules rules;
+    };
+
+    Generated GenerateQueue(std::mt19937& rng)
+    {
+        Generated out;
+
+        // Ratings are drawn from a narrow band so that admissible pairs are common. A wide
+        // band would mostly generate queues where nothing can play anything.
+        std::uniform_int_distribution teamCount(0, 12);
+        std::uniform_int_distribution<uint32> rating(1000, 2600);
+        std::uniform_int_distribution waitedSeconds(0, 1500);
+        std::uniform_int_distribution gapRoll(0, 3);
+        std::uniform_int_distribution timerRoll(0, 3);
+
+        if (gapRoll(rng) == 0)
+            out.rules.maxRatingDifference.reset();
+        else
+            out.rules.maxRatingDifference = std::uniform_int_distribution<uint32>(0, 400)(rng);
+
+        if (timerRoll(rng) == 0)
+            out.rules.ratingDiscardTimer.reset();
+        else
+            out.rules.ratingDiscardTimer = Milliseconds{ std::uniform_int_distribution(0, 900)(rng) * 1000 };
+
+        out.rules.previousOpponentsDiscardTimer =
+            Milliseconds{ std::uniform_int_distribution(0, 300)(rng) * 1000 };
+
+        int const count = teamCount(rng);
+        out.teams.reserve(count);
+
+        for (int i = 0; i < count; ++i)
+        {
+            QueuedTeam team;
+            team.teamId = static_cast<uint32>(i) + 1;               // distinct, as the caller guarantees
+            team.matchmakerRating = rating(rng);
+            team.waited = Milliseconds{ waitedSeconds(rng) * 1000 };
+            out.teams.push_back(team);
+        }
+
+        // Some teams remember a previous opponent, usually one that is also queued.
+        std::uniform_int_distribution rematchRoll(0, 2);
+        for (QueuedTeam& team : out.teams)
+        {
+            if (rematchRoll(rng) != 0 || out.teams.size() < 2)
+                continue;
+
+            std::uniform_int_distribution<std::size_t> pick(0, out.teams.size() - 1);
+            uint32 const other = out.teams[pick(rng)].teamId;
+            if (other != team.teamId)
+                team.previousOpponentsTeamId = other;
+        }
+
+        return out;
+    }
+}
+
+class ArenaMatchmakingPropertyTest : public ::testing::Test
+{
+protected:
+    static constexpr int Iterations = 2000;
+
+    void SetUp() override
+    {
+        // Time based unless --gtest_random_seed pins it
+        _seed = ::testing::UnitTest::GetInstance()->random_seed();
+        RecordProperty("random_seed", _seed);
+        std::cout << "[          ] replay with --gtest_random_seed=" << _seed << '\n';
+        _rng.seed(_seed);
+    }
+
+    std::string Context(int iteration, Generated const& input) const
+    {
+        return "--gtest_random_seed=" + std::to_string(_seed) + " iteration " + std::to_string(iteration)
+            + "\nteams " + PrintToString(input.teams) + "\nrules " + PrintToString(input.rules);
+    }
+
+    std::mt19937 _rng;
+
+private:
+    int _seed = 0;
+};
+
+TEST_F(ArenaMatchmakingPropertyTest, RandomQueuesObeyThePairingContract)
+{
+    for (int iteration = 0; iteration < Iterations; ++iteration)
+    {
+        auto const input = GenerateQueue(_rng);
+        SCOPED_TRACE(Context(iteration, input));
+
+        std::span const teams = input.teams;
+        auto const matches = ArenaMatchmaking::SelectMatches(teams, input.rules);
+
+        std::set<uint32> paired;
+        for (Match const& match : matches)
+        {
+            auto const first = std::ranges::find(teams, match.firstTeamId, &QueuedTeam::teamId);
+            auto const second = std::ranges::find(teams, match.secondTeamId, &QueuedTeam::teamId);
+            ASSERT_TRUE(first != teams.end() && second != teams.end()) << "a match names a team that was never queued";
+
+            ASSERT_TRUE(paired.insert(first->teamId).second) << "team " << first->teamId << " was placed in two matches";
+            ASSERT_TRUE(paired.insert(second->teamId).second) << "team " << second->teamId << " was placed in two matches";
+
+            ASSERT_TRUE(CanFaceEachOther(*first, *second, input.rules))
+                << "started an inadmissible pair " << first->teamId << " vs " << second->teamId;
+
+            ASSERT_GE(first->waited.count(), second->waited.count())
+                << "the shorter waiter " << first->teamId << " was listed first";
+        }
+
+        // Maximal: nothing left over could have played anything else left over, otherwise the
+        // pass gave up early and those teams wait for no reason.
+        for (QueuedTeam const& lhs : teams)
+        {
+            if (paired.contains(lhs.teamId))
+                continue;
+
+            for (QueuedTeam const& rhs : teams)
+            {
+                if (rhs.teamId == lhs.teamId || paired.contains(rhs.teamId))
+                    continue;
+
+                ASSERT_FALSE(CanFaceEachOther(lhs, rhs, input.rules))
+                    << "left " << lhs.teamId << " and " << rhs.teamId << " queued although they could have played each other";
+            }
+        }
+    }
+}
+
+// The same queue must yield the same matches however the caller happened to order it,
+// otherwise the outcome depends on list order rather than on the rules. Equal waits keep
+// input order by contract, so they are made distinct first.
+TEST_F(ArenaMatchmakingPropertyTest, ResultDoesNotDependOnInputOrder)
+{
+    for (int iteration = 0; iteration < Iterations; ++iteration)
+    {
+        auto input = GenerateQueue(_rng);
+        for (std::size_t i = 0; i < input.teams.size(); ++i)
+            input.teams[i].waited += Milliseconds{ i };
+
+        SCOPED_TRACE(Context(iteration, input));
+
+        auto const expected = ArenaMatchmaking::SelectMatches(input.teams, input.rules);
+
+        auto shuffled = input.teams;
+        std::ranges::shuffle(shuffled, _rng);
+
+        ASSERT_THAT(ArenaMatchmaking::SelectMatches(shuffled, input.rules), ContainerEq(expected));
+    }
+}

--- a/src/test/server/game/Battlegrounds/ArenaMatchmakingTest.cpp
+++ b/src/test/server/game/Battlegrounds/ArenaMatchmakingTest.cpp
@@ -1,0 +1,195 @@
+/*
+ * This file is part of the AzerothCore Project. See AUTHORS file for Copyright information
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "ArenaMatchmaking.h"
+#include "ArenaMatchmakingPrinters.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include <vector>
+
+using ::testing::ElementsAre;
+using ::testing::IsEmpty;
+
+/**
+ * Rated arena pairing. No world, no managers, no clock, no database.
+ */
+class ArenaMatchmakingTest : public ::testing::Test
+{
+protected:
+    using QueuedTeam = ArenaMatchmaking::QueuedTeam;
+    using Match = ArenaMatchmaking::Match;
+    using Rules = ArenaMatchmaking::Rules;
+
+    static constexpr uint32 MaxRatingDifference = 150;
+    static constexpr Milliseconds RatingDiscardTimer = 10min;
+    static constexpr Milliseconds PrevOpponentsDiscardTimer = 2min;
+
+    static Rules DefaultRules()
+    {
+        return { .maxRatingDifference = MaxRatingDifference,
+            .ratingDiscardTimer = RatingDiscardTimer,
+            .previousOpponentsDiscardTimer = PrevOpponentsDiscardTimer };
+    }
+
+    static QueuedTeam Team(uint32 teamId, uint32 matchmakerRating, Milliseconds waited = 0s,
+        uint32 previousOpponentsTeamId = 0)
+    {
+        return { .teamId = teamId, .matchmakerRating = matchmakerRating, .waited = waited,
+            .previousOpponentsTeamId = previousOpponentsTeamId };
+    }
+
+    static std::vector<Match> Select(std::vector<QueuedTeam> const& teams, Rules const& rules = DefaultRules())
+    {
+        return ArenaMatchmaking::SelectMatches(teams, rules);
+    }
+};
+
+TEST_F(ArenaMatchmakingTest, MatchesTwoTeamsInsideTheGap)
+{
+    EXPECT_THAT(Select({ Team(1, 1500), Team(2, 1600) }), ElementsAre(Match{ 1, 2 }));
+}
+
+TEST_F(ArenaMatchmakingTest, AnEmptyQueueYieldsNothing)
+{
+    EXPECT_THAT(Select({}), IsEmpty());
+    EXPECT_THAT(Select({ Team(1, 1500) }), IsEmpty());
+}
+
+TEST_F(ArenaMatchmakingTest, TeamsOutsideTheGapAreNotMatched)
+{
+    EXPECT_THAT(Select({ Team(1, 1500), Team(2, 1900) }), IsEmpty());
+}
+
+TEST_F(ArenaMatchmakingTest, ATeamNeverFacesItself)
+{
+    EXPECT_THAT(Select({ Team(1, 1500), Team(1, 1500) }), IsEmpty());
+}
+
+// The gap belongs to the pair. Measuring both teams against a third one instead lets two teams
+// up to twice the gap apart end up against each other.
+TEST_F(ArenaMatchmakingTest, TeamsAreComparedToEachOtherNotToAThirdTeam)
+{
+    EXPECT_THAT(Select({ Team(1, 1850, 30s), Team(2, 2150, 20s) }), IsEmpty());
+}
+
+TEST_F(ArenaMatchmakingTest, LongestWaiterTakesItsClosestOpponent)
+{
+    EXPECT_THAT(Select({ Team(1, 2000, 30s), Team(2, 1850, 20s), Team(3, 2150, 10s) }),
+        ElementsAre(Match{ 1, 2 }));
+}
+
+// Priority is wait, not closeness: a newcomer closer to someone else still goes to the longest
+// waiter it can face.
+TEST_F(ArenaMatchmakingTest, LongestWaiterOutranksACloserPair)
+{
+    EXPECT_THAT(Select({ Team(1, 1500, 60s), Team(2, 1700, 30s), Team(3, 1650) }), ElementsAre(Match{ 1, 3 }));
+}
+
+// A team nobody can play must not hold up the teams behind it.
+TEST_F(ArenaMatchmakingTest, UnmatchableLongestWaiterDoesNotStallTheQueue)
+{
+    EXPECT_THAT(Select({ Team(1, 3000, 60s), Team(2, 1500, 30s), Team(3, 1550, 20s) }),
+        ElementsAre(Match{ 2, 3 }));
+}
+
+TEST_F(ArenaMatchmakingTest, EveryFormableMatchIsFormedAtOnce)
+{
+    EXPECT_THAT(Select({ Team(1, 1500, 40s), Team(2, 1500, 30s), Team(3, 1500, 20s), Team(4, 1500, 10s) }),
+        ElementsAre(Match{ 1, 2 }, Match{ 3, 4 }));
+}
+
+TEST_F(ArenaMatchmakingTest, OddTeamOutIsLeftQueued)
+{
+    EXPECT_THAT(Select({ Team(1, 1500, 40s), Team(2, 1500, 30s), Team(3, 1500, 20s) }),
+        ElementsAre(Match{ 1, 2 }));
+}
+
+// Waiting out the discard timer waives the gap, but the waiting team still takes the closest
+// opponent it can rather than whichever one is looked at first.
+TEST_F(ArenaMatchmakingTest, StaleTeamStillTakesItsClosestOpponent)
+{
+    EXPECT_THAT(Select({ Team(1, 1000, RatingDiscardTimer), Team(2, 2000, 10s), Team(3, 3000, 5s) }),
+        ElementsAre(Match{ 1, 2 }));
+}
+
+TEST_F(ArenaMatchmakingTest, RematchNeedsBothTeamsToHaveWaitedOutTheTimer)
+{
+    EXPECT_THAT(Select({ Team(1, 1500, PrevOpponentsDiscardTimer, 2), Team(2, 1500, 10s) }), IsEmpty());
+
+    EXPECT_THAT(Select({ Team(1, 1500, PrevOpponentsDiscardTimer, 2), Team(2, 1500, PrevOpponentsDiscardTimer) }),
+        ElementsAre(Match{ 1, 2 }));
+}
+
+TEST_F(ArenaMatchmakingTest, RematchIsBlockedWhicheverSideRecordsIt)
+{
+    EXPECT_THAT(Select({ Team(1, 1500, 10s), Team(2, 1500, 10s, 1) }), IsEmpty());
+}
+
+// Waiting waives the rating gap, never the rematch timer.
+TEST_F(ArenaMatchmakingTest, StaleTeamStillRespectsTheRematchTimer)
+{
+    EXPECT_THAT(Select({ Team(1, 1500, RatingDiscardTimer, 2), Team(2, 1500, 10s) }), IsEmpty());
+}
+
+TEST_F(ArenaMatchmakingTest, ResultDoesNotDependOnTheOrderTeamsAreGivenIn)
+{
+    EXPECT_THAT(Select({ Team(1, 2000, 30s), Team(2, 1850, 20s), Team(3, 2150, 10s) }), ElementsAre(Match{ 1, 2 }));
+    EXPECT_THAT(Select({ Team(3, 2150, 10s), Team(2, 1850, 20s), Team(1, 2000, 30s) }), ElementsAre(Match{ 1, 2 }));
+    EXPECT_THAT(Select({ Team(2, 1850, 20s), Team(3, 2150, 10s), Team(1, 2000, 30s) }), ElementsAre(Match{ 1, 2 }));
+}
+
+// Teams that joined in the same tick share a wait, and the order they were given in is the
+// order they joined.
+TEST_F(ArenaMatchmakingTest, EqualWaitsKeepTheCallersOrder)
+{
+    EXPECT_THAT(Select({ Team(7, 1500, 20s), Team(3, 1500, 20s), Team(5, 1500, 20s) }), ElementsAre(Match{ 7, 3 }));
+}
+
+// Arena.RatingDiscardTimer is documented as disabled at 0. Disabled means the gap always
+// applies, not that every team is instantly stale.
+TEST_F(ArenaMatchmakingTest, AbsentRatingDiscardTimerNeverWaivesTheGap)
+{
+    Rules rules = DefaultRules();
+    rules.ratingDiscardTimer.reset();
+
+    EXPECT_THAT(Select({ Team(1, 1000, 60min), Team(2, 3000, 60min) }, rules), IsEmpty());
+}
+
+TEST_F(ArenaMatchmakingTest, ZeroRematchTimerAllowsAnImmediateRematch)
+{
+    Rules rules = DefaultRules();
+    rules.previousOpponentsDiscardTimer = 0s;
+
+    EXPECT_THAT(Select({ Team(1, 1500, 0s, 2), Team(2, 1500) }, rules), ElementsAre(Match{ 1, 2 }));
+}
+
+TEST_F(ArenaMatchmakingTest, AbsentMaxRatingDifferenceLeavesTheGapUnconstrained)
+{
+    Rules rules = DefaultRules();
+    rules.maxRatingDifference.reset();
+
+    EXPECT_THAT(Select({ Team(1, 500), Team(2, 3000) }, rules), ElementsAre(Match{ 1, 2 }));
+}
+
+TEST_F(ArenaMatchmakingTest, ZeroMaxRatingDifferenceDemandsAnExactMatch)
+{
+    Rules rules = DefaultRules();
+    rules.maxRatingDifference = 0;
+
+    EXPECT_THAT(Select({ Team(1, 1500, 20s), Team(2, 1500, 10s), Team(3, 1501, 5s) }, rules),
+        ElementsAre(Match{ 1, 2 }));
+}

--- a/src/test/server/game/Battlegrounds/ArenaMatchmakingWiringTest.cpp
+++ b/src/test/server/game/Battlegrounds/ArenaMatchmakingWiringTest.cpp
@@ -1,0 +1,533 @@
+/*
+ * This file is part of the AzerothCore Project. See AUTHORS file for Copyright information
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "ArenaTeam.h"
+#include "Battleground.h"
+#include "BattlegroundMgr.h"
+#include "BattlegroundQueue.h"
+#include "DBCStores.h"
+#include "GameTime.h"
+#include "IntegrationTestFixture.h"
+#include "MapMgr.h"
+#include "ScriptMgr.h"
+#include "ScriptDefines/AllBattlegroundScript.h"
+#include "ScriptDefines/ArenaTeamScript.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include <memory>
+#include <string>
+#include <vector>
+
+using ::testing::Each;
+using ::testing::ElementsAre;
+using ::testing::IsEmpty;
+using ::testing::SizeIs;
+using ::testing::TestParamInfo;
+using ::testing::Values;
+using ::testing::WithParamInterface;
+
+// A queue entry filed in the given list, which is where the update will look for it.
+MATCHER_P(FiledIn, list, "")
+{
+    *result_listener << "team " << arg->ArenaTeamId << " is filed in list " << uint32(arg->GroupType);
+    return arg->GroupType == list;
+}
+
+/**
+ * BattlegroundQueue driven through its real entry points with no server behind it.
+ *
+ * The pairing rules are covered by ArenaMatchmakingTest without any of this scaffolding.
+ * Two things are checked here. The wiring: AddGroup files rated teams into
+ * BG_QUEUE_RATED_ARENA, the update projects that bucket, maps the configs onto Rules and
+ * applies the invitations, and RemovePlayer drains it. And the defects behind issue 1, each
+ * driven through the real update.
+ */
+namespace
+{
+    constexpr uint32 TestMapId = 559;                       // Nagrand Arena
+    constexpr uint32 TestBracket = 0;
+    constexpr uint32 BracketDbcRow = 1;
+    constexpr uint32 InvitedInstanceId = 0xABCD;
+
+    // Stands in for the per-map factory so CreateNewBattleground succeeds, and owns every
+    // arena the update starts. ~Battleground takes the arena out of bgDataStore itself.
+    std::vector<std::unique_ptr<Battleground>> g_createdArenas;
+
+    Battleground* RecordingArenaFactory(Battleground* bgTemplate)
+    {
+        return g_createdArenas.emplace_back(std::make_unique<Battleground>(*bgTemplate)).get();
+    }
+}
+
+class ArenaMatchmakingWiringTest : public IntegrationTestFixture
+{
+protected:
+    static constexpr uint32 MaxRatingDifference = 150;
+    static constexpr uint32 RatingDiscardTimer = 600000;
+    static constexpr uint32 PrevOpponentsDiscardTimer = 120000;
+
+    void SetUp() override
+    {
+        IntegrationTestFixture::SetUp();
+
+        ScriptRegistry<BGScript>::InitEnabledHooksIfNeeded(ALLBATTLEGROUNDHOOK_END);
+        ScriptRegistry<ArenaTeamScript>::InitEnabledHooksIfNeeded(ARENATEAMHOOK_END);
+
+        SetIntConfig(CONFIG_ARENA_MAX_RATING_DIFFERENCE, MaxRatingDifference);
+        SetIntConfig(CONFIG_ARENA_RATING_DISCARD_TIMER, RatingDiscardTimer);
+        SetIntConfig(CONFIG_ARENA_PREV_OPPONENTS_DISCARD_TIMER, PrevOpponentsDiscardTimer);
+
+        // The store takes ownership and deletes the entry on the next SetEntry.
+        sPvPDifficultyStore.SetEntry(BracketDbcRow,
+            new PvPDifficultyEntry(TestMapId, TestBracket, /*minLevel*/ 80, /*maxLevel*/ 80, /*difficulty*/ 0));
+
+        // Instance id 0 is where GetBattlegroundTemplate looks. Started arenas get higher ids.
+        _arenaTemplate = std::make_unique<Battleground>();
+        _arenaTemplate->SetBgTypeID(BATTLEGROUND_TYPE_NONE);
+        _arenaTemplate->SetInstanceID(0);
+        _arenaTemplate->SetMapId(TestMapId);
+        _arenaTemplate->SetArenaorBGType(true);
+        _arenaTemplate->SetMinPlayersPerTeam(ARENA_TYPE_2v2);
+        _arenaTemplate->SetMaxPlayersPerTeam(ARENA_TYPE_2v2);
+        _arenaTemplate->SetLevelRange(80, 80);
+        sBattlegroundMgr->AddBattleground(_arenaTemplate.get());
+        BattlegroundMgr::bgTypeToTemplate[BATTLEGROUND_TYPE_NONE] = &RecordingArenaFactory;
+
+        // Burn instance id 0 so an invited group's IsInvitedToBGInstanceGUID is never
+        // confused with the zero that means "not invited".
+        sMapMgr->GenerateInstanceId();
+
+        // The same clock the rated branch reads, so "joined N ms ago" below means exactly
+        // that. GameTime sits near zero in a unit test and the subtraction wraps, which is
+        // harmless because wait times are computed in unsigned arithmetic.
+        _now = static_cast<uint32>(GameTime::GetGameTimeMS().count());
+    }
+
+    void TearDown() override
+    {
+        g_createdArenas.clear();
+        _arenaTemplate.reset();
+        BattlegroundMgr::bgTypeToTemplate.erase(BATTLEGROUND_TYPE_NONE);
+        sPvPDifficultyStore.SetEntry(BracketDbcRow, nullptr);
+
+        IntegrationTestFixture::TearDown();
+    }
+
+    void SetIntConfig(ServerConfigs index, uint32 value)
+    {
+        ON_CALL(*GetWorldMock(), getIntConfig(index)).WillByDefault(::testing::Return(value));
+    }
+
+    static int PairsCreated() { return static_cast<int>(g_createdArenas.size()); }
+
+    static PvPDifficultyEntry const* Bracket() { return sPvPDifficultyStore.LookupEntry(BracketDbcRow); }
+
+    static BattlegroundQueue::GroupsQueueType const& List(BattlegroundQueue const& queue, BattlegroundQueueGroupTypes list)
+    {
+        return queue.m_QueuedGroups[TestBracket][list];
+    }
+
+    struct TeamSpec
+    {
+        uint32 arenaTeamId{};
+        uint32 matchmakerRating{};
+        uint32 joinedMsAgo{};
+        uint32 previousOpponentsTeamId{};
+        bool   invited{};
+        TeamId teamId{ TEAM_ALLIANCE };
+        BattlegroundQueueGroupTypes list{ BG_QUEUE_RATED_ARENA };
+    };
+
+    // Files an entry the way AddGroup would, without a player behind each GUID, which keeps
+    // InviteGroupToBG's loop empty.
+    GroupQueueInfo* Enqueue(BattlegroundQueue& queue, TeamSpec const& spec)
+    {
+        auto* ginfo = new GroupQueueInfo();
+        ginfo->teamId = spec.teamId;
+        ginfo->RealTeamID = spec.teamId;
+        ginfo->BgTypeId = BATTLEGROUND_TYPE_NONE;
+        ginfo->IsRated = true;
+        ginfo->ArenaType = ARENA_TYPE_2v2;
+        ginfo->ArenaTeamId = spec.arenaTeamId;
+        ginfo->JoinTime = _now - spec.joinedMsAgo;
+        ginfo->RemoveInviteTime = 0;
+        ginfo->IsInvitedToBGInstanceGUID = spec.invited ? InvitedInstanceId : 0;
+        ginfo->ArenaTeamRating = spec.matchmakerRating;
+        ginfo->ArenaMatchmakerRating = spec.matchmakerRating;
+        ginfo->OpponentsTeamRating = 0;
+        ginfo->OpponentsMatchmakerRating = 0;
+        ginfo->PreviousOpponentsTeamId = spec.previousOpponentsTeamId;
+        ginfo->BracketId = TestBracket;
+        ginfo->GroupType = spec.list;
+
+        for (uint32 i = 0; i < ARENA_TYPE_2v2; ++i)
+        {
+            ObjectGuid const guid = ObjectGuid::Create<HighGuid::Player>(++_nextPlayerGuid);
+            ginfo->Players.insert(guid);
+            queue.m_QueuedPlayers[guid] = ginfo;
+        }
+
+        // The queue owns the allocation and frees it in its destructor.
+        queue.m_QueuedGroups[TestBracket][spec.list].push_back(ginfo);
+        return ginfo;
+    }
+
+    // The last argument is the rating the caller believes is interesting. It is still handed
+    // to the script hooks, and must no longer affect selection.
+    static void RunRatedUpdate(BattlegroundQueue& queue, uint32 callerRating)
+    {
+        queue.BattlegroundQueueUpdate(/*diff*/ 0, BATTLEGROUND_TYPE_NONE, BattlegroundBracketId(TestBracket),
+            ARENA_TYPE_2v2, /*isRated*/ true, callerRating);
+    }
+
+    uint32 _now = 0;
+    uint32 _nextPlayerGuid = 0;
+    std::unique_ptr<Battleground> _arenaTemplate;
+};
+
+// The fixture must be able to reach the pairing code, otherwise nothing below means anything.
+TEST_F(ArenaMatchmakingWiringTest, BaselineWellMatchedPairIsCreated)
+{
+    BattlegroundQueue queue;
+    Enqueue(queue, { .arenaTeamId = 2, .matchmakerRating = 1600 });
+    Enqueue(queue, { .arenaTeamId = 3, .matchmakerRating = 1620 });
+
+    RunRatedUpdate(queue, /*callerRating*/ 0);
+
+    EXPECT_EQ(PairsCreated(), 1);
+}
+
+namespace
+{
+    struct RoutingCase
+    {
+        char const* name;
+        bool isRated;
+        bool isPremade;
+        TeamId team;
+        uint32 arenaTeamId;
+        BattlegroundQueueGroupTypes list;
+    };
+
+    void PrintTo(RoutingCase const& routing, std::ostream* os)
+    {
+        *os << routing.name;
+    }
+}
+
+// AddGroup is where a group is filed, and the update only reads rated teams out of
+// BG_QUEUE_RATED_ARENA. The faction split used to put horde teams in a different list.
+class ArenaQueueRoutingTest : public ArenaMatchmakingWiringTest, public WithParamInterface<RoutingCase>
+{
+};
+
+TEST_P(ArenaQueueRoutingTest, AddGroupFilesTheGroupWhereTheUpdateReadsIt)
+{
+    RoutingCase const& routing = GetParam();
+
+    BattlegroundQueue queue;
+    TestPlayer* leader = CreateTestPlayer();
+    leader->SetTeamIdForTest(routing.team);
+
+    GroupQueueInfo const* ginfo = queue.AddGroup(leader, nullptr, BATTLEGROUND_TYPE_NONE, Bracket(), ARENA_TYPE_2v2,
+        routing.isRated, routing.isPremade, 1500, 1500, routing.arenaTeamId);
+
+    EXPECT_THAT(ginfo, FiledIn(routing.list));
+    EXPECT_THAT(List(queue, routing.list), ElementsAre(ginfo));
+}
+
+INSTANTIATE_TEST_SUITE_P(Buckets, ArenaQueueRoutingTest,
+    Values(
+        RoutingCase{ "RatedAlliance",   true,  false, TEAM_ALLIANCE, 7, BG_QUEUE_RATED_ARENA },
+        RoutingCase{ "RatedHorde",      true,  false, TEAM_HORDE,    7, BG_QUEUE_RATED_ARENA },
+        RoutingCase{ "UnratedAlliance", false, false, TEAM_ALLIANCE, 0, BG_QUEUE_NORMAL_ALLIANCE },
+        RoutingCase{ "UnratedHorde",    false, false, TEAM_HORDE,    0, BG_QUEUE_NORMAL_HORDE },
+        RoutingCase{ "PremadeAlliance", false, true,  TEAM_ALLIANCE, 0, BG_QUEUE_PREMADE_ALLIANCE },
+        RoutingCase{ "PremadeHorde",    false, true,  TEAM_HORDE,    0, BG_QUEUE_PREMADE_HORDE }),
+    [](TestParamInfo<RoutingCase> const& info) { return std::string(info.param.name); });
+
+// Both sides learn the other's ratings and are invited to the same instance.
+TEST_F(ArenaMatchmakingWiringTest, PairedGroupsAreInvitedAndCrossReferenced)
+{
+    BattlegroundQueue queue;
+    GroupQueueInfo* first = Enqueue(queue, { .arenaTeamId = 2, .matchmakerRating = 1600 });
+    GroupQueueInfo* second = Enqueue(queue, { .arenaTeamId = 3, .matchmakerRating = 1620 });
+
+    RunRatedUpdate(queue, /*callerRating*/ 0);
+    ASSERT_EQ(PairsCreated(), 1);
+
+    EXPECT_EQ(first->OpponentsMatchmakerRating, second->ArenaMatchmakerRating);
+    EXPECT_EQ(second->OpponentsMatchmakerRating, first->ArenaMatchmakerRating);
+    EXPECT_EQ(first->OpponentsTeamRating, second->ArenaTeamRating);
+    EXPECT_EQ(second->OpponentsTeamRating, first->ArenaTeamRating);
+
+    EXPECT_NE(first->IsInvitedToBGInstanceGUID, 0u);
+    EXPECT_EQ(first->IsInvitedToBGInstanceGUID, second->IsInvitedToBGInstanceGUID);
+}
+
+// The side a rated team plays is chosen at invite time, so both teams stay in the one bucket
+// they queued into and no list move is needed to keep GroupType honest.
+TEST_F(ArenaMatchmakingWiringTest, PairedGroupsStayInTheRatedQueue)
+{
+    BattlegroundQueue queue;
+    Enqueue(queue, { .arenaTeamId = 11, .matchmakerRating = 2400, .teamId = TEAM_HORDE });
+    Enqueue(queue, { .arenaTeamId = 22, .matchmakerRating = 2400, .teamId = TEAM_HORDE });
+
+    RunRatedUpdate(queue, /*callerRating*/ 0);
+    ASSERT_EQ(PairsCreated(), 1) << "the same-faction pair was not formed";
+
+    EXPECT_THAT(List(queue, BG_QUEUE_RATED_ARENA), SizeIs(2));
+    EXPECT_THAT(List(queue, BG_QUEUE_RATED_ARENA), Each(FiledIn(BG_QUEUE_RATED_ARENA)));
+
+    for (BattlegroundQueueGroupTypes const list : { BG_QUEUE_PREMADE_ALLIANCE, BG_QUEUE_PREMADE_HORDE,
+        BG_QUEUE_NORMAL_ALLIANCE, BG_QUEUE_NORMAL_HORDE })
+    {
+        SCOPED_TRACE("list " + std::to_string(list));
+        EXPECT_THAT(List(queue, list), IsEmpty());
+    }
+}
+
+// Entering the arena removes each member through RemovePlayer, which has to find the entry
+// under the GroupType it was queued with. The last member out takes the entry with it.
+TEST_F(ArenaMatchmakingWiringTest, EnteringTheArenaDrainsTheRatedQueue)
+{
+    BattlegroundQueue queue;
+    Enqueue(queue, { .arenaTeamId = 2, .matchmakerRating = 1600 });
+    Enqueue(queue, { .arenaTeamId = 3, .matchmakerRating = 1620 });
+
+    RunRatedUpdate(queue, /*callerRating*/ 0);
+    ASSERT_EQ(PairsCreated(), 1);
+
+    // Copied first: RemovePlayer frees the entry along with its last member.
+    std::vector<ObjectGuid> players;
+    for (auto const& entry : queue.m_QueuedPlayers)
+        players.push_back(entry.first);
+
+    for (ObjectGuid const& guid : players)
+        queue.RemovePlayer(guid, /*decreaseInvitedCount*/ false);
+
+    EXPECT_THAT(List(queue, BG_QUEUE_RATED_ARENA), IsEmpty());
+    EXPECT_THAT(queue.m_QueuedPlayers, IsEmpty());
+}
+
+// A group with no arena team resolves to a null ArenaTeam at match end.
+TEST_F(ArenaMatchmakingWiringTest, GroupWithoutArenaTeamIsNotSelectedForRatedMatch)
+{
+    BattlegroundQueue queue;
+    Enqueue(queue, { .arenaTeamId = 0, .matchmakerRating = 1500 });
+    Enqueue(queue, { .arenaTeamId = 22, .matchmakerRating = 1500 });
+
+    RunRatedUpdate(queue, /*callerRating*/ 1500);
+
+    EXPECT_EQ(PairsCreated(), 0) << "a group with ArenaTeamId 0 was selected for a rated arena";
+}
+
+// Rated arena teams live in BG_QUEUE_RATED_ARENA and nowhere else. A module still writing
+// them into the faction-split premade lists must not have them silently matched from there.
+TEST_F(ArenaMatchmakingWiringTest, StaleGroupInAPremadeQueueIsNotSelected)
+{
+    BattlegroundQueue queue;
+    Enqueue(queue, { .arenaTeamId = 1, .matchmakerRating = 1500, .list = BG_QUEUE_PREMADE_ALLIANCE });
+    Enqueue(queue, { .arenaTeamId = 2, .matchmakerRating = 1500, .list = BG_QUEUE_PREMADE_HORDE });
+
+    RunRatedUpdate(queue, /*callerRating*/ 0);
+
+    EXPECT_EQ(PairsCreated(), 0) << "a rated team was matched out of a premade battleground queue";
+}
+
+// Arena.RatingDiscardTimer is documented "0 - (Disabled)". Disabled means the gap keeps
+// applying however long a team waits, not that every team is instantly stale.
+TEST_F(ArenaMatchmakingWiringTest, DisabledRatingDiscardTimerKeepsEnforcingTheGap)
+{
+    SetIntConfig(CONFIG_ARENA_RATING_DISCARD_TIMER, 0);
+
+    BattlegroundQueue queue;
+    Enqueue(queue, { .arenaTeamId = 1, .matchmakerRating = 1000, .joinedMsAgo = 3600000 });
+    Enqueue(queue, { .arenaTeamId = 2, .matchmakerRating = 3000, .joinedMsAgo = 3600000 });
+
+    RunRatedUpdate(queue, /*callerRating*/ 0);
+
+    EXPECT_EQ(PairsCreated(), 0) << "a disabled discard timer waived the rating gap";
+}
+
+// Arena.MaxRatingDifference is documented the same way, and for the gap itself disabled does
+// mean unconstrained.
+TEST_F(ArenaMatchmakingWiringTest, DisabledMaxRatingDifferenceLeavesTheGapUnconstrained)
+{
+    SetIntConfig(CONFIG_ARENA_MAX_RATING_DIFFERENCE, 0);
+
+    BattlegroundQueue queue;
+    Enqueue(queue, { .arenaTeamId = 1, .matchmakerRating = 500 });
+    Enqueue(queue, { .arenaTeamId = 2, .matchmakerRating = 3000 });
+
+    RunRatedUpdate(queue, /*callerRating*/ 0);
+
+    EXPECT_EQ(PairsCreated(), 1);
+}
+
+// JoinTime is the ms clock truncated to 32 bits and GameTime sits near zero here, so every
+// JoinTime below predates the wrap. Measured any wider than 32 bits these teams look like
+// 49 day waiters and the gap is waived. A guard, not a reproduction: the old code declines
+// this pair too, for the unrelated reason that 3000 is outside the window anchored on 1000.
+TEST_F(ArenaMatchmakingWiringTest, WaitIsMeasuredAcrossTheClockWrap)
+{
+    ASSERT_LT(_now, RatingDiscardTimer) << "fixture assumption: the clock has not yet passed the timer";
+
+    BattlegroundQueue queue;
+    Enqueue(queue, { .arenaTeamId = 1, .matchmakerRating = 1000, .joinedMsAgo = 30000 });
+    Enqueue(queue, { .arenaTeamId = 2, .matchmakerRating = 3000, .joinedMsAgo = 20000 });
+
+    RunRatedUpdate(queue, /*callerRating*/ 0);
+
+    EXPECT_EQ(PairsCreated(), 0) << "two teams 2000 apart were treated as having waited out the discard timer";
+}
+
+/**
+ * The defects behind issue 1, each driven through the real update.
+ */
+
+// Selection no longer takes a rating from the caller, so the same queue must produce the same
+// match whatever the caller passes.
+class ArenaCallerRatingTest : public ArenaMatchmakingWiringTest, public WithParamInterface<uint32>
+{
+};
+
+TEST_P(ArenaCallerRatingTest, DoesNotSteerSelection)
+{
+    BattlegroundQueue queue;
+    Enqueue(queue, { .arenaTeamId = 2, .matchmakerRating = 1600 });
+    Enqueue(queue, { .arenaTeamId = 3, .matchmakerRating = 1620 });
+
+    RunRatedUpdate(queue, GetParam());
+
+    EXPECT_EQ(PairsCreated(), 1);
+}
+
+INSTANTIATE_TEST_SUITE_P(CallerRating, ArenaCallerRatingTest, Values(0u, 1500u, 2400u),
+    [](TestParamInfo<uint32> const& info) { return "Rating" + std::to_string(info.param); });
+
+// A group that is already in a match must not affect the outcome.
+TEST_F(ArenaMatchmakingWiringTest, InvitedGroupDoesNotChangeTheOutcome)
+{
+    BattlegroundQueue queue;
+    Enqueue(queue, { .arenaTeamId = 1, .matchmakerRating = 2400, .joinedMsAgo = 60000, .invited = true });
+    Enqueue(queue, { .arenaTeamId = 2, .matchmakerRating = 1600 });
+    Enqueue(queue, { .arenaTeamId = 3, .matchmakerRating = 1620 });
+
+    RunRatedUpdate(queue, /*callerRating*/ 0);
+
+    EXPECT_EQ(PairsCreated(), 1) << "a group already in a match suppressed an otherwise valid pairing";
+}
+
+// The rejection has to survive the trip through the wiring, not just the selector, so no
+// arena is created.
+TEST_F(ArenaMatchmakingWiringTest, PairBeyondMaxRatingDifferenceIsNotStarted)
+{
+    BattlegroundQueue queue;
+    Enqueue(queue, { .arenaTeamId = 1, .matchmakerRating = 1850 });
+    Enqueue(queue, { .arenaTeamId = 2, .matchmakerRating = 2150 });
+
+    RunRatedUpdate(queue, /*callerRating*/ 2000);
+
+    EXPECT_EQ(PairsCreated(), 0) << "paired two teams 300 apart at a 150 setting";
+}
+
+// The old selection centred a window on the rating it was handed and tested both candidates
+// against that rather than against each other, so 1850 and 2150, both inside a window centred
+// on 2000, were started against each other at twice the gap.
+TEST_F(ArenaMatchmakingWiringTest, StartedPairIsNeverWiderThanMaxRatingDifference)
+{
+    BattlegroundQueue queue;
+    GroupQueueInfo const* low = Enqueue(queue, { .arenaTeamId = 1, .matchmakerRating = 1850, .joinedMsAgo = 30000 });
+    GroupQueueInfo const* high = Enqueue(queue, { .arenaTeamId = 2, .matchmakerRating = 2150, .joinedMsAgo = 20000 });
+    GroupQueueInfo const* mid = Enqueue(queue, { .arenaTeamId = 3, .matchmakerRating = 2000, .joinedMsAgo = 10000 });
+
+    // The scheduler hands in the joining team's rating, which is what the old code anchored on.
+    RunRatedUpdate(queue, /*callerRating*/ 2000);
+
+    EXPECT_EQ(PairsCreated(), 1);
+    EXPECT_NE(low->IsInvitedToBGInstanceGUID, 0u) << "the longest waiter was not started";
+    EXPECT_NE(mid->IsInvitedToBGInstanceGUID, 0u) << "1850 was not started against 2000, the only team it can face";
+    EXPECT_EQ(high->IsInvitedToBGInstanceGUID, 0u) << "2150 was started against 1850, twice the gap";
+}
+
+// Faction is not a pairing criterion any more, so the rematch timer has to hold whichever
+// sides the two teams last played on.
+TEST_F(ArenaMatchmakingWiringTest, SameFactionPreviousOpponentsAreNotRematched)
+{
+    BattlegroundQueue queue;
+    Enqueue(queue, { .arenaTeamId = 11, .matchmakerRating = 1800, .previousOpponentsTeamId = 22 });
+    Enqueue(queue, { .arenaTeamId = 22, .matchmakerRating = 1800, .previousOpponentsTeamId = 11 });
+
+    RunRatedUpdate(queue, /*callerRating*/ 1800);
+
+    EXPECT_EQ(PairsCreated(), 0);
+}
+
+TEST_F(ArenaMatchmakingWiringTest, CrossFactionPreviousOpponentsAreNotRematched)
+{
+    BattlegroundQueue queue;
+    Enqueue(queue, { .arenaTeamId = 11, .matchmakerRating = 1800, .previousOpponentsTeamId = 22,
+        .teamId = TEAM_ALLIANCE });
+    Enqueue(queue, { .arenaTeamId = 22, .matchmakerRating = 1800, .previousOpponentsTeamId = 11,
+        .teamId = TEAM_HORDE });
+
+    RunRatedUpdate(queue, /*callerRating*/ 1800);
+
+    EXPECT_EQ(PairsCreated(), 0) << "rematched two teams inside PreviousOpponentsDiscardTimer";
+}
+
+// Queue position must not stop a valid pair from forming.
+TEST_F(ArenaMatchmakingWiringTest, PartnerSearchConsidersEarlierGroups)
+{
+    BattlegroundQueue queue;
+    Enqueue(queue, { .arenaTeamId = 1, .matchmakerRating = 1800 });
+    Enqueue(queue, { .arenaTeamId = 2, .matchmakerRating = 1900 });
+
+    RunRatedUpdate(queue, /*callerRating*/ 2000);
+
+    EXPECT_EQ(PairsCreated(), 1) << "a pair 100 apart was skipped because one of them precedes the other";
+}
+
+// The comment on the branch has always promised "can create many in single queue update".
+// Only one match was ever started, which is the stall behind issue 1.
+TEST_F(ArenaMatchmakingWiringTest, EveryFormableMatchIsStartedInOneUpdate)
+{
+    BattlegroundQueue queue;
+    Enqueue(queue, { .arenaTeamId = 1, .matchmakerRating = 1500, .joinedMsAgo = 40000 });
+    Enqueue(queue, { .arenaTeamId = 2, .matchmakerRating = 1500, .joinedMsAgo = 30000 });
+    Enqueue(queue, { .arenaTeamId = 3, .matchmakerRating = 1500, .joinedMsAgo = 20000 });
+    Enqueue(queue, { .arenaTeamId = 4, .matchmakerRating = 1500, .joinedMsAgo = 10000 });
+
+    RunRatedUpdate(queue, /*callerRating*/ 0);
+
+    EXPECT_EQ(PairsCreated(), 2);
+}
+
+// A team nobody can play used to abort the whole bracket, so the teams behind it waited for
+// the discard timer rather than for an opponent.
+TEST_F(ArenaMatchmakingWiringTest, UnmatchableLongestWaiterDoesNotStallTheQueue)
+{
+    BattlegroundQueue queue;
+    Enqueue(queue, { .arenaTeamId = 1, .matchmakerRating = 3000, .joinedMsAgo = 60000 });
+    Enqueue(queue, { .arenaTeamId = 2, .matchmakerRating = 1500, .joinedMsAgo = 30000 });
+    Enqueue(queue, { .arenaTeamId = 3, .matchmakerRating = 1550, .joinedMsAgo = 20000 });
+
+    RunRatedUpdate(queue, /*callerRating*/ 0);
+
+    EXPECT_EQ(PairsCreated(), 1) << "an unmatchable team blocked the teams behind it";
+}


### PR DESCRIPTION
## Note that after merging this PR https://github.com/azerothcore/mod-arena-3v3-solo-queue/pull/65 , https://github.com/azerothcore/mod-queue-list-cache/pull/18 should be merged immediately to keep them up to date with the core

## Changes Proposed:
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

The old code grabbed a rating, drew a window around it, then checked both candidates against
that window instead of against each other. Teams on opposite edges are twice
`Arena.MaxRatingDifference` apart and got matched anyway - at the default 150 that's 1850 vs
2150. And if the first team in the list had nobody to play, the whole bracket was dropped for
that tick, so the teams behind it kept waiting even when they could have played each other.

The pairing decision now lives in `ArenaMatchmaking::SelectMatches` - no world, no managers, no
clock, no DB, just teams in and matches out. It compares teams to each other, gives the longest
waiter its closest valid opponent, and returns every match it can form instead of one.
`CreateRatedArenaMatches` feeds it the real queue and applies whatever comes back.

Rated teams also get their own bucket (`BG_QUEUE_RATED_ARENA`) instead of sitting in the
faction premade lists. A rated team's side is picked when it's invited, not when it queues, so
keeping them in faction lists meant moving them between lists later - and that move used
`push_front`, which broke join order. All of that is gone now.

Also in here:
- previous-opponents timer now applies cross-faction too
- wait time is measured at the same 32-bit width as `JoinTime`, so it survives the clock wrap
- a failed arena creation skips that pair instead of dropping the rest
- scripts can still pick the bucket through `OnAddGroup`, so an out-of-range index is refused
  rather than writing past the array, and a rated group sent somewhere it'll never be matched
  gets logged
- two test-infra fixes that were in the way: `IntegrationTestFixture` had
  `using namespace testing;` in a header, which clashes with core's `Field`/`Optional`, and
  `GetTypeName` was global so ADL pulled it into gtest's internals on MSVC and broke every
  `EXPECT_THAT`. Moved to `Acore::`.

**Behaviour change:** `Arena.RatingDiscardTimer = 0` now means disabled, like the config
comment already claims. Before, `0` made every team look instantly stale, so ratings were never
enforced at all. If you want that back, use `Arena.MaxRatingDifference = 0`.

**Merge these right after:** two modules read rated teams out of the old premade lists and will
find nothing until they're updated.
- https://github.com/azerothcore/mod-arena-3v3-solo-queue/pull/65
- https://github.com/azerothcore/mod-queue-list-cache/pull/18

E2E tests are in a separate PR: #<!-- number -->

### AI-assisted Pull Requests

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Opus 5, Fable 5.1
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Partially addresses https://github.com/azerothcore/azerothcore-wotlk/issues/27460

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

Not a cherry-pick. The window bug is visible from reading the old rated branch in
`BattlegroundQueueUpdate`.

## Tests Performed:
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Unit tests: 20 cases on the pairing rules, a 2000-iteration seeded property test (replay a
failure with `--gtest_random_seed=N`) checking every started pair is legal, nobody plays twice
and nothing matchable is left sitting in the queue, plus wiring tests that drive the real
`BattlegroundQueue` with no server behind it. The 1850/2150/2000 case is one of them and fails
against the old code.

E2E against a live worldserver (separate PR): two teams queue and both get invited, four teams
all pop in one pass, and the 1850/2150/2000 repro - red 8 runs out of 8 before the fix, green 8
out of 8 after.

For both UT and e2e negative tests verified that pre-fix behavior fails. 

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. `.arena season set state 1` and `.event start 31` (the Arena Battlemaster is behind that event).
2. Two 2v2 teams within 150 rating of each other, queue both at a Battlemaster. Both should get
   invited to the same arena.
3. Three teams at 1850 / 2150 / 2000, queued in that order. Set the ratings with
   `Arena.ArenaStartMatchmakerRating` + `.reload config` between team creations. Old code starts
   1850 vs 2150. New code invites 1850 vs 2000 and leaves 2150 queued.
4. Four or more teams that can all play each other - every pair should pop in one update, not
   one pair per tick.

## Known Issues and TODO List:

- The scheduler still passes a bracket rather than the team that joined, so every update
  rescans the whole bracket. It's tens of teams in practice so it doesn't really cost anything,
  but making the join path incremental means reworking the scheduler first. A periodic full
  pass would still be needed either way, since a pair can become valid just because a timer ran
  out and nobody joined.
- Progressive window widening (loosening the gap the longer you wait, instead of a hard limit
  plus an on/off discard timer) is a separate change.
- `IsInvitedToBGInstanceGUID` still isn't cleared until the last member of an invited group
  leaves. It's excluded from selection now so it doesn't affect matchmaking, just noting it.
