### PR TITLE
fix(Scripts/MagtheridonsLair): anchor the release countdown to the Channeler pull

### DIFF
--- a/src/server/scripts/Outland/HellfireCitadel/MagtheridonsLair/boss_magtheridon.cpp
+++ b/src/server/scripts/Outland/HellfireCitadel/MagtheridonsLair/boss_magtheridon.cpp
@@ -72,22 +72,25 @@ enum Groups
 
 struct boss_magtheridon : public BossAI
 {
-    boss_magtheridon(Creature* creature) : BossAI(creature, DATA_MAGTHERIDON)
+    boss_magtheridon(Creature* creature) : BossAI(creature, DATA_MAGTHERIDON),
+        _castingQuake(false), _magReleased(false), _currentPhase(0)
     {    }
 
     void Reset() override
     {
-        BossAI::Reset();
+        // State first: BossAI::Reset() calls back into this AI through the instance.
         _currentPhase = 0;
         _castingQuake = false;
         _magReleased = false;
+
+        BossAI::Reset();
         _interruptScheduler.CancelAll();
         scheduler.Schedule(90s, [this](TaskContext context)
         {
-            if (!me->IsEngaged())
-            {
+            // Engaged from the Channeler pull, so key the idle taunt on the release, not on combat.
+            if (!_magReleased)
                 Talk(SAY_TAUNT);
-            }
+
             context.Repeat(90s);
         });
         DoCastSelf(SPELL_SHADOW_CAGE, true);
@@ -175,27 +178,31 @@ struct boss_magtheridon : public BossAI
         });
     }
 
-    void DoAction(int32 action) override
+    // Both release paths land here: the 2 minute timer and the last Channeler dying.
+    void ReleaseMagtheridon()
     {
-        if (action == ACTION_RELEASE_MAGTHERIDON)
-        {
-            if (_magReleased)
-                return;
+        if (_magReleased)
+            return;
 
-            Talk(SAY_EMOTE_FREE);
-            Talk(SAY_FREE);
-            scheduler.CancelGroup(GROUP_EARLY_RELEASE_CHECK); //cancel regular countdown
-            _magReleased = true;
-            scheduler.Schedule(3s, [this](TaskContext)
-            {
-                ScheduleCombatEvents();
-            });
-        }
-        else if (action == ACTION_BANISH_SELF)
+        _magReleased = true;
+        Talk(SAY_EMOTE_FREE);
+        Talk(SAY_FREE);
+        scheduler.Schedule(3s, [this](TaskContext /*context*/)
         {
-            Talk(SAY_BANISH);
-            me->CastSpell(me, SPELL_SHADOW_CAGE_STUN, true);
-        }
+            ScheduleCombatEvents();
+        });
+    }
+
+    // Caged, he keeps UNIT_FLAG_IMMUNE_TO_PC, so every threat reference from the instance's
+    // SetInCombatWithZone() lands offline (ThreatReference::ShouldBeOffline) and the threat manager
+    // never engages him. Engage off the combat reference itself, so the encounter anchors to the
+    // Channeler pull and not to his release.
+    void JustEnteredCombat(Unit* who) override
+    {
+        if (IsEngaged())
+            return;
+
+        EngagementStart(who);
     }
 
     void JustEngagedWith(Unit* who) override
@@ -208,13 +215,65 @@ struct boss_magtheridon : public BossAI
             Talk(SAY_EMOTE_NEARLY);
         }).Schedule(120s, GROUP_EARLY_RELEASE_CHECK, [this](TaskContext /*context*/)
         {
-            Talk(SAY_EMOTE_FREE);
-            Talk(SAY_FREE);
-            _magReleased = true;
-        }).Schedule(123s, GROUP_EARLY_RELEASE_CHECK, [this](TaskContext /*context*/)
-        {
-            ScheduleCombatEvents();
+            ReleaseMagtheridon();
         });
