### PR TITLE
fix(Scripts/Ulduar): Respawn Hodir's Rare Cache with the boss

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1788994723018782200.sql
+++ b/data/sql/updates/pending_db_world/rev_1788994723018782200.sql
@@ -1,0 +1,2 @@
+-- Hodir despawns on evade and respawns with his helpers; boss_hodir restores the shattered Rare Cache at that point
+UPDATE `creature_template` SET `flags_extra` = `flags_extra` | 0x80000000 WHERE `entry` IN (32845, 32846);

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_hodir.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_hodir.cpp
@@ -256,6 +256,13 @@ struct boss_hodir : public BossAI
             SpawnHelpers();
     }
 
+    // CREATURE_FLAG_EXTRA_HARD_RESET despawns Hodir on evade, so a wiped attempt ends with him
+    // respawning: the point at which a Rare Cache shattered on that attempt comes back too.
+    void JustRespawned() override
+    {
+        instance->SetData(TYPE_HODIR_HM_RESET, 0);
+    }
+
     void JustEngagedWith(Unit*  /*who*/) override
     {
         me->CastSpell(me, SPELL_BITING_COLD_BOSS_AURA, true);

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/instance_ulduar.cpp
@@ -878,6 +878,19 @@ public:
             }
         }
 
+        // A shattered Rare Cache stays down for the DB respawn delay (7 days), so it has to be
+        // brought back with Hodir or the next attempt can never earn it.
+        void respawnHodirHardmodeChest()
+        {
+            if (GetBossState(BOSS_HODIR) == DONE)
+                return;
+
+            _hmHodir = true;
+
+            if (GameObject* go = GetHodirChest(true))
+                go->Respawn();
+        }
+
         void setChestsLootable(uint32 boss)
         {
             if (boss)
@@ -907,6 +920,9 @@ public:
         {
             switch (type)
             {
+                case TYPE_HODIR_HM_RESET:
+                    respawnHodirHardmodeChest();
+                    break;
                 case TYPE_HODIR_HM_FAIL:
                     if (GameObject* go = GetHodirChest(true))
                     {

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/ulduar.h
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/ulduar.h
@@ -51,6 +51,7 @@ enum UlduarData
     TYPE_WATCHERS                           = 14,
     TYPE_HODIR_HM_FAIL                      = 15,
     TYPE_WINTER_CACHE                       = 16,
+    TYPE_HODIR_HM_RESET                     = 17,
 
     // Assembly of Iron
     DATA_STEELBREAKER                       = 20,


### PR DESCRIPTION
## Changes Proposed:

Failing Hodir's hard mode timer shatters the Rare Cache of Winter, and the instance script despawns it with a 7 day respawn. Nothing ever brings it back, so a raid that wipes after the shatter finds the boss up again with no cache, and hard mode is unwinnable for the rest of the lockout. `_hmHodir` is also latched to `false` and never restored, so even a later success would not be credited.

A sniff of the encounter shows retail despawning the whole thing on a wipe and recreating it as one set 29 seconds later: Hodir, both helper sets, the eight Flash Freeze blocks and both caches, all in a single `SMSG_UPDATE_OBJECT` batch with fresh GUIDs. AzerothCore instead has Hodir evade in place.

This PR gives Hodir `CREATURE_FLAG_EXTRA_HARD_RESET` so he despawns on evade and returns 20 seconds later, and restores the Rare Cache at the moment he respawns. Doing it on the respawn rather than on the evade also settles an ordering problem: the shatter schedules its despawn 3 seconds after the animation, and nothing cancels it, so restoring the cache at evade time would let that leftover task fire afterwards and strand the cache again. Restoring it with the boss puts the restore after the despawn instead of racing it.

The flag is set on both difficulty entries to match how Auriaya, Thorim and Kologarn are stored, though the engine only ever reads the base entry.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Opus 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:

None, reported in-game.

## SOURCE:

The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [x] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:

This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Pull Hodir and let the hard mode timer expire. He emotes and the Rare Cache of Winter shatters.
2. Wipe. Hodir despawns along with his helpers and their Flash Freeze blocks, and everything returns about 20 seconds later.
3. Confirm the Rare Cache is back, closed and not selectable.
4. Re-engage and beat the timer. The Rare Cache should be lootable.
5. Regression: wipe without failing the timer, and confirm the helpers and Flash Freeze blocks all come back cleanly after the despawn gap.
6. Regression: fail the timer and then kill Hodir. The Rare Cache must stay gone and only the normal Cache of Winter should be lootable.
7. Both raid sizes.

## Known Issues and TODO List:

- [ ] Killing Hodir within 3 seconds of the shatter skips the despawn while the hard mode flag is still set, so the Rare Cache unlocks despite the failed timer. Pre-existing and untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
