### PR TITLE
chore(Core/Unit): Name all hitinfo flags seen in sniffs.

### DIFF
--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -96,29 +96,31 @@ enum VictimState
 enum HitInfo
 {
     HITINFO_NORMALSWING         = 0x00000000,
-    HITINFO_UNK1                = 0x00000001,               // req correct packet structure
+    HITINFO_DEBUG               = 0x00000001,               // packet includes extra debug data such as chance to crit, miss, dodge, etc
     HITINFO_AFFECTS_VICTIM      = 0x00000002,
     HITINFO_OFFHAND             = 0x00000004,
-    HITINFO_UNK2                = 0x00000008,
+    HITINFO_UNK2                = 0x00000008,               // not seen in sniffs
     HITINFO_MISS                = 0x00000010,
     HITINFO_FULL_ABSORB         = 0x00000020,
     HITINFO_PARTIAL_ABSORB      = 0x00000040,
     HITINFO_FULL_RESIST         = 0x00000080,
     HITINFO_PARTIAL_RESIST      = 0x00000100,
     HITINFO_CRITICALHIT         = 0x00000200,               // critical hit
-    HITINFO_UNK10               = 0x00000400,
-    HITINFO_UNK11               = 0x00000800,
-    HITINFO_UNK12               = 0x00001000,
-    HITINFO_BLOCK               = 0x00002000,               // blocked damage
-    HITINFO_UNK14               = 0x00004000,               // set only if meleespellid is present//  no world text when victim is hit for 0 dmg(HideWorldTextForNoDamage?)
-    HITINFO_UNK15               = 0x00008000,               // player victim?// something related to blod sprut visual (BloodSpurtInBack?)
+    HITINFO_ROLLED_DODGE        = 0x00000400,               // victim is able to dodge and chance was rolled, application follows code flow in RollMeleeOutcomeAgainst
+    HITINFO_ROLLED_PARRY        = 0x00000800,               // victim is able to parry and chance was rolled, application follows code flow in RollMeleeOutcomeAgainst
+    HITINFO_ROLLED_BLOCK        = 0x00001000,               // victim is able to block and chance was rolled, application follows code flow in RollMeleeOutcomeAgainst
+    HITINFO_BLOCK               = 0x00002000,               // blocked damage, always implies HITINFO_ROLLED_BLOCK
+    HITINFO_NO_FLOATING_TEXT    = 0x00004000,               // set only if meleespellid is present, no world text when victim is hit for 0 dmg(HideWorldTextForNoDamage?)
+    HITINFO_BLOOD_SPURT         = 0x00008000,               // sprays extra blood, set on 100% of hits where damage (incl. absorb/resist/block)
+                                                            // is between 20% and 100% of victim max health, only seen with player victims
     HITINFO_GLANCING            = 0x00010000,
     HITINFO_CRUSHING            = 0x00020000,
-    HITINFO_NO_ANIMATION        = 0x00040000,
-    HITINFO_UNK19               = 0x00080000,
-    HITINFO_UNK20               = 0x00100000,
-    HITINFO_SWINGNOHITSOUND     = 0x00200000,               // unused?
-    HITINFO_UNK22               = 0x00400000,
+    HITINFO_NO_ANIMATION        = 0x00040000,               // always set if meleespellid is present
+    HITINFO_PVP                 = 0x00080000,               // set if and only if attacker and victim both have UNIT_FLAG_PLAYER_CONTROLLED
+    HITINFO_DUEL                = 0x00100000,               // always implies HITINFO_PVP, never seen in battlegrounds or arenas, often seen in sanctuary areas
+    HITINFO_SWINGNOHITSOUND     = 0x00200000,               // not seen in sniffs
+    HITINFO_CRITICAL_BLOCK      = 0x00400000,               // always implies HITINFO_BLOCK, victim is always a warrior (protection talent Critical Block),
+                                                            // per victim the highest blocked amount with this flag is exactly 2x the highest blocked amount without it
     HITINFO_RAGE_GAIN           = 0x00800000,
     HITINFO_FAKE_DAMAGE         = 0x01000000                // enables damage animation even if no damage done, set only if no damage
 };


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

<!-- How to title your Pull Request, Description, Co-Authors (Cherry Pick) and others, please see the link below -->
<!-- https://www.azerothcore.org/wiki/commit-message-guidelines -->

## Changes Proposed:
<!-- If your pull request promotes complex changes that require a detailed explanation, please describe them in detail specifying what your solution is and what is it meant to address. -->
This PR proposes changes to:
-  [X] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [X] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude was used to help with data analysis. All conclusions were verified and refined by humans against the data.
- [X] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [x] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

A dataset containing 343082 parsed SMSG_ATTACKERSTATEUPDATE rows with additional data from the update fields of both attacker and victim at the time the packet was received in order to facilitate the analysis. Sniffs from patch 3.3.2 were used to create the dataset.

Parsed data can be downloaded here - https://github.com/ratkosrb/attacking_state_update_data

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Parse original wotlk sniffs.
2. Verify conclusions against sniff data.

**HITINFO_DEBUG** - This flag is read by the client when parsing the packet. It can be verified in IDA or Ghidra, and it's used to include extra debug info about the chance to miss, crit, dodge, parry, etc at the time of the attack.
**HITINFO_ROLLED_DODGE** - This flag is only set victim is able to dodge and the dodge check in RollMeleeOutcomeAgainst was reached. It's never set on Miss because the Miss check happens before the dodge check.
**HITINFO_ROLLED_PARRY** - This flag is only set victim is able to parry and the parry check in RollMeleeOutcomeAgainst was reached. It's never set on Miss or Dodge because those checks happens before the dodge check.
**HITINFO_ROLLED_BLOCK** - This flag is only set victim is able to block and the block check in RollMeleeOutcomeAgainst was reached. It's never set on Miss, Dodge, Parry or Glancing Blow because those checks happens before the block check.
**HITINFO_BLOOD_SPURT** - This flag is used by client to spray extra blood, and server only sets it on Player victims in cases where damage is between 20% and 100% of victim max health.
**HITINFO_PVP** - There is a 100% correlation between this flag and the attacker and victim both being players or a player pet (UNIT_FLAG_PLAYER_CONTROLLED). You will see it in any sniff that includes battlegrounds, arenas, duels, or open world pvp.
**HITINFO_DUEL** - This flag is again only set in cases where both the attacker and victim are players or player pets, but it's never set inside battlegrounds or arenas, and commonly set in fights between players inside sanctuary areas, indicating it is a duel flag.
**HITINFO_CRITICAL_BLOCK** - This flag is only set in case of block, and only for warriors, which is the only class that has the Critical Block talent. The blocked amount when this flag is set is double the amount the same victim blocks without it.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ] Actually implement use of the flags. (Not in this PR)

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
