### PR TITLE
fix(Scripts/TrialOfTheCrusader): retain protected spike targets

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -141,6 +141,7 @@ If the scenario should stay as a regression, **move** it into `suites/` next to 
 | combat/death | die → ghost → release → reclaim | P1 | covered | — |
 | combat/pets | summon / GUID / attack / dismiss | P1 | covered; dungeon Raise Dead `blocked-harness` (ready-check / instance summon) | #27081 |
 | combat/threat | engage / taunt switch / kill clears combat | P1 | covered | — |
+| instances/trial_of_the_crusader | spike retains protected target on arrival; full immunity releases target; reacquire without speed reset | P1 | covered (`TestAC_14076_PursuingSpikesImmunity`); [scope and validation](suites/instances/trial_of_the_crusader/spikes.md) | #14076 |
 | combat/vehicles | spellclick steed enter/exit | P2 | covered | — |
 | spells/aura | apply/query; CC broken by damage; mount persist | P1 | covered (`TestAC_26130_*`) | #26130 |
 | spells/cast | Charge on dummy; fail path; stance; Raise Dead + ghoul | P1 | covered (`TestAC_27061_*`) | #27061 |

--- a/e2e/suites/instances/trial_of_the_crusader/spikes.md
+++ b/e2e/suites/instances/trial_of_the_crusader/spikes.md
@@ -1,0 +1,38 @@
+# Pursuing Spikes targeting (AC#14076)
+
+Run with the normal `E2E_*` realm/database settings, from `e2e/`:
+
+```sh
+go test -tags=e2e ./suites/instances/trial_of_the_crusader -run TestAC_14076 -count=2 -p 1 -parallel 1 -v
+```
+
+Two level-80 paladins form a fresh raid and enter the empty ToC arena. A neutral
+World Trigger fixture casts the encounter's real summon spell (66169), creating
+Pursuing Spikes (34660) with the ToC instance AI. Characters receive extra health,
+but no god mode or damage immunity. The immunity spells are cast by the clients.
+The summon and persistent fixture are removed during cleanup.
+
+Oracles:
+
+- Hand of Protection (10278): retain Mark (67574) and the same target throughout
+  nine seconds, including reaching the stationary player and accelerating (65922).
+- Divine Shield (642): release the fully immune player and mark the other player.
+  If both players become fully immune, clear the target, continue accelerating,
+  and reacquire the first player after they cancel their shield without resetting speed.
+
+The [issue discussion](https://github.com/azerothcore/azerothcore-wotlk/issues/14076#issuecomment-1345338310)
+distinguishes Hand of Protection from Divine Shield, Ice Block and threat-dropping
+abilities. Mark has `SPELL_ATTR0_NO_IMMUNITIES`; full immunity does not itself
+remove it. The spike AI must explicitly release and replace the mark.
+
+Live reproduction on the unmodified PTR core (`ca8e6d78dee1+`) showed Hand of
+Protection still active when the spike reached the player and switched targets
+about 6.7 seconds after the cast. The committed test must fail with `AC#14076
+CONFIRMED BUG` on that behavior and pass on a patched server. Patched-binary
+validation is pending; local reproduction is not proof that the fix passes.
+
+This fixture exercises spike AI in an instance, not the complete boss fight.
+Manual encounter checks still needed: Ice Block, Feign Death, Vanish, target death
+and disconnect; Permafrost collision's four-second pause and speed restart; normal
+boss submerge/emerge cleanup. No change to Permafrost/Hand of Freedom (#16496) is
+included. PR #19684 was merged independently in August 2024.

--- a/e2e/suites/instances/trial_of_the_crusader/spikes.md
+++ b/e2e/suites/instances/trial_of_the_crusader/spikes.md
@@ -19,6 +19,8 @@ Oracles:
 - Divine Shield (642): release the fully immune player and mark the other player.
   If both players become fully immune, clear the target, continue accelerating,
   and reacquire the first player after they cancel their shield without resetting speed.
+- Initially immune: summon while both players have Divine Shield, then cancel one
+  shield and verify acquisition resumes at the accelerated speed.
 
 The [issue discussion](https://github.com/azerothcore/azerothcore-wotlk/issues/14076#issuecomment-1345338310)
 distinguishes Hand of Protection from Divine Shield, Ice Block and threat-dropping
@@ -36,3 +38,8 @@ Manual encounter checks still needed: Ice Block, Feign Death, Vanish, target dea
 and disconnect; Permafrost collision's four-second pause and speed restart; normal
 boss submerge/emerge cleanup. No change to Permafrost/Hand of Freedom (#16496) is
 included. PR #19684 was merged independently in August 2024.
+
+The TC9 gateway sometimes performs a second instance transfer during fixture setup
+when repeating the entire test in one process; this produces a setup failure before
+spike summoning. Reproduction succeeded in a complete single run. Stock-core CI and
+repeatability on the patched binary remain to be checked.

--- a/e2e/suites/instances/trial_of_the_crusader/spikes_e2e_test.go
+++ b/e2e/suites/instances/trial_of_the_crusader/spikes_e2e_test.go
@@ -1,0 +1,182 @@
+//go:build e2e
+
+package trial_of_the_crusader_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/azerothcore/AzerothGhost/e2e/e2eharness"
+	"github.com/azerothcore/azerothcore-wotlk/e2e/internal/meta"
+	_ "github.com/go-sql-driver/mysql"
+)
+
+// Issue: https://github.com/azerothcore/azerothcore-wotlk/issues/14076
+// Hand of Protection must retain the marked target after the spike reaches it.
+// Divine Shield grants full immunity and must still cause retargeting:
+// https://github.com/azerothcore/azerothcore-wotlk/issues/14076#issuecomment-1345338310
+// Use the actual summon spell inside a fresh ToC instance, without starting the
+// full encounter. GM setup gives health, not god mode or damage immunity.
+func TestAC_14076_PursuingSpikesImmunity(t *testing.T) {
+	meta.Begin(t, meta.TestMeta{
+		Tags: []string{"med", "issue", "multi_bot"}, Runtime: "med",
+		Issue: 14076, Category: "instances/trial_of_the_crusader",
+	})
+	const (
+		mark       = uint32(67574)
+		protection = uint32(10278)
+		shield     = uint32(642)
+		speed2     = uint32(65922)
+	)
+	bots := e2eharness.NewScenario(t, e2eharness.ScenarioOpts{
+		Prefix: "Spike", Bots: []e2eharness.BotSpec{
+			{Role: "one", Race: e2eharness.RaceHuman, Class: e2eharness.ClassPaladin, Level: 80},
+			{Role: "two", Race: e2eharness.RaceHuman, Class: e2eharness.ClassPaladin, Level: 80},
+		},
+	})
+	a, b := bots[0], bots[1]
+	e2eharness.FormPartyAtPad(t, e2eharness.PackagePad(t), a, b)
+	// CMSG_GROUP_RAID_CONVERT has no payload (GroupHandler.cpp).
+	// AzerothGhost v1.0.8 exposes raw packets but no raid conversion helper.
+	const groupRaidConvert = uint16(0x28e)
+	if err := a.World.SendPacketRaw(groupRaidConvert, nil); err != nil {
+		e2eharness.HarnessFailf(t, "convert party to raid: %v", err)
+	}
+	if !waitSpikeCondition(3*time.Second, func() bool { return a.GroupState().GroupType&2 != 0 }) {
+		e2eharness.Preconditionf(t, "raid conversion not acknowledged")
+	}
+	for _, bot := range bots {
+		bot.GM(t, ".gm on")
+		bot.FlushWorld(t)
+	}
+	// Empty arena above Anub'arak: no Frost Spheres or encounter waves.
+	a.Teleport(t, 563, 140, 394, 649)
+	b.Teleport(t, 563, 140, 394, 649)
+	caster, _ := a.SpawnPersistent(t, 12999, 10*time.Second)
+	a.Teleport(t, 550, 120, 394, 649)
+	b.Teleport(t, 580, 120, 394, 649)
+	for _, bot := range bots {
+		bot.Learn(t, protection)
+		bot.Learn(t, shield)
+		selectSpikeUnit(t, bot, bot.GUID)
+		bot.GM(t, ".modify hp 1000000")
+		e2eharness.CombatReady(t, bot.World, e2eharness.CombatReadyOpts{Power: true})
+		bot.FlushWorld(t)
+	}
+	a.WaitUnitGUID(t, b.GUID, 10*time.Second)
+	a.WaitUnitGUID(t, caster, 10*time.Second)
+	for _, tc := range []struct {
+		name  string
+		spell uint32
+	}{
+		{"hand_of_protection", protection},
+		{"divine_shield", shield},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, bot := range bots {
+				selectSpikeUnit(t, bot, bot.GUID)
+				bot.GM(t, ".combatstop")
+				bot.GM(t, ".unaura all")
+				bot.GM(t, ".modify hp 1000000")
+				bot.FlushWorld(t)
+			}
+			selectSpikeUnit(t, a, caster)
+			// Same spell as EVENT_SPELL_SUMMON_SPIKE. No "triggered" suffix:
+			// the GM command's debug mask would ignore the summon effect.
+			a.GM(t, ".cast self 66169")
+			spike := a.WaitUnit(t, 34660, 10*time.Second)
+			t.Cleanup(func() {
+				// Delete only this summon, before its persistent caster cleanup.
+				selectSpikeUnit(t, a, spike)
+				a.GM(t, ".npc delete")
+			})
+			if !waitSpikeCondition(3*time.Second, func() bool { return a.HasAura(mark) != b.HasAura(mark) }) {
+				e2eharness.Preconditionf(t, "expected exactly one marked player")
+			}
+			marked, other := a, b
+			if b.HasAura(mark) {
+				marked, other = b, a
+			}
+			a.WaitUnitTarget(t, spike, marked.GUID, 3*time.Second)
+			t.Logf("spike=0x%X marked=0x%X other=0x%X spell=%d", spike, marked.GUID, other.GUID, tc.spell)
+			marked.CastMust(t, tc.spell, marked.GUID, 5*time.Second)
+			marked.WaitUnitAura(t, marked.GUID, tc.spell, 2*time.Second)
+			if tc.spell == shield {
+				if !waitSpikeCondition(3*time.Second, func() bool {
+					return !marked.HasAura(mark) && other.HasAura(mark) && a.UnitTarget(spike) == other.GUID
+				}) {
+					e2eharness.ConfirmedBugf(t, 14076, "Divine Shield must allow retargeting: target=0x%X", a.UnitTarget(spike))
+				}
+				t.Log("PASS: Divine Shield causes the spike to mark and target the other player")
+				other.CastMust(t, shield, other.GUID, 5*time.Second)
+				if !waitSpikeCondition(3*time.Second, func() bool {
+					return a.UnitTarget(spike) == 0 && !a.HasAura(mark) && !b.HasAura(mark)
+				}) {
+					e2eharness.ConfirmedBugf(t, 14076, "spike must release its target when both players are fully immune")
+				}
+				// The existing 7s acceleration timer must keep running without a
+				// target, then pursuit must resume when one player becomes eligible.
+				a.WaitUnitAura(t, spike, speed2, 8*time.Second)
+				marked.AssertHasAura(t, shield)
+				other.AssertHasAura(t, shield)
+				marked.CancelAura(t, shield)
+				if !waitSpikeCondition(3*time.Second, func() bool {
+					return marked.HasAura(mark) && a.UnitTarget(spike) == marked.GUID
+				}) {
+					e2eharness.ConfirmedBugf(t, 14076, "spike did not reacquire player after full immunity ended")
+				}
+				if !a.UnitHasAura(spike, speed2) {
+					e2eharness.ConfirmedBugf(t, 14076, "reacquiring a target reset the spike's speed")
+				}
+				t.Log("PASS: both immune -> no target; cancel immunity -> pursuit resumes at accelerated speed")
+				return
+			}
+
+			// Spike reaches these stationary players in about 7s at its first
+			// speed. Observe 9s of the 10s protection, including arrival and the
+			// 7s acceleration event. Polling must not return early on arrival.
+			reached := false
+			deadline := time.Now().Add(9 * time.Second)
+			for time.Now().Before(deadline) {
+				if !marked.HasAura(protection) {
+					e2eharness.Preconditionf(t, "Hand of Protection expired before observation completed")
+				}
+				if !marked.HasAura(mark) || other.HasAura(mark) || a.UnitTarget(spike) != marked.GUID {
+					e2eharness.ConfirmedBugf(t, 14076, "spike lost protected target on arrival: target=0x%X mark=%v otherMark=%v",
+						a.UnitTarget(spike), marked.HasAura(mark), other.HasAura(mark))
+				}
+				if obj := a.World.GetObject(spike); obj != nil && obj.HasKnownPosition() {
+					x, y, z := obj.InterpolatedPosition()
+					px, py, pz, _ := marked.Pos()
+					reached = reached || e2eharness.Distance3D(x, y, z, px, py, pz) < 4
+				}
+				time.Sleep(25 * time.Millisecond)
+			}
+			if !reached {
+				e2eharness.Preconditionf(t, "spike never reached the protected player; cannot judge arrival behavior")
+			}
+			if !a.UnitHasAura(spike, speed2) {
+				e2eharness.ConfirmedBugf(t, 14076, "spike failed to accelerate while retaining the protected target")
+			}
+			t.Log("PASS: spike reaches protected player, keeps the mark and target, and accelerates")
+		})
+	}
+}
+
+func selectSpikeUnit(t *testing.T, bot *e2eharness.ScenarioBot, guid uint64) {
+	t.Helper()
+	if err := bot.World.SetTarget(guid); err != nil {
+		e2eharness.HarnessFailf(t, "select 0x%X: %v", guid, err)
+	}
+}
+
+func waitSpikeCondition(timeout time.Duration, condition func() bool) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if condition() {
+			return true
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	return condition()
+}

--- a/e2e/suites/instances/trial_of_the_crusader/spikes_e2e_test.go
+++ b/e2e/suites/instances/trial_of_the_crusader/spikes_e2e_test.go
@@ -71,14 +71,22 @@ func TestAC_14076_PursuingSpikesImmunity(t *testing.T) {
 	}{
 		{"hand_of_protection", protection},
 		{"divine_shield", shield},
+		{"initially_immune", shield},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			for _, bot := range bots {
 				selectSpikeUnit(t, bot, bot.GUID)
 				bot.GM(t, ".combatstop")
 				bot.GM(t, ".unaura all")
+				bot.GM(t, ".cooldown")
 				bot.GM(t, ".modify hp 1000000")
 				bot.FlushWorld(t)
+			}
+			if tc.name == "initially_immune" {
+				for _, bot := range bots {
+					bot.CastMust(t, shield, bot.GUID, 5*time.Second)
+					bot.WaitUnitAura(t, bot.GUID, shield, 2*time.Second)
+				}
 			}
 			selectSpikeUnit(t, a, caster)
 			// Same spell as EVENT_SPELL_SUMMON_SPIKE. No "triggered" suffix:
@@ -90,6 +98,22 @@ func TestAC_14076_PursuingSpikesImmunity(t *testing.T) {
 				selectSpikeUnit(t, a, spike)
 				a.GM(t, ".npc delete")
 			})
+			if tc.name == "initially_immune" {
+				a.WaitUnitAura(t, spike, speed2, 8*time.Second)
+				a.AssertHasAura(t, shield)
+				b.AssertHasAura(t, shield)
+				if a.UnitTarget(spike) != 0 || a.HasAura(mark) || b.HasAura(mark) {
+					e2eharness.ConfirmedBugf(t, 14076, "spike selected a fully immune player on initial acquisition")
+				}
+				a.CancelAura(t, shield)
+				if !waitSpikeCondition(3*time.Second, func() bool {
+					return a.HasAura(mark) && a.UnitTarget(spike) == a.GUID && a.UnitHasAura(spike, speed2)
+				}) {
+					e2eharness.ConfirmedBugf(t, 14076, "spike stalled after all players were immune on initial acquisition")
+				}
+				t.Log("PASS: initially all immune -> acquisition resumes without resetting acceleration")
+				return
+			}
 			if !waitSpikeCondition(3*time.Second, func() bool { return a.HasAura(mark) != b.HasAura(mark) }) {
 				e2eharness.Preconditionf(t, "expected exactly one marked player")
 			}

--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_anubarak_trial.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_anubarak_trial.cpp
@@ -756,12 +756,21 @@ public:
             }
         }
 
