### PR TITLE
fix(DB/Loot): Correct Steelbreaker 10-man hard mode loot

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1788939201810173800.sql
+++ b/data/sql/updates/pending_db_world/rev_1788939201810173800.sql
@@ -1,0 +1,2 @@
+--
+UPDATE `creature_loot_template` SET `Item` = 45455, `Comment` = 'Steelbreaker - Belt of the Crystal Tree' WHERE `Entry` = 32867 AND `Item` = 25455;


### PR DESCRIPTION
## Changes Proposed:
Steelbreaker's 10-man loot table (entry 32867) had item 25455 (Phosphorescent Globe, grey) where 45455 (Belt of the Crystal Tree) belongs. The row sits in loot group 1 with the four other hard mode epics, so every hard mode kill (Steelbreaker dying last) had a 20% chance to roll the grey item instead of the belt.

This PR fixes the item id in that row. TrinityCore's table for the same entry lists 45455 in group 1; the 25-man table (entry 33693) was already correct.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Claude Fable 5.1)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #27562

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

https://www.wowhead.com/wotlk/item=45455/belt-of-the-crystal-tree
https://www.wowhead.com/wotlk/npc=32867/steelbreaker

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Ulduar 10-man, kill the Assembly of Iron with Steelbreaker last.
2. Loot Steelbreaker repeatedly (or inspect `creature_loot_template` for entry 32867): Belt of the Crystal Tree is in the epic group and Phosphorescent Globe never drops.

## Known Issues and TODO List:

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
