### PR TITLE
fix(DB/Quest): Summon Lord Kragaru from the Serpent Statue

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1789122903351611000.sql
+++ b/data/sql/updates/pending_db_world/rev_1789122903351611000.sql
@@ -1,0 +1,21 @@
+--
+-- Quest 6027 'Book of the Ancients': using the Gem of the Serpent lights the Naga Beam but
+-- often summons nothing, leaving Lord Kragaru (12369) unreachable. The beam is a temporary
+-- gameobject whose lifetime is rounded to whole seconds, so it frequently expires before its
+-- own 3500ms summon timer fires, depending on when inside a second the player clicked.
+-- Drive the summon from the statue instead - a permanent spawn whose SmartAI cannot despawn.
+--
+DELETE FROM `smart_scripts` WHERE (`source_type` = 1 AND `entryorguid` IN (177673, 177705)) OR (`source_type` = 9 AND `entryorguid` = 17767300);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `event_param6`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+    (177673, 1, 0, 1, 70, 0, 100, 0, 2, 0, 0, 0, 0, 0, 80, 17767300, 2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Serpent Statue - On Loot State Changed (Activated) - Call Timed Actionlist'),
+    (177673, 1, 1, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 0, 241, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Serpent Statue - On Link - Summon Gameobject Group 0 \'Naga Beam\''),
+    (17767300, 9, 0, 0, 0, 0, 100, 0, 3500, 3500, 0, 0, 0, 0, 12, 12369, 1, 180000, 0, 0, 0, 8, 0, 0, 0, 0, 252.57, 2963.7, 1.72356, 1.29154, 'Serpent Statue - On Script - Summon Creature \'Lord Kragaru\'');
+
+-- The beam is summoned through a gameobject summon group so that its sniffed rotation survives:
+-- SMART_ACTION_SUMMON_GO hands SummonGameObject an identity quaternion and cannot carry one.
+DELETE FROM `gameobject_summon_groups` WHERE (`summonerId` = 177673 AND `summonerType` = 1 AND `groupId` = 0);
+INSERT INTO `gameobject_summon_groups` (`summonerId`, `summonerType`, `groupId`, `entry`, `position_x`, `position_y`, `position_z`, `orientation`, `rotation0`, `rotation1`, `rotation2`, `rotation3`, `respawnTime`, `Comment`) VALUES
+    (177673, 1, 0, 177705, 252.547, 2963.69, 1.64267, 5.58505, 0, 0, -0.34202, 0.939693, 4, 'Serpent Statue - Naga Beam');
+
+-- The Naga Beam is purely cosmetic now; it carries no script.
+UPDATE `gameobject_template` SET `AIName` = '' WHERE (`entry` = 177705);

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -157,6 +157,7 @@ go test -tags=e2e ./local/... -count=1 -v -timeout 30m -parallel 1
 | quests/escort | find spawned unit; follow-NPC despawns on logout | P2 | covered (`TestAC_24450_*`) | #24450 |
 | quests/frostmourne | scrying-orb vision runs; Muradin leaves the cavern and despawns; quest 12478 COMPLETE | P2 | covered (`TestAC_25760_*`); dialogue order and duplicate line `blocked-harness` (no monster-say capture) | #25760 |
 | quests/objectives | a mob that drops a quest item advertises it, so the client shows the objective on hover (`creature_questitem` -> `SMSG_CREATURE_QUERY_RESPONSE.questItems`) | P2 | covered (`TestAC_27553_*`), decoding the response through a raw packet hook since the harness has no dispatch case for it | #27553 |
+| quests/summons | using the Serpent Statue on Ranazjar Isle summons Lord Kragaru, the only source of the Book of the Ancients (quest 6027). Beam and summon are asserted separately so a failure names which script broke, and the activation is repeated because the regression it guards was probabilistic, not absolute | P2 | covered (`TestQuest6027_*`) | — |
 | items/equip | visible-item slot after EquipEntry; additem; survives relog | P2 | covered | — |
 | protocol/session | pos; item/quest load; money save/relog | P1 | covered; GM vis persist `blocked-harness` (extra_flags after relog) | #25793 |
 | protocol/teleport | cross-map; named; GoCreatureID | P1 | covered | — |

--- a/e2e/suites/quests/summons/serpent_statue_e2e_test.go
+++ b/e2e/suites/quests/summons/serpent_statue_e2e_test.go
@@ -1,0 +1,140 @@
+//go:build e2e
+
+package summons_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+
+	"github.com/azerothcore/AzerothGhost/e2e/e2eharness"
+	"github.com/azerothcore/azerothcore-wotlk/e2e/internal/meta"
+)
+
+const (
+	serpentStatue     uint32 = 177673 // GO, type BUTTON, Ranazjar Isle
+	serpentStatueGUID        = 12609  // its single gameobject.guid spawn
+	nagaBeam          uint32 = 177705 // GO summoned by the statue, cosmetic
+	lordKragaru       uint32 = 12369  // drops Book of the Ancients (15803)
+
+	statueX  float32 = 252.513
+	statueY  float32 = 2963.7
+	statueZ  float32 = 1.64204
+	kalimdor uint32  = 1
+
+	// The statue summons the beam, then Lord Kragaru 3500ms later.
+	summonWindow = 10 * time.Second
+
+	// Long enough for the gameobject to tick once and drop the finished action list.
+	settleBetweenActivations = 500 * time.Millisecond
+
+	// One activation is not a regression test: the bug this guards against was
+	// probabilistic (measured 4/16 on unfixed data), so a single success proves
+	// nothing. Six consecutive successes put a regression under ~2%.
+	activations = 6
+)
+
+// Quest 6027 "Book of the Ancients" hands out a Gem of the Serpent to place on the
+// Serpent Statue on Ranazjar Isle. That must summon Lord Kragaru, who carries the
+// book; without him the quest cannot be completed.
+//
+// The summon used to hang off the Naga Beam, a gameobject the statue summons for
+// four seconds. SMART_ACTION_SUMMON_GO's despawn parameter is in whole seconds and
+// lands in GameObject::SetRespawnTime, which adds it to the second-granular
+// GameTime clock, so the beam's real lifetime was anywhere in (3.0s, 4.0s] and it
+// was frequently deleted before its own 3500ms summon timer fired.
+//
+// Both halves are asserted: the beam is the visual the player reports seeing, so
+// separating "beam appeared" from "Kragaru appeared" tells a failing run which of
+// the two scripts broke.
+func TestQuest6027_SerpentStatueSummonsKragaru(t *testing.T) {
+	meta.Begin(t, meta.TestMeta{
+		Tags:     []string{"med", "quests", "serial"},
+		Runtime:  "med",
+		Category: "quests/summons",
+	})
+
+	bot := e2eharness.NewSolo(t, e2eharness.ScenarioOpts{Prefix: "Serp"})
+	e2eharness.TeleportGo(t, bot.World, statueX, statueY+6, statueZ, kalimdor)
+
+	statue := bot.WaitGameObject(t, serpentStatue, 15*time.Second)
+
+	// Any use leaves the statue in GO_ACTIVATED for button.autoCloseTime (60s), and
+	// UseDoorOrButton is a no-op until it resets — so a previous run, or a player who
+	// just clicked it, would make the real click below silently do nothing.
+	// .gobject activate forces GO_READY and re-uses it with a 10s autoclose instead,
+	// which bounds the wait to that rather than a minute.
+	e2eharness.MustGM(t, bot.World, fmt.Sprintf(".gobject activate %d", serpentStatueGUID))
+	time.Sleep(12 * time.Second)
+
+	// Every successful summon is a new ObjectGuid. Counting distinct guids rather
+	// than "is a Kragaru nearby" keeps earlier summons from satisfying later
+	// activations — on unfixed data that would mask exactly the failures we hunt.
+	seen := map[uint64]bool{}
+	for _, u := range bot.World.GetNearbyUnits(100) {
+		if u.Entry == lordKragaru {
+			seen[u.GUID] = true
+		}
+	}
+
+	for i := 1; i <= activations; i++ {
+		prevBeam := bot.World.FindGameObjectByEntry(nagaBeam, 0)
+
+		if i == 1 {
+			// The player path: CMSG_GAMEOBJ_USE reaches GameObject::Use, which for a
+			// BUTTON calls UseDoorOrButton -- the same call the gem's OpenLock effect
+			// makes through Spell::SendLoot. Only the first activation can afford it:
+			// it leaves the full 60s autoclose behind.
+			bot.GameObjectUse(t, statue)
+		} else {
+			// Same UseDoorOrButton call, reached past that autoclose.
+			e2eharness.MustGM(t, bot.World, fmt.Sprintf(".gobject activate %d", serpentStatueGUID))
+		}
+
+		beam, summoned := uint64(0), uint64(0)
+		deadline := time.Now().Add(summonWindow)
+		for time.Now().Before(deadline) {
+			// Require a beam this activation did not inherit. Its lifetime overlaps the
+			// next activation, so matching on entry alone would let the previous one
+			// stand in and hide an intermittent break of the summon-GO row.
+			if beam == 0 {
+				if g := bot.World.FindGameObjectByEntry(nagaBeam, 0); g != 0 && g != prevBeam {
+					beam = g
+				}
+			}
+			for _, u := range bot.World.GetNearbyUnits(100) {
+				if u.Entry == lordKragaru && !seen[u.GUID] {
+					seen[u.GUID] = true
+					summoned = u.GUID
+				}
+			}
+			if summoned != 0 {
+				break
+			}
+			time.Sleep(50 * time.Millisecond)
+		}
+
+		if beam == 0 {
+			e2eharness.Assertf(t, "activation %d/%d: Serpent Statue (%d) did not summon the Naga Beam (%d); "+
+				"the statue's own script is broken, before any Kragaru summon can run",
+				i, activations, serpentStatue, nagaBeam)
+		}
+		if summoned == 0 {
+			e2eharness.Assertf(t, "activation %d/%d: Serpent Statue (%d) did not summon Lord Kragaru (%d) within %s; "+
+				"without him the Book of the Ancients (15803) never drops and quest 6027 cannot be completed",
+				i, activations, serpentStatue, lordKragaru, summonWindow)
+		}
+		t.Logf("activation %d/%d: beam 0x%X lit, Lord Kragaru summoned guid=0x%X",
+			i, activations, beam, summoned)
+
+		// SetScript9 refuses a new action list while one is still registered
+		// (allowOverride = 0), and the finished list is only dropped on the
+		// gameobject's next update tick. Re-activating inside that tick would be
+		// ignored — a beam, since that hangs off the link, but no Kragaru. A player
+		// cannot reach this: the 60s autoclose forbids back-to-back use, and only a
+		// GM force-reset gets here. Give the statue its tick.
+		time.Sleep(settleBetweenActivations)
+	}
+}


