### PR TITLE
fix(Scripts/Ulduar): stop XT-002 summoning adds after death

### DIFF
--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_xt002.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_xt002.cpp
@@ -744,7 +744,9 @@ class spell_xt002_searing_light_spawn_life_spark : public AuraScript
     {
         if (Player* player = GetOwner()->ToPlayer())
             if (Unit* xt002 = GetCaster())
-                if (xt002->HasAura(aurEff->GetAmount()))   // Heartbreak aura indicating hard mode
+                // Heartbreak indicates hard mode; it is death-persistent, so the alive check keeps a
+                // debuff outliving the kill from summoning off the corpse
+                if (xt002->IsAlive() && xt002->HasAura(aurEff->GetAmount()))
                     xt002->CastSpell(player, SPELL_SUMMON_LIFE_SPARK, true);
     }
 
@@ -768,7 +770,9 @@ class spell_xt002_gravity_bomb_aura : public AuraScript
     {
         if (Player* player = GetOwner()->ToPlayer())
             if (Unit* xt002 = GetCaster())
-                if (xt002->HasAura(aurEff->GetAmount()))   // Heartbreak aura indicating hard mode
+                // Heartbreak indicates hard mode; it is death-persistent, so the alive check keeps a
+                // debuff outliving the kill from summoning off the corpse
+                if (xt002->IsAlive() && xt002->HasAura(aurEff->GetAmount()))
                     xt002->CastSpell(player, SPELL_SUMMON_VOID_ZONE, true);
     }
 

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_xt002.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_xt002.cpp
@@ -744,8 +744,7 @@ class spell_xt002_searing_light_spawn_life_spark : public AuraScript
     {
         if (Player* player = GetOwner()->ToPlayer())
             if (Unit* xt002 = GetCaster())
-                // Heartbreak indicates hard mode; it is death-persistent, so the alive check keeps a
-                // debuff outliving the kill from summoning off the corpse
+                // Heartbreak (hard mode) is death-persistent, so without this a corpse still summons
                 if (xt002->IsAlive() && xt002->HasAura(aurEff->GetAmount()))
                     xt002->CastSpell(player, SPELL_SUMMON_LIFE_SPARK, true);
     }
@@ -770,8 +769,7 @@ class spell_xt002_gravity_bomb_aura : public AuraScript
     {
         if (Player* player = GetOwner()->ToPlayer())
             if (Unit* xt002 = GetCaster())
-                // Heartbreak indicates hard mode; it is death-persistent, so the alive check keeps a
-                // debuff outliving the kill from summoning off the corpse
+                // Heartbreak (hard mode) is death-persistent, so without this a corpse still summons
                 if (xt002->IsAlive() && xt002->HasAura(aurEff->GetAmount()))
                     xt002->CastSpell(player, SPELL_SUMMON_VOID_ZONE, true);
     }


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

In hard mode, Gravity Bomb and Searing Light summon a Void Zone / Life Spark from `AfterEffectRemove`, gated on XT-002 having Heartbreak. Nothing checks that he is still alive, and every step of that chain survives his death:

- The player debuff is not removed when its caster dies, so it keeps ticking for up to 9s after the kill.
- Heartbreak (65737 / 64193) has `SPELL_ATTR3_ALLOW_AURA_WHILE_DEAD`, and `Unit::RemoveAllAurasOnDeath` deliberately keeps death-persistent auras, so `HasAura` is still true on the corpse.
- The summon is a triggered cast, and `Spell::CheckCast` waives `SPELL_FAILED_CASTER_DEAD` for triggered casts with no `m_triggeredByAuraSpell`.

The add is then summoned *after* `BossAI::_JustDied` ran `summons.DespawnAll()`, and the boss state is already `DONE`, so nothing despawns it again. A Void Zone summoned this way pulses Consumption (~900 AoE damage per second) for its full 3 minute lifetime, which is what keeps the raid in combat and locks them out of the teleporter. The Searing Light path is worse but has not been reported: it drops an aggressive Life Spark on the raid after the boss is dead.

Fix is an `IsAlive()` guard on both handlers. The evade path is already safe, since `CreatureAI::_EnterEvadeMode` calls `RemoveEvadeAuras()` and strips Heartbreak.

TrinityCore's 3.3.5 branch carries the same code and the same bug, so this is not a cherry-pick.

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Opus 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #27576

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

https://youtu.be/SyQEeDRo4sI?t=514

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

Note that the linked issue's repro steps are missing a step: the summons are gated on Heartbreak, so the encounter has to be in hard mode.

1. `.tele xt`, pull XT-002 and kill the heart when it opens to enter hard mode.
2. Wait for someone to get Gravity Bomb, then `.damage` XT-002 down while the debuff is still on them. No Void Zone should appear after he dies, and the raid should drop combat.
3. Repeat with Searing Light up instead. No Life Spark should appear after the kill.
4. Regression check, still in hard mode: let both debuffs expire normally on a living XT-002 and confirm the Void Zone and Life Spark still spawn, and that the ones alive at the moment of the kill are despawned with the rest of the summons.
5. Regression check, normal mode: no summons from either debuff, before or after the kill.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
