### PR TITLE
docs(agents): set flags_extra on every difficulty entry

### DIFF
--- a/.agents/docs/sql-guidelines.md
+++ b/.agents/docs/sql-guidelines.md
@@ -10,6 +10,7 @@ Run the linter before claiming a change is done: `python apps/codestyle/codestyl
 
 ## Data conventions
 
+- Set `flags_extra` on every `difficulty_entry_*` template, not just the base entry: which of the two the engine reads varies by call site.
 - `smart_scripts` edits always rewrite the full block — `DELETE` + `INSERT` of every row for the `(entryorguid, source_type)` pair, with the `DELETE` matching both columns — never a partial `UPDATE`, not even for a comment-only fix.
 - Sniff-backed changes stamp `VerifiedBuild` (the sniff's client build) on every row the sniff validated, including rows the fix doesn't otherwise touch.
 - `creature_immunities`: negative ids are curated shared sets — reference them via `creature_template.CreatureImmunitiesId`, never edit them or allocate new ones. Positive ids are single-creature sets — reuse an existing set only on an exact match; to extend a creature's immunities, insert a superset under a new id and point the creature's `CreatureImmunitiesId` at it.


### PR DESCRIPTION
## Changes Proposed:

Adds one line to `.agents/docs/sql-guidelines.md` telling agents to set `flags_extra` on every `difficulty_entry_*` template rather than only the base entry.

Whether the engine reads a creature's base template or its difficulty one depends on the call site: `Creature::InitEntry` keeps `GetEntry()` on the base entry ("normal entry always") while `GetCreatureTemplate()` returns the swapped difficulty template. Setting the flag on only one of them leaves behaviour dependent on which path happens to run, and the difference is invisible in the data.

The existing data mostly reflects this already: Auriaya (`2026_06_15_00.sql`), Thorim (`2026_08_09_01.sql`) and Kologarn (`2026_08_25_00.sql`, commented "also add 2147483648 HARD_RESET to sync with 10m") all set both entries. Freya's 25-man entry 33360 is the outlier that never got synced. Writing the rule down keeps it from being re-derived per PR.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Documentation only, no code or data changes.

### AI-assisted Pull Requests

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Opus 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:

None.

## SOURCE:

The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Existing `data/sql/updates/db_world/` revisions and `Creature::InitEntry`.

## Tests Performed:

Documentation only, nothing to run.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

## Known Issues and TODO List:

- [ ] Freya's 25-man entry 33360 still lacks `HARD_RESET` where the 10-man entry 32906 has it. Not touched here, since this PR is documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