+    }
+
+    // Caged, he is engaged but never fights, so a wipe gets here through his own UpdateVictim() or
+    // through the instance, whichever creature updates first. BossAI's evade would trip
+    // CREATURE_FLAG_EXTRA_HARD_RESET and despawn him for 20s in front of the raid. Reset in place
+    // instead. Released, the normal boss evade applies.
+    void EnterEvadeMode(EvadeReason why = EVADE_REASON_OTHER) override
+    {
+        if (_magReleased)
+        {
+            BossAI::EnterEvadeMode(why);
+            return;
+        }
+
+        // Also covers the re-entry from Reset() via instance->SetBossState(NOT_STARTED):
+        // EngagementOver() already ran.
+        if (!IsEngaged())
+            return;
+
+        me->CombatStop(true);
+        // BossAI::_Reset() bails while engaged, so end the engagement first. Reset() then drops the
+        // countdown through scheduler.CancelAll().
+        EngagementOver();
+        // He never walks home, so clear what BossAI::_JustReachedHome() would have.
+        me->setActive(false);
+        Reset();
+    }
+
+    // Read by the instance: IsImmuneToPC() lags the release by the 3s until ScheduleCombatEvents().
+    uint32 GetData(uint32 type) const override
+    {
+        return type == DATA_MAGTHERIDON_RELEASED ? uint32(_magReleased) : 0;
+    }
+
+    void DoAction(int32 action) override
+    {
+        switch (action)
+        {
+            case ACTION_RELEASE_MAGTHERIDON:
+                // Channelers died before the timer ran out. Drop the rest of it, or the 60s task
+                // still calls him nearly free after he is free.
+                scheduler.CancelGroup(GROUP_EARLY_RELEASE_CHECK);
+                ReleaseMagtheridon();
+                break;
+            case ACTION_BANISH_SELF:
+                Talk(SAY_BANISH);
+                DoCastSelf(SPELL_SHADOW_CAGE_STUN, true);
+                break;
+            case ACTION_RESET_ENCOUNTER:
+                // Wipe signal from the instance. UpdateVictim() catches most wipes on its own, but
+                // not a survivor outside the room still holding him in combat. Freed, he fights on.
+                if (!_magReleased)
+                    EnterEvadeMode(EVADE_REASON_OTHER);
+                break;
+            default:
+                break;
+        }
     }
 
     void UpdateAI(uint32 diff) override

--- a/src/server/scripts/Outland/HellfireCitadel/MagtheridonsLair/boss_magtheridon.cpp
+++ b/src/server/scripts/Outland/HellfireCitadel/MagtheridonsLair/boss_magtheridon.cpp
@@ -169,6 +169,7 @@ struct boss_magtheridon : public BossAI
             context.Repeat(56300ms, 64300ms);
         }).Schedule(55650ms, [this](TaskContext context)
         {
+            Talk(SAY_EMOTE_NOVA);
             DoCastSelf(SPELL_BLAST_NOVA);
             scheduler.DelayAll(10s);
             context.Repeat(54350ms, 55400ms);

--- a/src/server/scripts/Outland/HellfireCitadel/MagtheridonsLair/instance_magtheridons_lair.cpp
+++ b/src/server/scripts/Outland/HellfireCitadel/MagtheridonsLair/instance_magtheridons_lair.cpp
@@ -106,9 +106,17 @@ public:
 
         void OnCreatureEvade(Creature* creature) override
         {
-            // Phase-1 wipe signal: Mag is ImmuneToPC so BossAI evade does not fire; a Channeler evade is the trigger.
-            if (creature->GetEntry() == NPC_HELLFIRE_CHANNELER && GetBossState(DATA_MAGTHERIDON) == IN_PROGRESS)
-                SetBossState(DATA_MAGTHERIDON, NOT_STARTED);
+            if (creature->GetEntry() != NPC_HELLFIRE_CHANNELER || GetBossState(DATA_MAGTHERIDON) != IN_PROGRESS)
+                return;
+
+            // Only a Channeler-phase wipe resets the encounter. Past the 2 minute auto-release he is
+            // loose with Channelers still up, and a reset there would disable the Manticron Cubes and
+            // open the door mid-fight.
+            if (Creature* magtheridon = instance->GetCreature(_magtheridonGUID))
+                if (magtheridon->AI()->GetData(DATA_MAGTHERIDON_RELEASED))
+                    return;
+
+            SetBossState(DATA_MAGTHERIDON, NOT_STARTED);
         }
 
         void OnGameObjectCreate(GameObject* go) override
@@ -191,6 +199,10 @@ public:
                         for (ObjectGuid const& guid : _burningAbyssalsSet)
                             if (Creature* abyssal = instance->GetCreature(guid))
                                 abyssal->DespawnOrUnsummon();
+
+                        // Reset a still-caged Magtheridon: he is engaged from the Channeler pull on.
+                        if (Creature* magtheridon = instance->GetCreature(_magtheridonGUID))
+                            magtheridon->AI()->DoAction(ACTION_RESET_ENCOUNTER);
                     }
                 }
             }
