### PR TITLE
fix(DB/Ulduar): award Stokin' the Furnace on Ignis kill

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1789074965957828800.sql
+++ b/data/sql/updates/pending_db_world/rev_1789074965957828800.sql
@@ -1,0 +1,4 @@
+--
+-- Stokin' the Furnace: move achievement_heartbreaker from criteria 10072/10073 to Heartbreaker 10220/10221
+UPDATE `achievement_criteria_data` SET `criteria_id` = 10220 WHERE (`criteria_id` = 10072) AND (`type` = 11) AND (`value1` = 0) AND (`value2` = 0) AND (`ScriptName` = 'achievement_heartbreaker');
+UPDATE `achievement_criteria_data` SET `criteria_id` = 10221 WHERE (`criteria_id` = 10073) AND (`type` = 11) AND (`value1` = 0) AND (`value2` = 0) AND (`ScriptName` = 'achievement_heartbreaker');

--- a/data/sql/updates/pending_db_world/rev_1789074965957828800.sql
+++ b/data/sql/updates/pending_db_world/rev_1789074965957828800.sql
@@ -1,4 +1,6 @@
 --
 -- Stokin' the Furnace: move achievement_heartbreaker from criteria 10072/10073 to Heartbreaker 10220/10221
-UPDATE `achievement_criteria_data` SET `criteria_id` = 10220 WHERE (`criteria_id` = 10072) AND (`type` = 11) AND (`value1` = 0) AND (`value2` = 0) AND (`ScriptName` = 'achievement_heartbreaker');
-UPDATE `achievement_criteria_data` SET `criteria_id` = 10221 WHERE (`criteria_id` = 10073) AND (`type` = 11) AND (`value1` = 0) AND (`value2` = 0) AND (`ScriptName` = 'achievement_heartbreaker');
+DELETE FROM `achievement_criteria_data` WHERE `criteria_id` IN (10072, 10073, 10220, 10221) AND `type` = 11;
+INSERT INTO `achievement_criteria_data` (`criteria_id`, `type`, `value1`, `value2`, `ScriptName`) VALUES
+(10220, 11, 0, 0, 'achievement_heartbreaker'),
+(10221, 11, 0, 0, 'achievement_heartbreaker');


### PR DESCRIPTION
## Changes Proposed:
"Stokin' the Furnace" (kill Ignis within 4 minutes, 10 and 25 player) was never awarded. The XT-002 rework in #26345 added `achievement_heartbreaker` rows to `achievement_criteria_data`, but on criteria 10072/10073, which per the client DBC belong to Stokin' the Furnace. Heartbreaker's criteria are 10220 (25 player) and 10221 (10 player). The script checks the killed boss for XT-002 hard mode, which Ignis never reports, so the Ignis criteria could never complete.

This deletes the type 11 rows on all four criteria and inserts the two Heartbreaker ones, so it also applies cleanly on a server that already added the 10220/10221 rows by hand. Deleting the rows without re-adding them would leave the `achievement_heartbreaker` script with no DB row, and the worldserver logs an unassigned-script error at startup. The Ignis timer in `boss_ignis.cpp` already works and isn't touched.

Heartbreaker keeps its existing Heartbreak aura rows, so after this it's gated by both the script row and the aura row. The script placement matches TrinityCore, which gates Heartbreaker with the script row alone (types 11 and 12 on 10220/10221); the aura rows on top are an AC-specific extra. They flip together when XT-002 enters hard mode, so nothing changes in play.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Claude Opus 5, Claude Fable 5.1)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #27577

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Criteria to achievement mapping read from the 3.3.5a `Achievement.dbc` and `Achievement_Criteria.dbc`. TrinityCore's SQL linked above has the same 10220/10221 wiring.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Tested in-game with GM mode off: Ignis 25 player killed after more than 4 minutes gives nothing, killed within 4 minutes gives the 25 player achievement, same on 10 player. XT-002 normal kill gives no Heartbreaker, hard mode kill (heart destroyed) does. The SQL applies twice without errors or duplicate rows, and the worldserver starts without the unassigned-script error. Also applied against a DB that already had the 10220/10221 script rows plus the old 10072/10073 ones, twice, same end state and no errors.

