### PR TITLE
fix(Scripts/Ulduar): fix Mimiron's Laser Barrage visual rotation and wipe desync

### DIFF
--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_mimiron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_mimiron.cpp
@@ -446,8 +446,6 @@ struct boss_mimiron : public BossAI
             case EVENT_BERSERK:
                 _berserk = true;
                 Talk(SAY_BERSERK);
-                if (_hardmode)
-                    me->SummonCreature(33576, 2744.78f, 2569.47f, 364.32f, 0.0f, TEMPSUMMON_TIMED_DESPAWN, 120000);
                 events.ScheduleEvent(EVENT_BERSERK_2, 0ms);
                 break;
             case EVENT_BERSERK_2:
@@ -737,7 +735,6 @@ struct boss_mimiron : public BossAI
                     me->GetMotionMaster()->Clear();
                     summons.DoAction(DO_DESPAWN_SUMMONS);
                     summons.DespawnEntry(NPC_FLAMES_INITIAL);
-                    summons.DespawnEntry(33576);
 
                     me->RemoveUnitFlag(UNIT_FLAG_NOT_SELECTABLE);
 


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
- [ ] Core (units, players, creatures, game systems).
- [x] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests
- [x] AI tools were partially used in preparing this pull request.
   - Tools/models used: Claude / Gemini

### Problem & Blizzlike Mechanics Explained:

1. **Client Model Freeze and Orientation Snapping (Phase 2 and Phase 4):**
   In `npc_ulduar_vx001::UpdateAI`, `EVENT_SPELL_SPINNING_UP` previously called `me->SetTarget(dbTarget->GetGUID())`. Setting `UNIT_FIELD_TARGET` instructs the client engine to orient the creature towards the target unit. Because `Mimiron DB Target` (entry 33576) patrols a wide perimeter in the 200-yard chamber, the target frequently exceeds standard client visibility distance (100 to 120 yards) for players standing across the room. When the client removes the distant target from memory, or when VX-001 is mounted as a passenger on the V-07-TR-0N vehicle in Phase 4, target tracking overrides the orientation splines sent by `SetFacingTo`. This causes the visual model and spell effect to freeze in place or snap erratically into a straight line while the server damage cone continues sweeping.
   *Fix:* Removed `me->SetTarget(dbTarget->GetGUID())`. `FaceBarrageArc` already handles exact angular tracking toward the DB target and dispatches continuous facing packets via `SetFacingTo` (including seat-local vehicle relative angles in Phase 4). Removing target locking allows the client model to sweep smoothly without visual desync or model snapping.

2. **Laser Barrage Freezing if DB Target Becomes Unavailable:**
   `FaceBarrageArc(Unit* caster)` previously executed an early return if `dbTarget` was null or missing. If the target was lost during encounter transitions or cell updates, the boss immediately halted facing updates for the remainder of the channel, locking the deadly laser beam into a single static corridor.
   *Fix:* Added a mathematical rotation fallback. If `dbTarget` is unavailable or dead, the boss continues sweeping clockwise at the sniffed rate (~0.185 rad/s, ~0.046 rad per 250ms tick, completing a 360 degree revolution in ~34 seconds). The barrage will never freeze or fire statically.

3. **Permanent Desync / Broken Barrage on Subsequent Pulls After Wipe:**
   In `boss_mimiron::UpdateAI`, `EVENT_BERSERK` summoned a temporary duplicate of entry 33576 (`me->SummonCreature(33576, ...)`), which overwrote `_objectGuids[DATA_MIMIRON_DB_TARGET]` in `instance_ulduar`. When that temporary summon expired or was cleared in `EVENT_FINISH` (`summons.DespawnEntry(33576)`), `_objectGuids.erase(DATA_MIMIRON_DB_TARGET)` permanently removed the instance reference. On all subsequent attempts, `instance->GetCreature(DATA_MIMIRON_DB_TARGET)` returned null, permanently breaking Laser Barrage tracking until a full soft instance reset.
   *Fix:* Removed the duplicate summon from `EVENT_BERSERK` and removed the entry from `EVENT_FINISH` cleanup. The instance-spawned DB target persists properly across wipes and resets cleanly between attempts.

