### PR TITLE
refactor(Core): support external zlib on Win32 (NOMERGE, ALT)

### DIFF
--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -30,10 +30,6 @@ jobs:
     name: ${{ matrix.os }}
     env:
       BOOST_ROOT: C:\local\boost_1_87_0
-    if: |
-      github.repository == 'azerothcore/azerothcore-wotlk'
-      && !github.event.pull_request.draft
-      && (github.ref == 'refs/heads/master' || contains(github.event.pull_request.labels.*.name, 'run-build') || github.event.label.name == 'run-build')
     steps:
       - uses: actions/checkout@v7
       - name: ccache

--- a/deps/zlib/CMakeLists.txt
+++ b/deps/zlib/CMakeLists.txt
@@ -38,6 +38,10 @@ else()
     zutil.c
   )
 
+  # prefix the zlib symbols so external modules can bring their own (via, e.g.,
+  # a library that already has them compiled in) without interfering with ours.
+  SET(Z_PREFIX 1)
+
   add_library(zlib STATIC
     ${zlib_STAT_SRCS})
 


### PR DESCRIPTION
A possible alternative way to do #27003

If CI passes, then that will be replaced by this. This PR gets abandoned either way, so don't spend much time looking at it.