### PR TITLE
fix(Scripts/Ulduar): give Flame Leviathan's Freya's Ward lashers their own targeting AI

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1788938971207265100.sql
+++ b/data/sql/updates/pending_db_world/rev_1788938971207265100.sql
@@ -1,0 +1,3 @@
+--
+DELETE FROM `smart_scripts` WHERE `entryorguid` IN (33387,34275) AND `source_type`=0;
+UPDATE `creature_template` SET `AIName`='', `ScriptName`='npc_freya_ward_summon' WHERE `entry` IN (33387,34275);

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_flame_leviathan.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_flame_leviathan.cpp
@@ -69,6 +69,7 @@ enum LeviathanSpells
     SPELL_FREYA_WARD                    = 62906, // removed spawn effect
     SPELL_MIMIRONS_INFERNO              = 62909,
     SPELL_THORIMS_HAMMER                = 62911,
+    SPELL_LASH                          = 65062,
 
     SPELL_FREYA_DUMMY_BLUE              = 63294,
     SPELL_FREYA_DUMMY_GREEN             = 63295,
@@ -126,6 +127,7 @@ enum Events
     EVENT_SOUND_BEGINNING               = 10,
     EVENT_EJECT_PLAYERS                 = 11,
     EVENT_CHECK_PLAYERS                 = 12,
+    EVENT_LASH                          = 13,
 };
 
 enum Texts
@@ -895,11 +897,9 @@ struct npc_freya_ward : public NullCreatureAI
 
     SummonList summons;
     uint32 _castTimer;
-    bool _summoned;
 
     void Reset() override
     {
-        _summoned = false;
         _castTimer = 25000;
         summons.DespawnAll();
         if (Creature* cr = me->FindNearestCreature(NPC_FREYA_WARD_TARGET, 60.0f, true))
@@ -910,32 +910,12 @@ struct npc_freya_ward : public NullCreatureAI
             }
     }
 
-    void JustSummoned(Creature* cr) override
-    {
-        _summoned = true;
-        summons.Summon(cr);
-    }
+    void JustSummoned(Creature* cr) override { summons.Summon(cr); }
 
     void SummonedCreatureDespawn(Creature* cr) override { summons.Despawn(cr); }
 
     void UpdateAI(uint32 diff) override
     {
-        if (_summoned)
-        {
-            for (SummonList::const_iterator itr = summons.begin(); itr != summons.end();)
-            {
-                Creature* summon = ObjectAccessor::GetCreature(*me, *itr);
-                ++itr;
-                if (summon)
-                {
-                    summon->ToTempSummon()->SetTempSummonType(TEMPSUMMON_MANUAL_DESPAWN);
-                    if (Unit* target = summon->SelectNearestTarget(200.0f))
-                        summon->AI()->AttackStart(target);
-                }
-            }
-            _summoned = false;
-        }
-
         _castTimer += diff;
         if (_castTimer >= 29 * IN_MILLISECONDS)
         {
@@ -953,6 +933,52 @@ struct npc_freya_ward : public NullCreatureAI
     {
         if (param == ACTION_DESPAWN_ADDS)
             summons.DespawnAll();
+    }
+};
+
+struct npc_freya_ward_summon : public ScriptedAI
+{
+    npc_freya_ward_summon(Creature* creature) : ScriptedAI(creature) { }
+
+    void Reset() override
+    {
+        events.Reset();
+    }
+
+    void IsSummonedBy(WorldObject* /*summoner*/) override
+    {
+        me->ToTempSummon()->SetTempSummonType(TEMPSUMMON_MANUAL_DESPAWN);
+        DoZoneInCombat();
+    }
+
+    void JustEngagedWith(Unit* /*who*/) override
+    {
+        events.ScheduleEvent(EVENT_LASH, 2s);
+    }
+
+    // Players thrown onto Leviathan's back and vehicles behind the closed arena gate are out of reach
+    bool CanAIAttack(Unit const* who) const override
+    {
+        if (Unit* base = who->GetVehicleBase())
+            if (base->GetEntry() == NPC_LEVIATHAN)
+                return false;
+
+        return me->IsWithinLOSInMap(who);
+    }
+
+    void UpdateAI(uint32 diff) override
+    {
+        if (!UpdateVictim())
+            return;
+
+        events.Update(diff);
+        if (events.ExecuteEvent() == EVENT_LASH)
+        {
+            DoCastVictim(SPELL_LASH);
+            events.Repeat(2s);
+        }
+
+        DoMeleeAttackIfReady();
     }
 };
 
@@ -1874,6 +1900,7 @@ void AddSC_boss_flame_leviathan()
 
     // Hard Mode
     RegisterUlduarCreatureAI(npc_freya_ward);
+    RegisterUlduarCreatureAI(npc_freya_ward_summon);
     RegisterUlduarCreatureAI(npc_thorims_hammer);
     RegisterUlduarCreatureAI(npc_mimirons_inferno);
     RegisterUlduarCreatureAI(npc_hodirs_fury);

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_flame_leviathan.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_flame_leviathan.cpp
@@ -956,10 +956,10 @@ struct npc_freya_ward_summon : public ScriptedAI
         events.ScheduleEvent(EVENT_LASH, 2s);
     }
 
-    // Players thrown onto Leviathan's back and vehicles behind the closed arena gate are out of reach
+    // Thrown players sit on a seat NPC nested in Leviathan's vehicle; vehicles behind the closed gate are out of reach
     bool CanAIAttack(Unit const* who) const override
     {
-        if (Unit* base = who->GetVehicleBase())
+        for (Unit const* base = who->GetVehicleBase(); base; base = base->GetVehicleBase())
             if (base->GetEntry() == NPC_LEVIATHAN)
                 return false;
 


### PR DESCRIPTION
## Changes Proposed:
Freya's Ward lashers (Writhing Lasher, Ward of Life) got their only target from a one-shot `SelectNearestTarget(200)` in the ward script right after the summon. That search ignores line of sight and height, so it picked players thrown on top of the Leviathan and vehicles parked behind the closed arena gate. When nothing was within 200 yards at that tick, the lashers stood idle at their spawn because they never move on their own.

The lashers now have their own script (`npc_freya_ward_summon`): they pull the zone on summon and refuse targets riding the Leviathan or out of line of sight through `CanAIAttack`. The threat manager marks references that fail `CanAIAttack` as offline, so outside vehicles never become the victim even though they end up on the threat list. Lash keeps the 2 second cadence from the removed SmartAI rows, and the manual-despawn type the ward used to set on each summon is kept.

Line of sight through the gate relies on the gate model having collision while the boss is in progress. Both gate models are M2s present in the vmaps and `CheckGameObjectLoS` is on by default; servers that turn it off lose the gate part of the fix.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Claude Fable 5.1)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #27545

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

The script name mirrors TrinityCore's `npc_freya_ward_summon`, but the mechanism is not ported from there.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:
- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Activate Tower of Life hard mode and start Flame Leviathan with a vehicle parked outside the arena gate.
2. Keep the raid at the far end of the arena when a ward summons: the lashers should engage anyway instead of standing at their spawn.
3. Throw a player on top of the Leviathan and lure it near a ward: the lashers should keep attacking vehicles and ignore the rider.
4. Check the vehicle outside the gate is never attacked.

## Known Issues and TODO List:

- [ ] The inability to release after dying on top of the Leviathan is a separate player-side problem and is not addressed here.

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