4. **Waypoint Generator Pausing on Wipe / Cell Unload:**
   The DB Target was not explicitly marked as active. If all raid members released spirit after a wipe, the creature cell could unload or pause its waypoint movement generator.
   *Fix:* In `instance_ulduar.cpp`, flagged `NPC_MIMIRON_DB_TARGET` with `creature->setActive(true)` and applied `UNIT_FLAG_NON_ATTACKABLE | UNIT_FLAG_IMMUNE_TO_PC | UNIT_FLAG_IMMUNE_TO_NPC` to guarantee continuous waypoint progression.

## Issues Addressed:

- Closes #27554
- Fixes visual rotation freeze during P3Wx2 Laser Barrage in Ulduar Phase 2 and Phase 4.
- Fixes Laser Barrage failing to rotate after wiping on Berserk.
- Related to #27079, #27265

## SOURCE:

The changes have been validated through:
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
  - **Bug demonstration footage (desync / frozen beam in straight line):**
    - Video: https://youtu.be/fM9DSmhtECY
    - Phase 2 visual freeze (shoots in straight line): https://youtu.be/fM9DSmhtECY?t=6
    - Phase 4 visual freeze on vehicle: https://youtu.be/fM9DSmhtECY?t=116
    - Player taking lethal damage away from the frozen visual beam: https://youtu.be/fM9DSmhtECY?t=120
  - **Retail / Blizzlike reference footage (smooth clockwise rotation):**
    - TankSpot's Guide to Mimiron (Phases 2 & 4 Addendum): https://www.youtube.com/watch?v=P13N2_XGZHk
      - Shows Blizzlike Laser Barrage sweeping smoothly clockwise in Phase 2 and Phase 4.
    - TankSpot's Guide to Mimiron (Original 2009 Retail): https://www.youtube.com/watch?v=ZjecQKcGuD4
      - Phase 2 rotation mechanics: https://www.youtube.com/watch?v=ZjecQKcGuD4&t=135s
      - Phase 4 vehicle torso rotation mechanics: https://www.youtube.com/watch?v=ZjecQKcGuD4&t=340s
  - AzerothCore commit `8f68451bb` / PR #27265 sniffs.

## Tests Performed:

- [x] Compiled `scripts.lib` and `worldserver.exe` on Windows Release x64 with 0 errors and 0 warnings.
- [x] Verified Phase 2 Laser Barrage: VX-001 rotates smoothly clockwise following DB Target without model freeze or jerky target snapping.
- [x] Verified Phase 4 Laser Barrage: V-07-TR-0N torso rotates properly relative to vehicle base.
- [x] Verified Wipe & Reset: Triggered wipe during hardmode Berserk, confirmed DB Target reference is preserved and Laser Barrage rotates properly on subsequent pulls.
- [x] Verified fallback: Artificially despawned DB Target; boss continues rotating clockwise at ~0.046 rad/tick instead of freezing.

## How to Test the Changes:

1. Teleport to Ulduar: `.tele Ulduar`
2. Advance to Mimiron chamber and initiate the encounter: `.go c id 33432`
3. Progress to Phase 2 (VX-001) and observe the first P3Wx2 Laser Barrage:
   - Verify VX-001 casts Spinning Up, turns toward the starting point, and continuously sweeps clockwise during the 10-second channel.
   - Verify the visual beam follows the creature orientation smoothly without stuttering or locking.
4. Wipe or reset the boss after Berserk triggers.
5. Re-engage Mimiron and advance to Phase 2 again.
   - Verify Laser Barrage still rotates smoothly on pull 2+ without requiring instance reload.
6. Progress to Phase 4 (combined V-07-TR-0N) and observe Laser Barrage:
   - Verify the torso section rotates correctly while mounted on the vehicle base.

## Known Issues and TODO List:

None.