### PR TITLE
fix(DB/Gameobject): Correct Call to Arms banner sides

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1788798767078677000.sql
+++ b/data/sql/updates/pending_db_world/rev_1788798767078677000.sql
@@ -1,0 +1,14 @@
+--
+-- Call to Arms banners stand on the wrong faction's side: both the Alterac Valley and
+-- Arathi Basin sets in Dalaran, and the Alterac Valley set in Shattrath, where #20539
+-- already corrected Arathi. The other holidays' banners at these spots are correct.
+--
+-- Dalaran
+UPDATE `gameobject` SET `id` = 180399 WHERE `guid` IN (151504, 151505) AND `id` = 180395;
+UPDATE `gameobject` SET `id` = 180398 WHERE `guid` IN (151508, 151509) AND `id` = 180396;
+UPDATE `gameobject` SET `id` = 180396 WHERE `guid` IN (151510, 151511) AND `id` = 180398;
+UPDATE `gameobject` SET `id` = 180395 WHERE `guid` IN (151506, 151507) AND `id` = 180399;
+
+-- Shattrath
+UPDATE `gameobject` SET `id` = 180399 WHERE `guid` IN (151480, 151481, 151482, 151483, 151484, 151485, 151486, 151487, 151488, 151489, 151490, 151491) AND `id` = 180395;
+UPDATE `gameobject` SET `id` = 180395 WHERE `guid` IN (151469, 151470, 151471, 151472, 151473, 151474, 151475, 151476, 151477, 151478, 151479) AND `id` = 180399;

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -157,6 +157,7 @@ If the scenario should stay as a regression, **move** it into `suites/` next to 
 | instances/bind_reset | party tele; ritual summon | P2 | covered; post-reset summon `blocked-harness` (AcceptSummon after reset) | #10708 |
 | instances/classic/stratholme | Timmy remains hidden while a relevant Square Scarlet lives, then emerges after the area is clear | P2 | covered (`TestAC_26363_TimmyEmergesAfterSquareCleared`) | #26363 |
 | instances/ulduar | named tele; Freya wave interval | P2 | covered (`TestAC_27095_*`); Kologarn Charge `blocked-harness` (bridge Z after Charge) | #26266 #27095 |
+| world/gameevents | Call to Arms banners at the Dalaran portals belong to the side they stand on, and the already-correct Warsong set is unchanged. **Wants an exclusive realm**: starting a holiday re-anchors its schedule in the running worldserver until restart; holidays already running are left alone | P2 | covered (`TestAC_24380_*`); Shattrath's 23 positions `gap` | #24380 |
 
 ---
 