+        bool CanPursue(Unit* target) const
+        {
+            // Physical immunity (Hand of Protection) does not break pursuit, but full immunity does.
+            return target && me->IsValidAttackTarget(target) && !target->HasAuraType(SPELL_AURA_FEIGN_DEATH)
+                && !target->HasSchoolImmunityForMask(SPELL_SCHOOL_MASK_ALL, me, nullptr);
+        }
+
         void SelectNewTarget(bool next)
         {
             if (TargetGUID)
                 if (Unit* target = ObjectAccessor::GetPlayer(*me, TargetGUID))
                     target->RemoveAura(SPELL_MARK);
             TargetGUID.Clear();
+            me->AttackStop();
+            me->GetMotionMaster()->MoveIdle();
             if (!next)
             {
                 events.Reset();
@@ -769,7 +778,10 @@ public:
             }
             DoZoneInCombat();
             DoResetThreatList();
-            if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, 250.0f, true))
+            if (Unit* target = SelectTarget(SelectTargetMethod::Random, 0, [this](Unit* candidate)
+            {
+                return DefaultTargetSelector(me, 250.0f, true, true, 0)(candidate) && CanPursue(candidate);
+            }))
             {
                 if (!next)
                 {
@@ -792,14 +804,14 @@ public:
 
         void UpdateAI(uint32 diff) override
         {
-            if (TargetGUID)
+            // Keep searching if no eligible player remains. The trail is removed during the Permafrost pause.
+            if (TargetGUID || me->HasAura(SPELL_SPIKE_TRAIL))
             {
                 Unit* target = ObjectAccessor::GetPlayer(*me, TargetGUID);
-                if (!target || !target->HasAura(SPELL_MARK) || !me->IsValidAttackTarget(target) || me->GetMotionMaster()->GetCurrentMovementGeneratorType() != CHASE_MOTION_TYPE || !me->HasUnitState(UNIT_STATE_CHASE_MOVE))
-                {
+                // Reaching the marked player clears CHASE_MOVE; that is not a reason to abandon pursuit.
+                if (!CanPursue(target) || !target->HasAura(SPELL_MARK) || me->GetVictim() != target
+                    || me->GetMotionMaster()->GetCurrentMovementGeneratorType() != CHASE_MOTION_TYPE)
                     SelectNewTarget(true);
-                    return;
-                }
             }
 
             events.Update(diff);

--- a/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_anubarak_trial.cpp
+++ b/src/server/scripts/Northrend/CrusadersColiseum/TrialOfTheCrusader/boss_anubarak_trial.cpp
@@ -739,6 +739,13 @@ public:
             me->SetCorpseDelay(0);
         }
 
+        enum SpikeEvents
+        {
+            EVENT_SPIKE_SPEED_2 = 1,
+            EVENT_SPIKE_SPEED_3,
+            EVENT_SPIKE_RESUME,
+        };
+
         EventMap events;
         ObjectGuid TargetGUID;
 
@@ -752,7 +759,7 @@ public:
                 me->RemoveAllAuras();
                 me->GetMotionMaster()->MoveIdle();
                 events.Reset();
-                events.RescheduleEvent(3, 4s);
+                events.RescheduleEvent(EVENT_SPIKE_RESUME, 4s);
             }
         }
 
