### PR TITLE
fix(DB/Quest): Show objective marker on Zaxxis mobs

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1788943514347882000.sql
+++ b/data/sql/updates/pending_db_world/rev_1788943514347882000.sql
@@ -1,0 +1,10 @@
+--
+-- Quests 10262 and 10308 ask for Zaxxis Insignias, but the three Zaxxis mobs that drop them
+-- advertise no quest item, so the client shows no objective when you hover them. The marker
+-- comes from creature_questitem, which nothing referenced for this item.
+--
+DELETE FROM `creature_questitem` WHERE (`CreatureEntry` IN (18875, 19641, 19642)) AND (`Idx` = 0);
+INSERT INTO `creature_questitem` (`CreatureEntry`, `Idx`, `ItemId`, `VerifiedBuild`) VALUES
+(18875, 0, 29209, 0),
+(19641, 0, 29209, 0),
+(19642, 0, 29209, 0);

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -159,6 +159,7 @@ If the scenario should stay as a regression, **move** it into `suites/` next to 
 | quests/lifecycle | STAY_ALIVE fail on death; status after save/relog | P1 | covered (`TestAC_26549_*`) | #26549 |
 | quests/escort | find spawned unit; follow-NPC despawns on logout | P2 | covered (`TestAC_24450_*`) | #24450 |
 | quests/frostmourne | scrying-orb vision runs; Muradin leaves the cavern and despawns; quest 12478 COMPLETE | P2 | covered (`TestAC_25760_*`); dialogue order and duplicate line `blocked-harness` (no monster-say capture) | #25760 |
+| quests/objectives | a mob that drops a quest item advertises it, so the client shows the objective on hover (`creature_questitem` -> `SMSG_CREATURE_QUERY_RESPONSE.questItems`) | P2 | covered (`TestAC_27553_*`), decoding the response through a raw packet hook since the harness has no dispatch case for it | #27553 |
 | items/equip | visible-item slot after EquipEntry; additem; survives relog | P2 | covered | — |
 | protocol/session | pos; item/quest load; money save/relog | P1 | covered; GM vis persist `blocked-harness` (extra_flags after relog) | #25793 |
 | protocol/teleport | cross-map; named; GoCreatureID | P1 | covered | — |

