### PR TITLE
fix(Core/Unit): clear moving flags before sending root

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -14500,7 +14500,13 @@ void Unit::SendMoveRoot(bool apply)
     {
         if (apply)
         {
-            m_movementInfo.RemoveMovementFlag(MOVEMENTFLAG_MASK_MOVING_FLY);
+            // MOVEMENTFLAG_ROOT must not be sent alongside MOVEMENTFLAG_MASK_MOVING.
+            // The 3.3.5a client's movement step returns zero consumed time as soon
+            // as it sees ROOT, while the loop driving it only terminates once that
+            // time reaches the step target - so a moving flag alongside ROOT spins
+            // forever and freezes every client that receives this unit's movement
+            // info. Turn and pitch bits are inert here, they never reach that step.
+            m_movementInfo.RemoveMovementFlag(MOVEMENTFLAG_MASK_MOVING | MOVEMENTFLAG_MASK_MOVING_FLY);
             m_movementInfo.AddMovementFlag(MOVEMENTFLAG_ROOT);
             if (!client)
                 StopMoving();

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -14503,9 +14503,9 @@ void Unit::SendMoveRoot(bool apply)
             // MOVEMENTFLAG_ROOT must not be sent alongside MOVEMENTFLAG_MASK_MOVING.
             // The 3.3.5a client's movement step returns zero consumed time as soon
             // as it sees ROOT, while the loop driving it only terminates once that
-            // time reaches the step target - so a moving flag alongside ROOT spins
+            // time reaches the step target, so a moving flag alongside ROOT spins
             // forever and freezes every client that receives this unit's movement
-            // info. Turn and pitch bits are inert here, they never reach that step.
+            // info. The turn bits stay set, they never reach that step.
             m_movementInfo.RemoveMovementFlag(MOVEMENTFLAG_MASK_MOVING | MOVEMENTFLAG_MASK_MOVING_FLY);
             m_movementInfo.AddMovementFlag(MOVEMENTFLAG_ROOT);
             if (!client)


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

For a unit that is not rooted, the client consumes the elapsed delta and derives the displacement from it. `MOVEMENTFLAG_ROOT` (0x800) sends the step down a fallback path that reports zero consumed time, while the loop driving that step only terminates once the consumed time reaches the step target. So `MOVEMENTFLAG_ROOT` combined with any bit of `0xC0100F` (the moving bits, turn and pitch excluded, as those never reach that step) gives a loop that can never make progress and never exits. Every client that receives such movement info for any unit hangs, not just the client of the affected unit.

The guard lived in `Unit::SetRooted()` since AzerothCore's first commit. 
#23147 moved the in-place flag application into the new Unit::SendMoveRoot() and, in the move, replaced `MOVEMENTFLAG_MASK_MOVING` with `MOVEMENTFLAG_MASK_MOVING_FLY`.

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [ ] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used:
- [ ] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