@@ -775,6 +782,10 @@ public:
             {
                 events.Reset();
                 me->RemoveAllAuras();
+                // Start the pursuit even if everyone is currently immune, so acquisition can retry.
+                DoCastSelf(SPELL_SPIKE_SPEED1, true);
+                DoCastSelf(SPELL_SPIKE_TRAIL, true);
+                events.RescheduleEvent(EVENT_SPIKE_SPEED_2, 7s);
             }
             DoZoneInCombat();
             DoResetThreatList();
@@ -783,12 +794,6 @@ public:
                 return DefaultTargetSelector(me, 250.0f, true, true, 0)(candidate) && CanPursue(candidate);
             }))
             {
-                if (!next)
-                {
-                    me->CastSpell(me, SPELL_SPIKE_SPEED1, true);
-                    me->CastSpell(me, SPELL_SPIKE_TRAIL, true);
-                    events.RescheduleEvent(1, 7s);
-                }
                 TargetGUID = target->GetGUID();
                 me->CastSpell(target, SPELL_MARK, true);
                 Talk(EMOTE_SPIKE, target);
@@ -820,16 +825,16 @@ public:
             {
                 case 0:
                     break;
-                case 1:
+                case EVENT_SPIKE_SPEED_2:
                     me->CastSpell(me, SPELL_SPIKE_SPEED2, true);
 
-                    events.RescheduleEvent(2, 7s);
+                    events.RescheduleEvent(EVENT_SPIKE_SPEED_3, 7s);
                     break;
-                case 2:
+                case EVENT_SPIKE_SPEED_3:
                     me->CastSpell(me, SPELL_SPIKE_SPEED3, true);
 
                     break;
-                case 3:
+                case EVENT_SPIKE_RESUME:
                     Reset();
                     break;
             }


### PR DESCRIPTION
## Changes Proposed:
- [ ] Core
- [x] Scripts
- [ ] Database

When Pursuing Spikes reach a player protected by Hand of Protection, chase movement finishes and the current script selects another player. Keep the marked target when the movement spline ends. Release fully immune, feigning or invalid targets, and retry acquisition without resetting acceleration. Preserve the four-second Permafrost pause, including recovery if everyone is immune when the pause ends.

Add client-driven e2e coverage for protected arrival, Divine Shield retargeting, all-immune recovery and initially-all-immune acquisition.

### AI-assisted Pull Requests
- [x] AI tools were used: OpenAI Codex (GPT-6), with an isolated fresh-context reviewer (model identifier unavailable).
- [x] Read the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering).