@@ -202,7 +214,9 @@ public:
             switch (type)
             {
                 case DATA_CHANNELER_COMBAT:
-                    // Force the encounter start: Mag is ImmuneToPC so SetInCombatWithZone alone may miss JustEngagedWith.
+                    // Start the encounter on the Channeler pull. The combat references this creates
+                    // engage Magtheridon (boss_magtheridon::JustEnteredCombat), which anchors his
+                    // release countdown here and not to when players can first hit him.
                     if (GetBossState(DATA_MAGTHERIDON) != IN_PROGRESS)
                     {
                         SetBossState(DATA_MAGTHERIDON, IN_PROGRESS);

--- a/src/server/scripts/Outland/HellfireCitadel/MagtheridonsLair/magtheridons_lair.h
+++ b/src/server/scripts/Outland/HellfireCitadel/MagtheridonsLair/magtheridons_lair.h
@@ -30,7 +30,8 @@ enum DataTypes
 
     DATA_CHANNELER_COMBAT           = 10,
     DATA_ACTIVATE_CUBES             = 11,
-    DATA_COLLAPSE                   = 12
+    DATA_COLLAPSE                   = 12,
+    DATA_MAGTHERIDON_RELEASED       = 13
 };
 
 enum NpcIds
@@ -46,7 +47,8 @@ enum NpcIds
 enum MagtheridonActions
 {
     ACTION_RELEASE_MAGTHERIDON      = 1,
-    ACTION_BANISH_SELF              = 2
+    ACTION_BANISH_SELF              = 2,
+    ACTION_RESET_ENCOUNTER          = 3
 };
 
 enum GoIds


### PR DESCRIPTION
## Changes Proposed:

Magtheridon's release countdown was anchored to the moment players could first hit him, not to the Channeler pull. Caged, he keeps `UNIT_FLAG_IMMUNE_TO_PC`, so every threat reference from the instance's `SetInCombatWithZone()` sits offline and the threat manager never engages him, and `JustEngagedWith` only ran after the release. So the two-minute auto-release never fired on time, and killing the Channelers early left a second countdown running behind the release, which re-announced "breaks free" 120s later and stacked a duplicate ability schedule on the first.

The fix engages him off the combat reference itself, the way `boss_valithria_dreamwalker` handles the same problem: `JustEnteredCombat` calls `EngagementStart`, so `JustEngagedWith` runs on the pull and `BossAI`'s normal lifecycle stays intact. Both release paths go through one guarded `ReleaseMagtheridon()`, and the early-kill path cancels the leftover countdown so the 60s "nearly free" emote can't fire after he's already free.

Worth knowing when reading it:

- `EnterEvadeMode` is overridden to reset him in place while caged. Entry 17257 carries `CREATURE_FLAG_EXTRA_HARD_RESET`, so the stock evade despawns him for 20s in front of the raid, and in testing the Channelers were pullable again 16s after a reset. A wipe can reach the evade from his own `UpdateVictim()` or from the instance's reset signal, whichever creature updates first, so both paths share the override. Once released, the normal boss evade applies.
- The instance asks the AI whether he's released (`DATA_MAGTHERIDON_RELEASED`) instead of reading `IsImmuneToPC()`, which stays true for the 3s between the release emote and `ScheduleCombatEvents()`.
- He now counts as engaged for the whole Channeler phase, so the idle taunt keys on the release rather than on combat. Otherwise his caged taunts would go silent on the pull.
- The Blast Nova emote (`SAY_EMOTE_NOVA`, declared but never spoken) is its own commit so it can be reverted on its own.

The two places worth a close read are `JustEnteredCombat` and `EnterEvadeMode` in `boss_magtheridon.cpp`, including the re-entry from `Reset()` into `SetBossState(NOT_STARTED)` and back into `ACTION_RESET_ENCOUNTER`, which the `IsEngaged()` check keeps inert. The `OnCreatureEvade` guard in `instance_magtheridons_lair.cpp` is the other judgment call. The header change is one enum value.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code with Claude Opus 5, for the analysis, the code and a self-review. All in-game testing was done by the author.
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
- Closes #26552

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

The reporter's video and timeline on #26552 show the duplicate cycle at release + 120s. The timings themselves (60s, 120s, 123s) are the script's existing ones and are unchanged, only their anchor moves.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Windows 11, local 3.3.5a stack, solo under `.cheat god on`, plus a playerbot raid for the full clear. Emote times are client chat timestamps.

- Pull and wait: "bonds begin to weaken" on the pull, "nearly free" at +60s, "breaks free" at +120s, attackable at +123s. Taunts kept firing through the Channeler phase and stopped after the release.
- Early kill, all five Channelers dead within 5s of the pull: no "nearly free" at +60s, no second "breaks free" at release + 120s. Over 4 minutes past the release, Blast Nova held at 61 to 62s apart and Quake at 66 to 70s, which is each ability's base period plus the delay the other one injects. A duplicate schedule would have halved the Nova spacing.
- Phase 1 wipe: he stayed visible and chained, Channelers respawned, door reopened, no self-release at +120s. Three consecutive wipes, chained every time. Same with the raid alive and a Channeler forced to evade with `.gm on`, across two interrupted pulls 16s apart. Before the fix he despawned for 20s in both cases.
- Full clear with a playerbot raid: cubes clickable after the release, the new Blast Nova emote as the cube cue, banish at five cubes, 30% collapse, kill, loot, encounter DONE.
- Pull with a bot in the group, so two combat references hit `JustEnteredCombat` on one pull: no `EngagementStart` "already engaged" error in the log.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Solo needs `Instance.IgnoreRaid = 1`. Use `.cheat god on` to survive the Channelers, not `.gm on`, which makes them evade and resets the encounter. Turn on chat timestamps. Between runs leave the map, `.instance unbind all`, re-enter.
2. Pull one Channeler and kill nothing. Expect the three emotes at 0s, 60s and 120s from the pull, him attackable at 123s, and taunts until the release.
3. Fresh instance. Pull, `.die` the five Channelers, then let him hit you for 4 minutes without damaging him. Expect no "nearly free" at +60s and no second "breaks free" at release + 120s. Blast Nova should stay about 62s apart.
4. Fresh instance. Pull, wait 20s, then `.die` (or `.gm on` to reset with the raid alive). He should stay chained, not despawn. Re-pull and do it again at least twice more. The second reset is the one that used to behave differently.

## Known Issues and TODO List:

- [ ] The 3s window between the release emote and `ScheduleCombatEvents()`, guarded by `DATA_MAGTHERIDON_RELEASED` in `OnCreatureEvade`, can't be reached by hand. It's covered by reading, not by a run.
- [ ] `creature_text` carries an orphan duplicate of the Blast Nova line for 17257 (group 10, identical to the group 9 this change speaks). Separate data cleanup.

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