### PR DESCRIPTION
## Changes Proposed:

Quest 6027 "Book of the Ancients" gives you a Gem of the Serpent to place on the Serpent Statue on Ranazjar Isle. That is supposed to summon Lord Kragaru, who carries the book. Most of the time it summoned nothing: the beam of light appeared and then the isle stayed empty, so the quest could not be finished.

The statue summons the Naga Beam (GO 177705) for four seconds, and the beam's own SmartAI was what summoned Kragaru, 3500ms later. `SMART_ACTION_SUMMON_GO`'s despawn parameter is in whole seconds and lands in `GameObject::SetRespawnTime`, which adds it to `GameTime::GetGameTime()`. So the beam is deleted at the next second boundary four ticks on, and its real lifetime is anywhere in (3.0s, 4.0s] depending on where inside the current second you clicked. Whenever it falls short of 3500ms the beam is gone before its own timer fires, and nothing is summoned.

This moves the delayed summon onto the statue, which is a permanent spawn whose SmartAI cannot be deleted out from under its own timer, and leaves the beam as the visual it now is. TrinityCore has done it this way since 2013, through a timed action list called from the statue's state change. AzerothCore has carried that action list (`17767300`) in its base data since 2016 but never the row that calls it. Wiring it up also retires the beam's dangling `link` to a row that was never written, which had been logging `Link Event 1 not found` on every use.