--- a/e2e/suites/quests/objectives/questitem_marker_e2e_test.go
+++ b/e2e/suites/quests/objectives/questitem_marker_e2e_test.go
@@ -1,0 +1,120 @@
+//go:build e2e
+
+package objectives_test
+
+import (
+	"encoding/binary"
+	"sync"
+	"testing"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+
+	"github.com/azerothcore/AzerothGhost/e2e/e2eharness"
+	"github.com/azerothcore/azerothcore-wotlk/e2e/internal/meta"
+)
+
+// SMSG_CREATURE_QUERY_RESPONSE. The harness has no dispatch case for this opcode,
+// so the payload is read through a raw packet hook: WorldClient.handlePacket calls
+// invokePacketHooks for every opcode before its own switch, so unparsed packets are
+// still observable. Same approach as suites/spells/immunity.
+const smsgCreatureQueryResponse uint16 = 0x0061
+
+// Issue: https://github.com/azerothcore/azerothcore-wotlk/issues/27553
+//
+// Quests 10262 and 10308 ask for Zaxxis Insignia (29209). Hovering a mob that drops
+// it showed no objective, because that marker is not a server-side flag: creatures
+// have no equivalent of GameObject::ActivateToQuest, and the client learns which
+// quest items a creature carries from the questItems array in
+// SMSG_CREATURE_QUERY_RESPONSE, filled from creature_questitem.
+//
+// This asks the server for each dropping creature and asserts the insignia is among
+// the six advertised items. On unfixed data all six are zero.
+func TestAC_27553_ZaxxisMobsAdvertiseQuestItem(t *testing.T) {
+	meta.Begin(t, meta.TestMeta{
+		Tags:     []string{"short", "quests", "issue", "serial"},
+		Runtime:  "short",
+		Issue:    27553,
+		Category: "quests/objectives",
+	})
+
+	const itemZaxxisInsignia = uint32(29209)
+	mobs := []struct {
+		entry uint32
+		name  string
+	}{
+		{18875, "ZaxxisRaider"},
+		{19641, "WarpRaiderNesaad"},
+		{19642, "ZaxxisStalker"},
+	}
+
+	// CMSG_CREATURE_QUERY is STATUS_LOGGEDIN and the handler ignores the guid it is
+	// given, so the bot can ask from wherever it logs in. No travel or spawn needed.
+	bot := e2eharness.NewSolo(t, e2eharness.ScenarioOpts{Prefix: "QItem", Level: 80})
+
+	for _, m := range mobs {
+		t.Run(m.name, func(t *testing.T) {
+			items := creatureQuestItems(t, bot, m.entry)
+			for _, it := range items {
+				if it == itemZaxxisInsignia {
+					t.Logf("OK %s (%d) advertises item %d", m.name, m.entry, itemZaxxisInsignia)
+					return
+				}
+			}
+			e2eharness.Assertf(t,
+				"%s (%d) advertises %v; expected %d among them, without which the client shows no objective on hover",
+				m.name, m.entry, items, itemZaxxisInsignia)
+		})
+	}
+
+	bot.AssertWorldAlive(t)
+}
+
+// creatureQuestItems asks the server about one creature and returns the six
+// questItems slots. The response ends with questItems[6] followed by movementId,
+// so they are the last 28 bytes less that trailing uint32.
+func creatureQuestItems(t *testing.T, bot *e2eharness.ScenarioBot, entry uint32) []uint32 {
+	t.Helper()
+
+	var (
+		mu   sync.Mutex
+		got  []uint32
+		once sync.Once
+	)
+	done := make(chan struct{})
+
+	cancel := bot.World.AddPacketHook(func(opcode uint16, data []byte) {
+		// A creature the server does not know answers with entry|0x80000000 and no
+		// body, which the length check drops.
+		if opcode != smsgCreatureQueryResponse || len(data) < 32 {
+			return
+		}
+		if binary.LittleEndian.Uint32(data[:4]) != entry {
+			return
+		}
+		tail := data[len(data)-28:]
+		out := make([]uint32, 6)
+		for i := range out {
+			out[i] = binary.LittleEndian.Uint32(tail[i*4 : i*4+4])
+		}
+		mu.Lock()
+		got = out
+		mu.Unlock()
+		once.Do(func() { close(done) })
+	})
+	defer cancel()
+
+	if err := bot.World.CreatureQuery(entry, 0); err != nil {
+		e2eharness.HarnessFailf(t, "CreatureQuery(%d): %v", entry, err)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(15 * time.Second):
+		e2eharness.HarnessFailf(t, "no creature query response for entry %d within 15s", entry)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	return got
+}


### PR DESCRIPTION
## Changes Proposed:
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

The three creatures that drop the insignia now list it. Because the table maps a creature to an
item rather than to a quest, and both quests ask for the same item, this also fixes **10308**
*Another Heap of Ethereals*. 

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Opus 5 via Claude Code. It produced the SQL, the e2e test and this description. I confirmed the fix in game myself and checked the expected behaviour against public sources. The `/self-review` report is posted as a comment below.
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #27553

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

https://www.wowhead.com/tbc/quest=10262/a-heap-of-ethereals confirms the objective and the mobs it comes from 10 Zaxxis Insignias returned to Nether-Stalker Khay'ji, sourced from Zaxxis
Raider, Zaxxis Stalker and Warp-Raider Nesaad. That matches `creature_loot_template` exactly and is what fixes the scope at three creatures.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Confirmed on a local 3.3.5a worldserver: on quest 10262 the objective now appears when hovering the Zaxxis mobs.

<img width="1457" height="939" alt="Screenshot 2026-09-09 at 11 25 39" src="https://github.com/user-attachments/assets/feebe84e-589a-4309-95a7-a54aae6cf763" />

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

```
.quest add 10262
.go creature id 18875
```

Hover the mob; the objective should appear in the tooltip. Same for 19641 and 19642, and for
quest 10308. Clear the client `Cache/` folder beforehand if you have already visited this zone.

## Known Issues and TODO List:

- [ ]
- [ ]

## How to Test AzerothCore PRs

When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
