### PR TITLE
fix(Core/Pets): Stop moving for autocast channels

### DIFF
--- a/src/server/game/AI/CoreAI/PetAI.cpp
+++ b/src/server/game/AI/CoreAI/PetAI.cpp
@@ -350,6 +350,12 @@ void PetAI::UpdateAI(uint32 diff)
             me->AddSpellCooldown(spell->m_spellInfo->Id, 0, 0);
 
             spell->prepare(&targets);
+
+            // Stop the current spline before the next movement update can interrupt a stationary channel.
+            if (Pet* controlledPet = me->ToPet())
+                if (spell->m_spellInfo->IsChanneled() && !spell->m_spellInfo->IsActionAllowedChannel()
+                    && controlledPet->IsMovementPreventedByCasting())
+                    controlledPet->StopMoving();
         }
 
         // deleted cached Spell objects


### PR DESCRIPTION
## Changes Proposed:

Follow-up to #27010. This prevents a pet's existing spline movement from interrupting a stationary autocast channel. When a controlled pet starts a channeled autocast that prevents movement, it now stops moving.

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: GPT-5.6 Sol
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:

- Follow-up to #27010 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Tested with a Succubus using Seduction on autocast while attacking and chasing. The pet stopped before casting and maintained the channel.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Use a Warlock with a Succubus that knows Seduction.
2. Enable Seduction autocast and disable the other offensive autocasts.
3. Start a duel with a second player and place the target outside Seduction range.
4. Set the Succubus to Passive and command it to attack without manually casting Seduction.
5. Verify the pet chases, stops when it enters range, and maintains Seduction without being interrupted by movement.
6. Let the channel finish or break it with damage, then verify normal pet movement resumes.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
