### PR TITLE
fix(Scripts/Ulduar): make Yogg-Saron's Laughing Skulls respect line of sight

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -163,7 +163,7 @@ go test -tags=e2e ./local/... -count=1 -v -timeout 30m -parallel 1
 | guild/charter_bank | charter buy+turn-in | P2 | covered | — |
 | instances/bind_reset | party tele; ritual summon | P2 | covered; post-reset summon `blocked-harness` (AcceptSummon after reset) | #10708 |
 | instances/classic/stratholme | Timmy remains hidden while a relevant Square Scarlet lives, then emerges after the area is clear | P2 | covered (`TestAC_26363_TimmyEmergesAfterSquareCleared`) | #26363 |
-| instances/ulduar | named tele; Freya wave interval | P2 | covered (`TestAC_27095_*`); Kologarn Charge `blocked-harness` (bridge Z after Charge) | #26266 #27095 |
+| instances/ulduar | named tele; Freya wave interval; a Laughing Skull's Lunatic Gaze stops at the brain room's geometry instead of draining sanity through it | P2 | covered (`TestAC_27095_*`, `TestAC_27602_*`); Kologarn Charge `blocked-harness` (bridge Z after Charge) | #26266 #27095 #27602 |
 | world/gameevents | Call to Arms banners at the Dalaran portals belong to the side they stand on, and the already-correct Warsong set is unchanged. **Wants an exclusive realm**: starting a holiday re-anchors its schedule in the running worldserver until restart; holidays already running are left alone | P2 | covered (`TestAC_24380_*`); Shattrath's 23 positions `gap` | #24380 |
 
 ---

--- a/e2e/suites/instances/northrend/ulduar/ulduar_e2e_test.go
+++ b/e2e/suites/instances/northrend/ulduar/ulduar_e2e_test.go
@@ -277,3 +277,81 @@ func TestUlduar_MultiBotLoginNearBossPad(t *testing.T) {
 	}
 	t.Logf("PASS multi-bot Freya pad login n=%d map=%d", len(bots), m0)
 }
+
+// Issue: https://github.com/azerothcore/azerothcore-wotlk/issues/27602
+// PR:    https://github.com/azerothcore/azerothcore-wotlk/pull/27614
+// A Laughing Skull's Lunatic Gaze (64168) must not reach a player behind the brain
+// room's geometry. 64168 has no ignore-LoS attribute of its own; it used to inherit
+// one from the aura that triggers it (64167), so the skulls drained sanity through
+// walls. The clear-line half runs first and is the fixture check: without sanity
+// loss there, the blocked half proves nothing.
+func TestAC_27602_LaughingSkullGazeLoS(t *testing.T) {
+	meta.Begin(t, meta.TestMeta{
+		Tags:     []string{"med", "instances", "issue"},
+		Runtime:  "med",
+		Issue:    27602,
+		Category: "instances/northrend/ulduar",
+	})
+
+	const (
+		npcLaughingSkull = uint32(33990)
+		spellSanity      = uint32(63050)
+
+		// Icecrown illusion chamber floor. The pair sits 18 yd either side of the
+		// skull: due west is open, due east is behind structure (verified in-world
+		// with a LoS-respecting player cast at 12, 18 and 24 yd).
+		skullX, skullY, skullZ = float32(1930.0), float32(-120.0), float32(240.07)
+		clearX, clearY         = float32(1912.0), float32(-120.0)
+		blockedX, blockedY     = float32(1948.0), float32(-120.0)
+
+		// 64167 ticks every second for 2 sanity; 8s leaves margin for spawn settle.
+		gazeWindow = 8 * time.Second
+	)
+
+	bot := e2eharness.NewSolo(t, e2eharness.ScenarioOpts{
+		Prefix: "YoggLo", Race: e2eharness.RaceHuman, Level: 80,
+	})
+
+	// Stay GM through the raid enter (.go xyz onto 603 is ignored after .gm off).
+	bot.Teleport(t, skullX, skullY, skullZ, e2eharness.MapUlduar)
+	if _, _, _, m := bot.Pos(); m != e2eharness.MapUlduar {
+		e2eharness.Preconditionf(t, "not in Ulduar after brain room tele map=%d", m)
+	}
+	// The skulls are SummonCreature'd by the Brain AI, not by a spell, so a GM spawn
+	// is the fixture rather than a stand-in for a summon path. 64167 rides on
+	// creature_template_addon, so the spawn gazes on its own with no AI to drive.
+	skull := bot.Spawn(t, npcLaughingSkull, 30*time.Second)
+
+	// Drop GM so the gaze can select the bot; god mode absorbs the 1749/s it deals.
+	bot.CombatReady(t)
+	bot.CheatGod(t)
+
+	// Sanity carries AURA_INTERRUPT_FLAG_CHANGE_MAP, so apply it after the tele.
+	sanityLost := func(label string, px, py float32) int {
+		bot.Teleport(t, px, py, skullZ, e2eharness.MapUlduar)
+		bot.WaitUnitGUID(t, skull, 15*time.Second) // tele clears the object cache
+		bot.Face(t, skull)                         // 64168 only takes targets facing the caster
+		bot.ApplyAura(t, spellSanity)
+		before := bot.AuraStacks(spellSanity)
+		if before == 0 {
+			e2eharness.Preconditionf(t, "%s: Sanity 63050 did not apply", label)
+		}
+		time.Sleep(gazeWindow)
+		after := bot.AuraStacks(spellSanity)
+		bot.CancelAura(t, spellSanity)
+		t.Logf("%s pos=(%.1f,%.1f) skull=0x%X sanity %d -> %d", label, px, py, skull, before, after)
+		return before - after
+	}
+
+	clearLoss := sanityLost("CLEAR", clearX, clearY)
+	if clearLoss <= 0 {
+		e2eharness.Preconditionf(t, "fixture dead: skull 0x%X drained no sanity with a clear line", skull)
+	}
+	blockedLoss := sanityLost("BLOCKED", blockedX, blockedY)
+	if blockedLoss > 0 {
+		e2eharness.ConfirmedBugf(t, 27602,
+			"Lunatic Gaze drained %d sanity through the brain room geometry (clear line drained %d)",
+			blockedLoss, clearLoss)
+	}
+	t.Logf("PASS Lunatic Gaze LoS: clear drained %d, blocked drained %d", clearLoss, blockedLoss)
+}

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_yoggsaron.cpp
@@ -2586,14 +2586,17 @@ class spell_yogg_saron_lunatic_gaze : public SpellScript
 
     void FilterTargets(std::list<WorldObject*>& targets)
     {
-        std::list<WorldObject*> tmplist;
-        for (std::list<WorldObject*>::iterator itr = targets.begin(); itr != targets.end(); ++itr)
-            if ((*itr)->HasInArc(M_PI, GetCaster()))
-                tmplist.push_back(*itr);
+        Unit* caster = GetCaster();
+        // 64168 inherits SPELL_ATTR2_IGNORE_LINE_OF_SIGHT from the aura triggering it, so the illusion room walls have to be checked here
+        bool ignoreLos = GetSpellInfo()->HasAttribute(SPELL_ATTR2_IGNORE_LINE_OF_SIGHT);
 
-        targets.clear();
-        for (std::list<WorldObject*>::iterator itr = tmplist.begin(); itr != tmplist.end(); ++itr)
-            targets.push_back(*itr);
+        targets.remove_if([caster, ignoreLos](WorldObject* target)
+        {
+            if (!target->HasInArc(M_PI, caster))
+                return true;
+
+            return !ignoreLos && !caster->IsWithinLOSInMap(target, VMAP::ModelIgnoreFlags::M2);
+        });
     }
 
     void Register() override


