### PR TITLE
fix(Shared/DBC): keep DBC string when DB override column is empty

### DIFF
--- a/src/server/shared/DataStores/DBCDatabaseLoader.cpp
+++ b/src/server/shared/DataStores/DBCDatabaseLoader.cpp
@@ -74,11 +74,11 @@ char* DBCDatabaseLoader::Load(uint32& records, char**& indexTable)
     {
         Field* fields = result->Fetch();
         uint32 indexValue = fields[_sqlIndexPos].Get<uint32>();
-        char* dataValue = indexTable[indexValue];
+        char* oldDataValue = indexTable[indexValue];
 
         // If exist in DBC file override from DB
         newIndexes[newRecords] = indexValue;
-        dataValue = &dataTable[newRecords++ * _recordSize];
+        char* dataValue = &dataTable[newRecords++ * _recordSize];
 
         uint32 dataOffset = 0;
         uint32 sqlColumnNumber = 0;
@@ -102,7 +102,15 @@ char* DBCDatabaseLoader::Load(uint32& records, char**& indexTable)
                     dataOffset += sizeof(uint8);
                     break;
                 case FT_STRING:
-                    *reinterpret_cast<char**>(&dataValue[dataOffset]) = CloneStringToPool(fields[sqlColumnNumber].Get<std::string>());
+                    // not override string if new string is empty
+                    if (fields[sqlColumnNumber].Get<std::string>().empty() && oldDataValue)
+                    {
+                        *reinterpret_cast<char**>(&dataValue[dataOffset]) = *reinterpret_cast<char**>(&oldDataValue[dataOffset]);
+                    }
+                    else
+                    {
+                        *reinterpret_cast<char**>(&dataValue[dataOffset]) = CloneStringToPool(fields[sqlColumnNumber].Get<std::string>());
+                    }
                     dataOffset += sizeof(char*);
                     break;
                 case FT_SORT:

--- a/src/server/shared/DataStores/DBCDatabaseLoader.cpp
+++ b/src/server/shared/DataStores/DBCDatabaseLoader.cpp
@@ -104,13 +104,9 @@ char* DBCDatabaseLoader::Load(uint32& records, char**& indexTable)
                 case FT_STRING:
                     // not override string if new string is empty
                     if (fields[sqlColumnNumber].Get<std::string>().empty() && oldDataValue)
-                    {
                         *reinterpret_cast<char**>(&dataValue[dataOffset]) = *reinterpret_cast<char**>(&oldDataValue[dataOffset]);
-                    }
                     else
-                    {
                         *reinterpret_cast<char**>(&dataValue[dataOffset]) = CloneStringToPool(fields[sqlColumnNumber].Get<std::string>());
-                    }
                     dataOffset += sizeof(char*);
                     break;
                 case FT_SORT:

--- a/src/server/shared/DataStores/DBCDatabaseLoader.cpp
+++ b/src/server/shared/DataStores/DBCDatabaseLoader.cpp
@@ -107,6 +107,7 @@ char* DBCDatabaseLoader::Load(uint32& records, char**& indexTable)
                         *reinterpret_cast<char**>(&dataValue[dataOffset]) = *reinterpret_cast<char**>(&oldDataValue[dataOffset]);
                     else
                         *reinterpret_cast<char**>(&dataValue[dataOffset]) = CloneStringToPool(fields[sqlColumnNumber].Get<std::string>());
+
                     dataOffset += sizeof(char*);
                     break;
                 case FT_SORT:

--- a/src/server/shared/DataStores/DBCDatabaseLoader.cpp
+++ b/src/server/shared/DataStores/DBCDatabaseLoader.cpp
@@ -102,7 +102,7 @@ char* DBCDatabaseLoader::Load(uint32& records, char**& indexTable)
                     dataOffset += sizeof(uint8);
                     break;
                 case FT_STRING:
-                    // not override string if new string is empty
+                    // an empty column means "not overridden", not "blank it"
                     if (fields[sqlColumnNumber].Get<std::string>().empty() && oldDataValue)
                         *reinterpret_cast<char**>(&dataValue[dataOffset]) = *reinterpret_cast<char**>(&oldDataValue[dataOffset]);
                     else


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

The fix keeps the original DBC string when the DB value is empty.

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used:
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**
Playerbots 

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1.
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
