### PR TITLE
fix(Core/Creature): Keep a spell's own recovery time on category cooldowns

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -3009,27 +3009,47 @@ void Creature::AddSpellCooldown(uint32 spell_id, uint32 /*itemid*/, uint32 end_t
     }
 
     SpellCategoryStore::const_iterator i_scstore = sSpellsByCategoryStore.find(categoryId);
-    if (categorycooldown && i_scstore != sSpellsByCategoryStore.end())
+    bool const hasCategoryCooldown = categorycooldown && i_scstore != sSpellsByCategoryStore.end();
+    if (hasCategoryCooldown)
     {
-        for (SpellCategorySet::const_iterator i_scset = i_scstore->second.begin(); i_scset != i_scstore->second.end(); ++i_scset)
+        for (auto const& [itemBased, categorySpellId] : i_scstore->second)
         {
-            _AddCreatureSpellCooldown(i_scset->second, categoryId, categorycooldown);
+            // A longer cooldown still running on a category spell is never shortened
+            if (GetSpellCooldown(categorySpellId) > categorycooldown)
+                continue;
+
+            _AddCreatureSpellCooldown(categorySpellId, categoryId, categorycooldown);
         }
-    }
-    else if (spellcooldown)
-    {
-        _AddCreatureSpellCooldown(spellInfo->Id, 0, spellcooldown);
     }
 
-    if (sSpellMgr->HasSpellCooldownOverride(spellInfo->Id))
+    // The cast spell keeps its own recovery time when it outlasts the category cooldown
+    if (spellcooldown > categorycooldown)
+        _AddCreatureSpellCooldown(spellInfo->Id, 0, spellcooldown);
+
+    // The controlling player only learns creature cooldowns from us, category spells included
+    Player* player = GetCharmerOrOwnerPlayerOrPlayerItself();
+    if (!player)
+        return;
+
+    PacketCooldowns cooldowns;
+    if (hasCategoryCooldown)
     {
-        if (IsCharmed() && GetCharmer()->IsPlayer())
+        for (auto const& [itemBased, categorySpellId] : i_scstore->second)
         {
-            WorldPacket data;
-            BuildCooldownPacket(data, SPELL_COOLDOWN_FLAG_NONE, spellInfo->Id, spellcooldown);
-            GetCharmer()->ToPlayer()->SendDirectMessage(&data);
+            if (HasSpell(categorySpellId))
+                cooldowns[categorySpellId] = GetSpellCooldown(categorySpellId);
         }
     }
+
+    if (uint32 remaining = GetSpellCooldown(spellInfo->Id))
+        cooldowns[spellInfo->Id] = remaining;
+
+    if (cooldowns.empty())
+        return;
+
+    WorldPacket data;
+    BuildCooldownPacket(data, SPELL_COOLDOWN_FLAG_NONE, cooldowns);
+    player->SendDirectMessage(&data);
 }
 
 uint32 Creature::GetSpellCooldown(uint32 spell_id) const


### PR DESCRIPTION
## Changes Proposed:
Argent Tournament mount Charge (62960) has a 4.5s recovery time but shares category 1244 (1.5s) with Defend and Shield-Breaker. `Creature::AddSpellCooldown` applied only the category cooldown to the cast spell, so the vehicle accepted a new Charge after 1.5s, and the rider's client was never told the real cooldown.

- The cast spell keeps its own recovery time when it outlasts the category cooldown. Other spells in the category still get the category cooldown.
- A category cast never shortens a longer cooldown still running on another spell of that category: Defend cast 2s after Charge leaves Charge's remaining 2.5s alone.
- The creature now reports its cooldowns to the controlling player after every cast, the cast spell and its category spells alike, each with its actual remaining time. This is what the client needs to show 4.5s on Charge and 1.5s on Defend / Shield-Breaker, and it replaces the `spell_cooldown_overrides` packet that only fired for spells with an override row. Approach by @sogladev, who implemented the vehicle cooldowns.
- Scripted NPC callers of this function either pass an explicit cooldown or have no controlling player, so they store the same cooldown as before and send nothing. AI casts never add creature cooldowns, so scripted rotations are untouched.

Review guide: everything is in `Creature::AddSpellCooldown`. The self entry is stored with category 0, which `VehicleSpellInitialize` and the pet save path read to decide spell vs category cooldown.

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Claude Fable 5.1)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Fixes https://github.com/chromiecraft/chromiecraft/issues/10145

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Spell.dbc: 62960 RecoveryTime 4500, CategoryRecoveryTime 1500, category 1244. Tooltip: https://wowgaming.altervista.org/aowow/?spell=62960. Reference footage: https://youtu.be/J7pelw9t20I&t=107

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Also verified on a live stack with a protocol-level test: after Charge the vehicle sends SMSG_SPELL_COOLDOWN with Charge 4500ms and Defend / Shield-Breaker 1500ms; Defend 1.8s later is accepted and its cooldown packet still reports Charge at about 2700ms; Charge at 3.6s is rejected with NOT_READY; Charge at 5.2s is past the cooldown. On master the recast passed the cooldown gate after 1.5s.

## How to Test the Changes:
- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Mount an Argent Tournament aspirant steed with a lance equipped and Charge a dummy: Charge shows 4.5s, Defend and Shield-Breaker show 1.5s, and the mount refuses a second Charge before 4.5s.
2. Charge, then Defend right after the 1.5s: Charge keeps its remaining cooldown instead of dropping to 1.5s.
3. Defend (62552, 3s / category 1.5s) is now enforced at 3s server-side too. The client already showed 3s, confirm nothing changed visibly.
4. Pets: abilities that have both a spell and a category cooldown now respect the longer one, and the owner's client receives the cooldown after each cast.

## Known Issues and TODO List:

- [ ] `SpellMgr::LoadSpellInfoCorrections` never applies the StartRecoveryTime / StartRecoveryCategory `spell_cooldown_overrides` columns (copy-paste assigns RecoveryTime). Unrelated to this PR, separate fix.
- [ ] With the creature now reporting every cooldown to its controlling player, the `_requireCooldownInfo` branch in `Spell::SendSpellCooldown` (hardcoded for 57493 and 7769 in SpellMgr) sends a second packet for the same spell that differs only in the INCLUDE_GCD flag. A follow-up should decide whether the new send needs that flag before removing the branch.

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