## Issues Addressed:
- Fixes #14076, following the comment distinguishing Hand of Protection from threat-dropping immunities.
- Independent of #19684 (merged August 22, 2024) and the Permafrost/Hand of Freedom regression work for #16496.

## SOURCE:
- [x] Public evidence: [clarification in #14076](https://github.com/azerothcore/azerothcore-wotlk/issues/14076#issuecomment-1345338310) and the [video linked in that discussion](https://www.youtube.com/watch?v=N7sZ1C-1Bv4).
- [ ] Live Blizzard research / sniffs
- [ ] Cherry-pick from another project

Local DBC inspection confirms Hand of Protection grants physical immunity; Divine Shield covers physical and magical schools. Mark (67574) pierces immunity, so full immunity does not automatically strip it. The script handles target release explicitly. This implements a narrower immunity distinction than the closed, unmerged #14078 proposal.

## Tests Performed:
- [ ] Patched core built and tested in game.
- [x] Further testing required — draft PR.

C++ and SQL style checks, `git diff --check`, and Go test compilation pass. On the unmodified PTR core (`ca8e6d78dee1+`), the final three cases all reached `AC#14076 CONFIRMED BUG` failures: protected arrival (~6s), Divine Shield retargeting, and initially immune acquisition (18s total). These runs reproduce the bug; they do not validate the patch.

A repeated whole-suite run also hit a TC9 gateway instance-transfer fixture failure before summoning. Stock AC repeatability and the patched behavior remain unverified. No core build/deployment was performed; repository AGENTS.md requires an explicit build request.

## How to Test the Changes:

With a patched realm and normal `E2E_*` settings, from `e2e/`:

```sh
go test -tags=e2e ./suites/instances/trial_of_the_crusader -run TestAC_14076 -count=2 -p 1 -parallel 1 -v
```

In the real encounter, let a marked player stand still under Hand of Protection and allow spikes to reach them: target and acceleration must persist. Verify Divine Shield, Ice Block, Feign Death, Vanish, death and disconnect cause a valid target switch. Check Permafrost still stops spikes for four seconds and restarts acceleration, and boss emergence clears summons.

## Known Issues and TODO List:
- [ ] Patched-core build and green e2e run, including repeatability.
- [ ] Full-encounter side-effect checks above.

## Self-review — spike targets → master

**Outcome** 1 finding fixed; final review clean. Draft: patched-binary validation is pending.

**Reviewed** `34f23fc816` (`fix/14076-anubarak-protection-target` vs `upstream/master`, merge-base diff; 4 files, +286 −17).

**By** Codex, GPT-6; isolated reviewer model identifier unavailable — self-review v0.7 / fresh-eyes-review v1.1, 2026-09-08.

**Verification** C++ and SQL codestyle, whitespace checks, and Go test compilation passed. On unmodified PTR `ca8e6d78dee1+`, all three final cases reached their expected CONFIRMED BUG failures (18s total). No patched-core build or live validation. Repeated whole-suite execution can encounter a TC9 instance-transfer fixture failure.

<details>
<summary>Review details (2 rounds)</summary>

**Intent** Keep Pursuing Spikes on Hand of Protection targets after arrival, permit full-immunity/feign/invalid-target switches, and preserve acceleration and Permafrost pause behavior.

**Project rules** `.agents/docs/self-review-rules.md`, code-review, C++/script and e2e policies applied. No core build: AGENTS.md prohibits configuring/building without an explicit build request. Source reviewed against current upstream master `a5e0e6b8f2bf878cb45cb1dc2251eb1448b9bbc3`.

**Diff** `4d9d756d0ce97cf5372dc04948d8f26a2d1dafd4`.

**Procedure** User-authorized implementation included fixing the review finding and committing the changes. Planning, scratch files and this report were excluded from reviewer inputs. All four changed files and relevant AI, immunity, movement, and harness consumers were reviewed. Second round reused the isolated reviewer's context, separate from authoring context.

### Round 1 — `30fc24c117`

1. `boss_anubarak_trial.cpp:781–790,808` — P1: if every player is immune at initial spawn or Permafrost resume, selection returns null after clearing events/auras; no target or trail remains to trigger retries, permanently stalling the spike → **fixed**: initialize pursuit trail/speed/timer independently of acquisition; add an initially-all-immune regression.

### Round 2 — `34f23fc816`

No new concrete findings. Reviewer confirmed initial/resume retries and unchanged four-second Permafrost pause; reviewed the new test and event naming.

**Remaining validation** Run on a patched binary, repeat on stock AC, and exercise full encounter Ice Block, Feign Death, Vanish, target death/disconnect, ice collisions and boss cleanup. These remain explicit draft testing requirements, not claimed successes.

</details>

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