Two smaller changes come with it:

- The action list's second row is dropped rather than restored. It has to be: `SmartScript::UpdateTimer` enables the next row of a list once the current one has run, so that row would hold `mTimedActionList` populated for 185 seconds, and `SetScript9` refuses to start a list while one is running unless `allowOverride` is set — the statue would summon Kragaru once and then ignore everybody for three minutes. Nothing is lost, because a BUTTON already resets itself through `button.autoCloseTime`.
- Kragaru changes from `TEMPSUMMON_TIMED_DESPAWN_OUT_OF_COMBAT`/30s to `TEMPSUMMON_TIMED_OR_DEAD_DESPAWN`/180s, matching the action list. An unengaged Kragaru therefore lingers longer than before, three minutes rather than thirty seconds; in exchange his corpse keeps the normal decay window instead of being pulled thirty seconds after he dies, which is the window you have to loot the book.

The delay stays at the 3500ms #9904 chose rather than TrinityCore's 5000ms, so Kragaru still materialises while the beam is lit rather than after it fades.

A live-stack e2e test comes with it. It activates the statue six times and requires a new Lord Kragaru each time. The repetition is the point: the bug was probabilistic, so one activation proves nothing — against unfixed data the first activation passes and the second fails.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Opus 5 via Claude Code. The AI produced the data change, the e2e test and this description; every claim about core behaviour in it was verified against the source and against a live stack.
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:

- Closes

No open issue — found while playing the quest.

## SOURCE:
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [x] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

The summon mechanism is TrinityCore's, from commit `1d31b5f4a76bba43a07f8ef513c51c1d4188a39c` ("DB/SAI: Book of the Ancients", 2013-11-03). The fix commit carries `--author Aokromes <jipr@hotmail.com>`, the upstream commit's author, and credits dr-j, whom that commit names as the fix's author, via `Co-authored-by`.

Expected behaviour per Wowhead: https://www.wowhead.com/classic/quest=6027/book-of-the-ancients — "Place this gem on the Serpent Statue's hand on Ranazjar Isle ... Placing it will summon the one who protects the Book of the Ancients."

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

In-game: quest accepted from Azore Aldamort, gem used on the statue, Lord Kragaru appeared, was killed, the Book of the Ancients was looted off the corpse and turned in successfully.

Measured on a live stack before the fix, using `.gobject activate` to drive the statue repeatedly: **4 of 16 activations summoned Kragaru, with the beam appearing 16/16**. After the fix, 16/16. The failures clustered in runs, which is what phase against a one-second grid predicts.

The e2e test (`e2e/suites/quests/summons/`) fails 3 of 3 runs against restored pre-fix data on a clean worldserver, and passes 5 consecutive runs on the fix. In two of those three failing runs the *first* activation passed and the second caught the bug.

Not tested: two players using the statue within the same 60-second autoclose window. Unchanged by this PR, but nobody has exercised it.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Apply the SQL and **restart the worldserver**. `gameobject_template` is not reloadable, so without a restart you will still be running the old Naga Beam AI and testing nothing.
2. `.go xyz 252.513 2963.7 1.64204 1` (Ranazjar Isle, Desolace). Take quest 6027 from Azore Aldamort (`.go creature id 11863`) if you want the full loop.
3. Use the Gem of the Serpent on the Serpent Statue. The beam lights, and Lord Kragaru appears in front of the statue about 3.5 seconds later.
4. Repeat several times — this is the part that matters, since the old behaviour worked sometimes. Note the statue holds `GO_ACTIVATED` for 60 seconds after each use and ignores clicks until it resets, so wait a minute between attempts or a working statue will look broken.
5. Kill Kragaru and loot the Book of the Ancients, then hand it in.

## Known Issues and TODO List:

- [ ] The underlying core behaviour is untouched: `GameObject::SetRespawnTime` quantises a summoned gameobject's lifetime to whole seconds, so *any* "temporary GO runs a short SAI timer then despawns" pattern is inherently racy. This PR removes the dependency rather than fixing that, because the core change would reach every summoned gameobject and belongs on its own.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.