--- a/e2e/suites/world/gameevents/cta_banners_e2e_test.go
+++ b/e2e/suites/world/gameevents/cta_banners_e2e_test.go
@@ -1,0 +1,150 @@
+//go:build e2e
+
+package gameevents_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+
+	"github.com/azerothcore/AzerothGhost/e2e/e2eharness"
+	"github.com/azerothcore/azerothcore-wotlk/e2e/internal/meta"
+)
+
+// Issue: https://github.com/azerothcore/azerothcore-wotlk/issues/24380
+//
+// Six Call to Arms holidays each light their own pair of PvP banners, and every
+// pair is spawned at the same positions. Dalaran has four such positions, two per
+// side. Alterac Valley and Arathi Basin had their banners on the wrong sides, so
+// Sunreaver's Sanctuary flew Alliance colours; Warsong Gulch was already correct.
+//
+// Standing at one position on each side, this starts a holiday at a time and
+// asserts the banner that spawns belongs to that side and its opposite does not.
+// Warsong is included as a control: it was correct before the fix and must stay
+// correct, which separates a targeted swap from a blanket one.
+//
+// REALM STATE: starting a holiday re-anchors its schedule in the running
+// worldserver — GameEventMgr::StartEvent sets Start to now and StopEvent sets it
+// to now minus the length, so the next natural occurrence shifts by up to a full
+// cycle. These events have world_event = 0, so no schedule state is persisted and
+// a worldserver restart restores it, but the suite still wants a realm it does not
+// share with players. A holiday already running is left strictly
+// alone, because stopping it afterwards would end the real one.
+//
+// Whether it is running has to be asked of the server, not of game_event: for Call
+// to Arms the stored start_time, length and occurence are replaced at load time
+// from Holidays.dbc (GameEventMgr::LoadFromDB -> SetHolidayEventTime), so the row
+// is not the schedule in force — the shipped start_time values are from 2010. A
+// banner of the holiday's own pair already standing here is the server's own state
+// and needs no second source.
+func TestAC_24380_CallToArmsBannerFactions(t *testing.T) {
+	meta.Begin(t, meta.TestMeta{
+		Tags:     []string{"med", "world", "gameevents", "issue", "serial"},
+		Runtime:  "med",
+		Issue:    24380,
+		Category: "world/gameevents",
+	})
+
+	const (
+		mapNorthrend = uint32(571)
+
+		eventAlteracValley = 18
+		eventWarsongGulch  = 19
+		eventArathiBasin   = 20
+
+		goHordeCTF       = uint32(180394)
+		goHordeAV        = uint32(180395)
+		goHordeArathi    = uint32(180396)
+		goAllianceArathi = uint32(180398)
+		goAllianceAV     = uint32(180399)
+		goAllianceCTF    = uint32(180400)
+	)
+
+	// One banner position per side. Sunreaver's Sanctuary is Horde: it also holds
+	// the Horde Isle of Conquest portal niche and the Sunreaver guardian mages. The
+	// Silver Enclave is Alliance, beside the Stormpike and League of Arathor
+	// emissaries. Dalaran has two more positions, one per side, spawned identically.
+	type spot struct {
+		name      string
+		short     string
+		anchorNPC uint32 // permanent NPC here, waited on to prove the area has streamed
+		x, y, z   float32
+		ownBanner map[int]uint32 // holiday -> banner that belongs on this side
+		foeBanner map[int]uint32 // holiday -> banner that must not be here
+	}
+	spots := []spot{
+		{
+			name: "Sunreaver's Sanctuary (Horde)", short: "SunreaverHorde",
+			anchorNPC: 29255, // Sunreaver Guardian Mage, 4.6 yd away
+			x:         5914.19, y: 554.681, z: 661.245,
+			ownBanner: map[int]uint32{eventAlteracValley: goHordeAV, eventArathiBasin: goHordeArathi, eventWarsongGulch: goHordeCTF},
+			foeBanner: map[int]uint32{eventAlteracValley: goAllianceAV, eventArathiBasin: goAllianceArathi, eventWarsongGulch: goAllianceCTF},
+		},
+		{
+			name: "Silver Enclave (Alliance)", short: "SilverEnclaveAlliance",
+			anchorNPC: 29254, // Silver Covenant Guardian Mage, 18.8 yd away
+			x:         5664.81, y: 791.002, z: 653.698,
+			ownBanner: map[int]uint32{eventAlteracValley: goAllianceAV, eventArathiBasin: goAllianceArathi, eventWarsongGulch: goAllianceCTF},
+			foeBanner: map[int]uint32{eventAlteracValley: goHordeAV, eventArathiBasin: goHordeArathi, eventWarsongGulch: goHordeCTF},
+		},
+	}
+	holidays := []struct {
+		id    int
+		name  string
+		short string
+	}{
+		{eventAlteracValley, "Alterac Valley", "AlteracValley"},
+		{eventArathiBasin, "Arathi Basin", "ArathiBasin"},
+		{eventWarsongGulch, "Warsong Gulch (control, already correct)", "WarsongControl"},
+	}
+
+	// NewSolo leaves GM mode on, which this test needs: npc_mageguard_dalaran
+	// teleports opposite-faction players out of both enclaves and only skips that
+	// for a GM. Do not add CombatReady here.
+	bot := e2eharness.NewSolo(t, e2eharness.ScenarioOpts{Prefix: "CtaBn", Level: 80})
+
+	for _, s := range spots {
+		bot.Teleport(t, s.x, s.y, s.z, mapNorthrend)
+		// A far tele clears the object cache and refills it asynchronously, so wait
+		// for a permanent neighbour before trusting any "is this banner here" probe.
+		// The guardian mages are ordinary spawns; the Call to Arms emissaries beside
+		// them are event-linked and would only appear when a holiday is already
+		// running, which is the very thing being probed for.
+		bot.WaitUnit(t, s.anchorNPC, 20*time.Second)
+
+		for _, h := range holidays {
+			// A subtest per position and holiday, so one failure does not mask the
+			// rest. That matters for the control: it has to be seen passing even on
+			// data where the other two holidays fail.
+			t.Run(fmt.Sprintf("%s/%s", s.short, h.short), func(t *testing.T) {
+				own := s.ownBanner[h.id]
+				foe := s.foeBanner[h.id]
+
+				alreadyRunning := e2eharness.TryNearbyGameObjectByEntry(t, bot.World, own, 2*time.Second) != 0 ||
+					e2eharness.TryNearbyGameObjectByEntry(t, bot.World, foe, 2*time.Second) != 0
+				if alreadyRunning {
+					t.Logf("%s already running; asserting against it and leaving the schedule alone", h.name)
+				} else {
+					bot.GM(t, fmt.Sprintf(".event start %d", h.id))
+					defer bot.GM(t, fmt.Sprintf(".event stop %d", h.id))
+				}
+
+				if guid := e2eharness.TryNearbyGameObjectByEntry(t, bot.World, own, 20*time.Second); guid == 0 {
+					e2eharness.Assertf(t, "%s during %s: banner %d for this side did not spawn", s.name, h.name, own)
+				}
+				// The pair spawns together, so by now the wrong one would be here too.
+				if guid := e2eharness.TryNearbyGameObjectByEntry(t, bot.World, foe, 3*time.Second); guid != 0 {
+					e2eharness.Assertf(t, "%s during %s: banner %d belongs to the other side (guid 0x%X)", s.name, h.name, foe, guid)
+				}
+				t.Logf("OK %s during %s: %d present, %d absent", s.name, h.name, own, foe)
+			})
+		}
+	}
+
+	bot.AssertWorldAlive(t)
+	if !t.Failed() {
+		t.Logf("PASS both Dalaran banner positions match their side across three holidays")
+	}
+}


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