## How to Test the Changes:
- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. `.gm off`, set raid difficulty to 25 player, `.tele ignis`
2. Pull Ignis and kill him within 4 minutes (`.damage 5000000` works)
3. "Stokin' the Furnace (25 player)" should pop. Same on 10 player.
4. Optional: kill XT-002 in hard mode (destroy the heart first), Heartbreaker should still be awarded, and not on a normal kill.

## Known Issues and TODO List:

- Players who killed Ignis in time since #26345 landed don't get the achievement retroactively.


# Self-review: fix/ignis-stokin-furnace-27577 → master

**Outcome** 1 finding, dismissed. Round 1 clean otherwise.

**Reviewed** `cf98473fd` (`fix/ignis-stokin-furnace-27577` vs `origin/master`, merge-base `c9a5efc49` diff: 1 file, +4 -0)

**By** Claude Code (desktop app), claude-fable-5-1. self-review v0.8, 2026-09-10

**Tested in-game by the author** (local server on the reviewed commit, GM mode off): Ignis 25-man killed after more than 4 minutes: no achievement. Ignis 25-man killed within 4 minutes: "Stokin' the Furnace (25 player)" awarded. Ignis 10-man killed within 4 minutes: "Stokin' the Furnace (10 player)" awarded. XT-002 normal kill: no Heartbreaker. XT-002 hard mode (heart destroyed): Heartbreaker awarded. SQL linter passes. Worldserver applies the pending file cleanly and logs no "not assigned in the database" error.

**Not tested:** Heartbreaker on the other raid size than the one used above, and the 10-man Ignis kill slower than 4 minutes.

<details>
<summary>Review details (1 round)</summary>

**Intent** Fix the Ulduar achievements "Stokin' the Furnace" 2929 (25 player) and 2930 (10 player), never awarded when Ignis is killed within 4 minutes, by moving the `achievement_criteria_data` script rows `achievement_heartbreaker` off criteria 10072/10073 onto the XT-002 Heartbreaker criteria 10220/10221, SQL only.

**Project rules** `.agents/docs/self-review-rules.md` found and applied (pinned review: satisfied, clean tree; SQL side-effect check and upstream attribution judgement below; in-game testing recorded above). `.agents/docs/code-review.md` applied on top.

**Diff** `623947a85a59548bf43c183ae78b8d9b6dbb4cad`

**Metadata** `478347aafd6b0515ca3104b7371157f2d2c7d561`

Reviewer verified: DBC criteria mapping (10072/10073 = Ignis 33118 timed 240s, 10220/10221 = XT-002 33293), the failing `GetData(DATA_HARD_MODE)` check on Ignis, origin of the bad rows in `2026_07_04_03.sql` (PR 26345), full-column WHERE clauses matching exactly two rows, re-runnability, no `(criteria_id, type)` collision, no other pending file touching these criteria, change still needed on current master, formatting (LF, trailing newline, no em-dashes), and the commit message against the repo convention. Upstream attribution: not a mirror, no `--author` needed. The script name and mechanism were already imported by PR 26345 and the correct ids follow from the client DBC alone; TrinityCore's `2011_06_10_02_world_misc.sql` only corroborates the end state.

## Round 1: `cf98473fd`, 1 finding

1. `data/sql/updates/pending_db_world/rev_1789074965957828800.sql:3-4`: the moved type 11 script row on 10220/10221 duplicates the gating of the existing type 7 Heartbreak aura row (both flip in `EVENT_ENTER_HARD_MODE`, ANDed by `Meets`), so a future breakage of either row would silently block Heartbreaker → **dismissed**: out of scope. No player-facing effect (Heartbreak 65737/64193 has no duration, so the rows cannot disagree at kill time); deleting the rows without dropping the C++ class logs a startup error every boot, and dropping the class is a C++ change reversing part of PR 26345. The move matches TrinityCore's wiring.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

