### PR TITLE
fix(DB/SAI): drop Mogg's link to an undefined event

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1789129458779463000.sql
+++ b/data/sql/updates/pending_db_world/rev_1789129458779463000.sql
@@ -1,0 +1,13 @@
+-- Mogg (14908): the waypoint 29 event linked to event 8, which was never defined, so
+-- SmartScript::ProcessAction logged "Event 7, Link Event 8 not found, skipped" on every pass.
+-- The link dates from the 2017 script (2017_02_03_15.sql) and has no target to point at.
+DELETE FROM `smart_scripts` WHERE (`source_type` = 0 AND `entryorguid` = 14908);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(14908, 0, 0, 0, 25, 0, 100, 512, 0, 0, 0, 0, 0, 0, 53, 1, 14908, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mogg - On Reset - Start Waypoint'),
+(14908, 0, 1, 0, 40, 0, 100, 512, 5, 14908, 0, 0, 0, 0, 80, 1490800, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mogg - On Waypoint 5 Reached - Run Script'),
+(14908, 0, 2, 0, 40, 0, 100, 512, 6, 14908, 0, 0, 0, 0, 80, 1490801, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mogg - On Waypoint 6 Reached - Run Script'),
+(14908, 0, 3, 0, 40, 0, 100, 512, 7, 14908, 0, 0, 0, 0, 80, 1490802, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mogg - On Waypoint 7 Reached - Run Script'),
+(14908, 0, 4, 0, 40, 0, 100, 512, 17, 14908, 0, 0, 0, 0, 80, 1490803, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mogg - On Waypoint 17 Reached - Run Script'),
+(14908, 0, 5, 0, 40, 0, 100, 512, 27, 14908, 0, 0, 0, 0, 80, 1490804, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mogg - On Waypoint 27 Reached - Run Script'),
+(14908, 0, 6, 0, 40, 0, 100, 512, 28, 14908, 0, 0, 0, 0, 80, 1490805, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mogg - On Waypoint 28 Reached - Run Script'),
+(14908, 0, 7, 0, 40, 0, 100, 512, 29, 14908, 0, 0, 0, 0, 80, 1490806, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Mogg - On Waypoint 29 Reached - Run Script');


### PR DESCRIPTION
## Changes Proposed

Rewrite the SmartAI block of creature 14908 (Mogg) so that the "On Waypoint 29 Reached" event (id 7) no longer links to event 8. Event 8 was never defined for this creature, so `SmartScript::ProcessAction` logs `Entry 14908 SourceType 0, Event 7, Link Event 8 not found, skipped.` every time the waypoint is reached. All eight rows are re-inserted unchanged apart from that link; the action on row 7 (run script 1490806) is untouched.

The dangling link dates back to `data/sql/old/db_world/2.x/2017_02_03_15.sql` and is still present in the current base dump (`smart_scripts.sql`, row for 14908 id 7).

## Issues Addressed

None filed. The message appears in `Errors.log` on any realm where Mogg walks his path.

## SOURCE

Own investigation: the event table for 14908 holds ids 0 through 7 only (base dump and a live database rebuilt from it), and no update ever added event 8.

## Tests Performed

- `python apps/codestyle/codestyle-sql.py` passes.
- Applied inside a transaction on a live `acore_world` and rolled back: row 7 reads link 0 with 8 rows present, and link 8 again after the rollback.

## How to Test the Changes

1. Apply the update to `acore_world` (or start the worldserver with the DB updater enabled).
2. `SELECT id, link FROM smart_scripts WHERE entryorguid = 14908 AND source_type = 0;` shows link 0 on every row.
3. Let Mogg reach waypoint 29 of his path; `Errors.log` no longer receives the "Link Event 8 not found" line.