The Call to Arms banners near portals in Dalaran and Shattrath stand on the wrong
faction's side during two of the six CTAs: Sunreaver's Sanctuary flies Alliance colors and
the Silver Enclave flies Horde ones. That is why the linked issue reports it as "sometimes random".

In Dalaran Arathi Basin and Alterac Valley had swapped ids, and in Shattrath Alterac Valley only.

**Shattrath is the other half of #20539.** That PR corrected Shattrath's Arathi banners (but no Dalaran).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Opus 5 via Claude Code. It produced the SQL, the e2e test and this description. I reproduced the bug and verified the fix in game myself in both cities, and made the scope calls. The `/self-review` report is posted as a comment below.
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #24380

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

The argument is internal to the database and checkable without a sniff: banners sharing a
position must share a faction, the surrounding battleground emissaries identify each side
independently, and #20539 established both the fix shape and the precedent.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Reproduced and verified on a local 3.3.5a worldserver in both cities, reading entry ids with
`.gobject near`.

| | Before | After |
| --- | --- | --- |
| Dalaran, Sunreaver's (Horde) | `151506` = 180399 Alliance AV | 180395 Horde AV |
| Shattrath, Horde position | `151469` = 180399 Alliance AV | 180395 Horde AV |
| Shattrath, Alliance position | `151480` = 180395 Horde AV | 180399 Alliance AV |
| Warsong control, Sunreaver's | `151498` = 180394 Horde CTF | unchanged |

**Regression test.** `e2e/suites/world/gameevents` visits one position on each side in Dalaran,
starts a holiday at a time and asserts the banner that spawns belongs to that side while its
opposite does not. It passes 6/6 on this branch; run against the restored pre-change data the
four Alterac Valley and Arathi Basin subtests fail while both Warsong controls pass, which is
what shows the swap is confined to two holidays rather than all six.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

```
.event start 20                            Call to Arms: Arathi Basin
.go xyz 5914 555 661 571                   Sunreaver's Sanctuary, Horde
.gobject near 5                            expect 180396, not 180398
.go xyz 5665 791 654 571                   Silver Enclave, Alliance
.gobject near 5                            expect 180398, not 180396
```

Repeat with `.event start 18` for Alterac Valley, and in Shattrath at
`-1667.1 5188.3 -41.7 530` (Horde) and `-1648.1 5217.7 -42.7 530` (Alliance). Checking
`.event start 19` as a control is worthwhile: Warsong is already correct and must stay so.

## Known Issues and TODO List:

- [ ]
- [ ]

## How to Test AzerothCore PRs

When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