### PR DESCRIPTION
## Changes Proposed:

The Laughing Skulls in Yogg-Saron's brain room illusions drain sanity through walls and pillars.

`Lunatic Gaze` 64168, the skulls' 30 yd gaze, carries no ignore-LoS attribute of its own. The aura that triggers it every second, 64167, does. `Spell::CheckEffectTarget` propagates a triggering aura's `SPELL_ATTR2_IGNORE_LINE_OF_SIGHT` onto the spell it triggers, so 64168 never gets a line of sight check and the skulls reach players standing behind cover.

The fix filters targets the caster cannot see in `spell_yogg_saron_lunatic_gaze`, keyed on the spell's own attribute. Yogg-Saron's phase 3 gaze 64164 does carry the attribute (it is room-wide at 130 yd) and keeps ignoring line of sight. The old hand-rolled copy loop becomes a `remove_if` in the same pass.

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Opus 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:

- Closes #27602

## SOURCE:

The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [x] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

A sniff of the encounter gives 1474 `SMSG_SPELL_GO` for 64168, each carrying the skull's position and the hit list. Correlating every cast with the player's position reported within one second:

- No target beyond 30 yd was ever hit, confirming the radius.
- Hits stop around 95 degrees off the player's facing, confirming the existing `HasInArc(M_PI)` filter.
- 19 casts had the player in range and facing the skull, yet off the hit list, and they form a geometric shadow rather than range noise. Two examples from the Icecrown illusion, same room, same Z:

```
skull (1929.7, -82.1)
  d=12.5 ang=0.72  player(1933.7, -93.9)   not hit
  d=22.3 ang=0.19  player(1932.1,-104.2)   not hit
  d=12.8 ang=1.62  player(1941.2, -87.7)   hit
  d=17.8 ang=1.43  player(1947.0, -86.1)   hit
  d=22.6 ang=0.82  player(1951.7, -76.9)   hit

skull (1951.5, -105.2)
  d=12.5 ang=0.44  player(1953.1, -92.8)   not hit
  d=16.4 ang=0.59  player(1950.5, -88.9)   not hit
  d=19.5 ang=0.74  player(1947.3, -86.2)   not hit
  d= 8.1 ang=1.19  player(1954.9, -97.9)   hit
```

Everything on one bearing is spared at 12-25 yd while everything on another is hit at the same distances. The videos linked in the issue show the same thing from the player side.

## Tests Performed:

- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

Worth covering both spells the script is bound to, since they share the filter:

1. In the brain room, stand behind a pillar or wall within 30 yd of a skull and face it. Sanity should stop dropping from `Lunatic Gaze`, and resume in the open.
2. Still in the brain room, stand in the open near a skull facing it, then turn away. The facing filter should behave exactly as before.
3. In phase 3, check Yogg-Saron's own `Lunatic Gaze` still reaches the whole platform regardless of cover, and still costs 4 sanity per tick against the skulls' 2.

## Known Issues and TODO List:

- [ ] Unrelated to this fix: the sniff shows skull spawn positions varying between illusion cycles and not matching the hardcoded ones in `PrepareChamberIllusion` / `PrepareIceCrownIllusion` / `PrepareStormwindIllusion`. Left alone here, worth its own issue.

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
