### PR TITLE
fix(Core/Spells): Prevent taunts from affecting totems

### DIFF
--- a/src/server/game/Entities/Totem/Totem.cpp
+++ b/src/server/game/Entities/Totem/Totem.cpp
@@ -190,6 +190,10 @@ bool Totem::IsImmunedToSpellEffect(SpellInfo const* spellInfo, uint32 index, Uni
             spellInfo->Id != SPELL_STONECLAW && spellInfo->Id != SPELL_BIND_SIGHT && spellInfo->Id != SPELL_INTERVENE)
         return true;
 
+    if (spellInfo->Effects[index].Effect == SPELL_EFFECT_ATTACK_ME ||
+            spellInfo->Effects[index].ApplyAuraName == SPELL_AURA_MOD_TAUNT)
+        return true;
+
     // Cyclone shouldn't be casted on totems
     if (spellInfo->Id == SPELL_CYCLONE)
     {


### PR DESCRIPTION
## Changes Proposed:

Totems cannot maintain threat lists, but taunt spells could still apply their taunt aura. Hand of Reckoning could therefore display the Taunted debuff and trigger its conditional damage.

This change makes totems immune to both the direct taunt effect and the taunt aura. Hand of Reckoning now reports Immune without damaging or debuffing the totem.

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: GPT-5.6 Sol
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:


## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

Sources:
- [Hand of Reckoning spell data](https://wowgaming.altervista.org/aowow/?spell=62124): "[...] If the target is tauntable [...]"

- [World of Warcraft Patch 3.2.0 notes](https://warcraft.wiki.gg/wiki/Patch_3.2.0): “Now does damage only when the target does not currently have the caster targeted [...] occurring after the taunt effect is applied.”

- [World of Warcraft Patch 3.3.0 notes](https://warcraft.wiki.gg/wiki/Patch_3.3.0): Hand of Reckoning was clarified so taunt-immune targets do not take damage.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Hand of Reckoning was tested against a totem on commit `2a6e3f780`. The cast reported Immune, applied no Taunted aura, and dealt no damage.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Start a duel between a Paladin and a Shaman.
2. Have the Shaman summon a totem.
3. Target the totem with the Paladin and cast Hand of Reckoning.
4. Confirm that the cast reports Immune, deals no damage, and applies no Taunted aura.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
