### PR TITLE
fix(Scripts/Ulduar): Use Thorim Sif's 10-man spell ids

### DIFF
--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_thorim.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_thorim.cpp
@@ -53,10 +53,10 @@ enum ThorimSpells
     SPELL_TOUCH_OF_DOMINION                 = 62507,
     SPELL_SIF_TRANSFORM                     = 64778,
     SPELL_SIF_CHANNEL_HOLOGRAM              = 64324,
-    SPELL_FROSTBOLT                         = 62601,
-    SPELL_FROSTBOLT_VALLEY                  = 62604,
+    SPELL_FROSTBOLT                         = 62583,
+    SPELL_FROSTBOLT_VALLEY                  = 62580,
     SPELL_BLIZZARD                          = 62577,
-    SPELL_FROST_NOVA                        = 62605,
+    SPELL_FROST_NOVA                        = 62597,
 
     // DARK RUNE ACOLYTE
     SPELL_GREATER_HEAL                      = 62334,


### PR DESCRIPTION
## Changes Proposed:

Sif's Frostbolt, Frostbolt Volley and Frost Nova were declared with the 25-man spell ids:

```cpp
SPELL_FROSTBOLT                         = 62601,
SPELL_FROSTBOLT_VALLEY                  = 62604,
SPELL_BLIZZARD                          = 62577,
SPELL_FROST_NOVA                        = 62605,
```

Every cast goes through `SpellMgr::GetSpellForDifficultyFromSpell` (from the `Spell` constructor), which looks the id up in `SpellDifficulty.dbc` as `spellid0` and swaps in `spellid1` on 25-man. The relevant rows are:

| id / 10-man | 25-man | spell |
| --- | --- | --- |
| 62577 | 62603 | Blizzard |
| 62580 | 62604 | Frostbolt Volley |
| 62583 | 62601 | Frostbolt |
| 62597 | 62605 | Frost Nova |

62601, 62604 and 62605 only ever appear in the right-hand column, never as a row id, so `GetSpellDifficultyId` returns 0 and the spell is cast unchanged. 10-man hard mode was getting the 25-man versions, and 25-man happened to land on the correct ones only because no remap took place.

This declares the 10-man base ids and lets the difficulty lookup pick the 25-man variants, which is what `SPELL_BLIZZARD` in the same enum already does correctly.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Opus 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:

None, reported on Discord.

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

The base/25-man pairing comes from the client's own `SpellDifficulty.dbc`, quoted in the table above. TrinityCore uses the same four base ids in [boss_thorim.cpp](https://github.com/TrinityCore/TrinityCore/blob/3.3.5/src/server/scripts/Northrend/Ulduar/Ulduar/boss_thorim.cpp#L69-L73) and documents the pairing in a comment above its volley script (`// 62580, 62604 - Frostbolt Volley`). It is not a cherry-pick: TC never had the 25-man ids there, so there is no upstream commit to credit.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

Sif only casts after she joins the fight, so this needs the hard mode. On both raid sizes:

1. Enter Ulduar and start Thorim.
2. Clear the gauntlet fast enough to reach Thorim before Sif finishes Touch of Dominion, so she joins the fight.
3. Watch her casts in the combat log or with spell debug logging.
4. On 10-man expect Frostbolt 62583, Frostbolt Volley 62580, Frost Nova 62597, Blizzard 62577.
5. On 25-man expect Frostbolt 62601, Frostbolt Volley 62604, Frost Nova 62605, Blizzard 62603.

Normal mode is unaffected: Sif casts nothing there beyond Touch of Dominion.

## Known Issues and TODO List:

- [ ] The enum entry is spelled `SPELL_FROSTBOLT_VALLEY` (and `EVENT_SIF_FROSTBOLT_VALLEY`); the spell is Frostbolt Volley. Left alone here to keep the diff to the ids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
