### PR TITLE
fix(Core/Spells): stop forced casts from inheriting the caster as their destination

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -149,7 +149,7 @@ go test -tags=e2e ./local/... -count=1 -v -timeout 30m -parallel 1
 | combat/vehicles | spellclick steed enter/exit | P2 | covered | — |
 | spells/aura | apply/query; CC broken by damage; mount persist | P1 | covered (`TestAC_26130_*`) | #26130 |
 | spells/cast | Charge on dummy; fail path; stance; Raise Dead + ghoul | P1 | covered (`TestAC_27061_*`) | #27061 |
-| spells/effects | Charge / grounding totem / Sweeping Strikes Execute | P1 | covered (`TestAC_26997_*`); dummy-summon `blocked-harness` (engineering dummy lifetime) | #26774 #26997 |
+| spells/effects | Charge / grounding totem / Sweeping Strikes Execute; forced cast summons at the forced caster, not at the unit that forced it | P1 | covered (`TestAC_26997_*`, `TestEffects_ForceCastDestination`); dummy-summon `blocked-harness` (engineering dummy lifetime) | #26774 #26997 #27621 |
 | social/group | form / leave / leader / loot method / disband | P2 | covered | — |
 | social/loot | need/greed / master loot; below-half kill | P1 | covered (`TestAC_26862_*`); chest mid-roll `blocked-harness` (GO 194821 UseGameObject); pass-on-loot delete `blocked-harness` (item-survive after ALL_PASSED) | #26894 #26862 #22000 |
 | social/trade | item+gold accept; cancel; walk-OOR TARGET_TO_FAR | P1 | covered | #25723 |

--- a/e2e/suites/spells/effects/effects_e2e_test.go
+++ b/e2e/suites/spells/effects/effects_e2e_test.go
@@ -3,6 +3,10 @@
 package effects_test
 
 import (
+	"fmt"
+	"math"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -230,4 +234,204 @@ func TestEffects_AddItemCreatePath(t *testing.T) {
 	bot.AddItemWait(t, e2eharness.ItemCorpseDust, 3)
 	bot.AssertInventoryAtLeast(t, e2eharness.ItemCorpseDust, 3)
 	t.Logf("PASS create-item seed path count>=3")
+}
+
+// PR: https://github.com/azerothcore/azerothcore-wotlk/pull/27621
+// Spell::EffectForceCast handed the forced cast the original caster as its unit target. When the
+// triggered spell takes no unit target but does need a destination, Spell::InitExplicitTargets
+// turns that unit target into the destination, so the forced cast resolves against the unit that
+// forced the cast instead of against the unit that was forced to cast it.
+//
+// Both trigger shapes are covered: 62221 and 62293 summon at the destination itself, while 48757
+// summons at a fixed offset behind it (TARGET_DEST_DEST_BACK).
+func TestEffects_ForceCastDestination(t *testing.T) {
+	meta.Begin(t, meta.TestMeta{Tags: []string{"med", "spells"}, Runtime: "med", Category: "spells/effects"})
+
+	const (
+		// Northshire open strip (map 0): flat ground, and no ambient summons of these entries to
+		// confuse a placement oracle.
+		stripX   float32 = -8904.0
+		stripY   float32 = -128.0
+		stripZ   float32 = 81.0
+		stripMap uint32  = 0
+
+		// Unkillable Test Dummy 80: faction 7, so the bot is a valid TARGET_UNIT_SRC_AREA_ENEMY
+		// pick for the area force-casts, and no ScriptName to interfere.
+		driverEntry = uint32(32171)
+
+		// The driver's own summon lands on the driver, so bot and driver must stand further apart
+		// than any oracle radius below.
+		driverStandOff = float32(15)
+		cacheRange     = float32(90)
+		summonWait     = 12 * time.Second
+	)
+
+	bot := e2eharness.NewSolo(t, e2eharness.ScenarioOpts{
+		Prefix: "FxFC",
+		Level:  80,
+	})
+
+	// GM command failures are reported as system chat only, so a drive that summons nothing would
+	// otherwise be indistinguishable from a placement bug.
+	var chatMu sync.Mutex
+	var chat []string
+	bot.World.OnChatMessage = func(_, msg string, _ uint8) {
+		chatMu.Lock()
+		chat = append(chat, msg)
+		chatMu.Unlock()
+	}
+	lastChat := func(n int) string {
+		chatMu.Lock()
+		defer chatMu.Unlock()
+		if len(chat) < n {
+			n = len(chat)
+		}
+		return strings.Join(chat[len(chat)-n:], " | ")
+	}
+
+	bot.Teleport(t, stripX, stripY, stripZ, stripMap)
+	bot.CombatReady(t)
+	driver := bot.Spawn(t, driverEntry, 20*time.Second)
+	if driver == 0 {
+		e2eharness.Preconditionf(t, "no force-cast driver %d spawned", driverEntry)
+	}
+	// .npc add drops the driver on the bot, where both candidate destinations coincide.
+	bot.Teleport(t, stripX+driverStandOff, stripY, stripZ, stripMap)
+	bot.CombatReady(t)
+	bot.CombatStop(t)
+	driver = bot.WaitUnit(t, driverEntry, 20*time.Second) // the tele cleared the object cache
+	if driver == 0 {
+		e2eharness.Preconditionf(t, "driver %d not back in cache after stepping clear", driverEntry)
+	}
+
+	for _, tc := range []struct {
+		name        string
+		spellID     uint32
+		summonEntry uint32
+		onCaster    float32
+		what        string
+	}{
+		// 62207 summons 33050 at the caster and force-casts 62221 on every player within 100 yd;
+		// 62221 summons at its own caster's position.
+		{"UnstableSunBeam", 62207, 33050, 4, "at the forced caster"},
+		// 62301 force-casts 62293 on enemies within 100 yd; 62293 summons the crater marker at its
+		// own caster's position. This is the path the removed SpellInfoCorrections entry covered.
+		{"CosmicSmash", 62301, 33104, 4, "at the forced caster"},
+		// 48759 force-casts 48757 on its explicit target; 48757 summons 3 yd behind the
+		// destination, so the offset shape is covered too.
+		{"SummonBehindForcedCaster", 48759, 27439, 6, "3 yd behind the forced caster"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			known := summonGUIDs(summonsInCache(bot, tc.summonEntry, cacheRange))
+			bot.Face(t, driver)
+			bot.FlushWorld(t)
+			// No "triggered": TRIGGERED_FULL_DEBUG_MASK carries TRIGGERED_IGNORE_EFFECTS, which
+			// would send the cast without running a single effect.
+			bot.GM(t, fmt.Sprintf(".cast back %d", tc.spellID))
+
+			fresh := waitNewSummons(bot, tc.summonEntry, cacheRange, known, summonWait)
+			if len(fresh) == 0 {
+				e2eharness.Preconditionf(t, "%d force-cast produced no new %d within %s (last chat: %s) (cache: %s)",
+					tc.spellID, tc.summonEntry, summonWait, lastChat(3), dumpNearby(bot, cacheRange))
+			}
+			drv := bot.World.GetObject(driver)
+			if drv == nil {
+				e2eharness.Preconditionf(t, "driver 0x%X left the object cache before the summon landed", driver)
+			}
+			bx, by, bz, _ := bot.Pos()
+			for _, s := range fresh {
+				t.Logf("%d -> %d guid=0x%X at (%.1f,%.1f,%.1f) dist bot=%.1f driver=%.1f",
+					tc.spellID, tc.summonEntry, s.guid, s.x, s.y, s.z,
+					e2eharness.Distance3D(bx, by, bz, s.x, s.y, s.z),
+					e2eharness.Distance3D(drv.PosX, drv.PosY, drv.PosZ, s.x, s.y, s.z))
+			}
+			near, toBot := nearestSummon(fresh, bx, by, bz)
+			toDriver := e2eharness.Distance3D(drv.PosX, drv.PosY, drv.PosZ, near.x, near.y, near.z)
+			if toBot > tc.onCaster {
+				e2eharness.Assertf(t, "%d: nearest of %d summoned %d sits %.1fy from the forced caster and %.1fy from the original caster, expected %s - the forced cast inherited the original caster as its destination",
+					tc.spellID, len(fresh), tc.summonEntry, toBot, toDriver, tc.what)
+			}
+			t.Logf("PASS %d summoned %d %.1fy from the forced caster (%.1fy from the original caster)",
+				tc.spellID, tc.summonEntry, toBot, toDriver)
+		})
+	}
+}
+
+type forceCastSummon struct {
+	guid    uint64
+	x, y, z float32
+}
+
+// summonsInCache snapshots every tracked unit of one template within maxDist.
+func summonsInCache(bot *e2eharness.ScenarioBot, entry uint32, maxDist float32) []forceCastSummon {
+	var out []forceCastSummon
+	for _, u := range bot.World.GetNearbyUnits(maxDist) {
+		if u.Entry != entry {
+			continue
+		}
+		out = append(out, forceCastSummon{guid: u.GUID, x: u.PosX, y: u.PosY, z: u.PosZ})
+	}
+	return out
+}
+
+func summonGUIDs(summons []forceCastSummon) map[uint64]struct{} {
+	out := make(map[uint64]struct{}, len(summons))
+	for _, s := range summons {
+		out[s.guid] = struct{}{}
+	}
+	return out
+}
+
+func newSummons(bot *e2eharness.ScenarioBot, entry uint32, maxDist float32, known map[uint64]struct{}) []forceCastSummon {
+	var out []forceCastSummon
+	for _, s := range summonsInCache(bot, entry, maxDist) {
+		if _, seen := known[s.guid]; seen {
+			continue
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
+// waitNewSummons waits for a unit of entry that was not in known, then settles briefly so a second
+// summon from the same cast (62207 also places one on its own caster) joins the same batch.
+// Novelty by GUID is what keeps a permanent summon left by an earlier run out of the oracle.
+func waitNewSummons(bot *e2eharness.ScenarioBot, entry uint32, maxDist float32,
+	known map[uint64]struct{}, timeout time.Duration) []forceCastSummon {
+	deadline := time.Now().Add(timeout)
+	for {
+		if fresh := newSummons(bot, entry, maxDist, known); len(fresh) > 0 {
+			time.Sleep(700 * time.Millisecond)
+			return newSummons(bot, entry, maxDist, known)
+		}
+		if !time.Now().Before(deadline) {
+			return nil
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+}
+
+// dumpNearby lists the tracked units around the bot, so a drive that summoned nothing can be told
+// apart from a summon the client never received.
+func dumpNearby(bot *e2eharness.ScenarioBot, maxDist float32) string {
+	bx, by, bz, _ := bot.Pos()
+	var parts []string
+	for _, u := range bot.World.GetNearbyUnits(maxDist) {
+		parts = append(parts, fmt.Sprintf("%d@%.0fy", u.Entry, e2eharness.Distance3D(bx, by, bz, u.PosX, u.PosY, u.PosZ)))
+	}
+	if len(parts) == 0 {
+		return "no units tracked"
+	}
+	return strings.Join(parts, ",")
+}
+
+func nearestSummon(summons []forceCastSummon, x, y, z float32) (forceCastSummon, float32) {
+	var best forceCastSummon
+	bestDist := float32(math.MaxFloat32)
+	for _, s := range summons {
+		if d := e2eharness.Distance3D(x, y, z, s.x, s.y, s.z); d < bestDist {
+			best, bestDist = s, d
+		}
+	}
+	return best, bestDist
 }

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -1043,7 +1043,11 @@ void Spell::EffectForceCast(SpellEffIndex effIndex)
     }
 
     SpellCastTargets targets;
-    targets.SetUnitTarget(m_caster);
+    // InitExplicitTargets turns a unit target the triggered spell cannot take into that spell's
+    // destination, which would anchor the forced cast to the original caster instead of to the
+    // forced one (e.g. Algalon's Cosmic Smash craters, Elder Brightleaf's Unstable Sun Beams).
+    if (spellInfo->GetExplicitTargetMask() & (TARGET_FLAG_UNIT_MASK | TARGET_FLAG_CORPSE_MASK))
+        targets.SetUnitTarget(m_caster);
 
     unitTarget->CastSpell(targets, spellInfo, &values, TRIGGERED_FULL_MASK);
 }

--- a/src/server/game/Spells/SpellInfoCorrections.cpp
+++ b/src/server/game/Spells/SpellInfoCorrections.cpp
@@ -2053,12 +2053,6 @@ void SpellMgr::LoadSpellInfoCorrections()
     });
 
     // Cosmic Smash (Algalon the Observer)
-    ApplySpellFix({ 62293 }, [](SpellInfo* spellInfo)
-    {
-        spellInfo->Effects[EFFECT_0].TargetB = SpellImplicitTargetInfo(TARGET_DEST_CASTER);
-    });
-
-    // Cosmic Smash (Algalon the Observer)
     ApplySpellFix({ 62311, 64596 }, [](SpellInfo* spellInfo)
     {
         spellInfo->AttributesEx2 |= SPELL_ATTR2_IGNORE_LINE_OF_SIGHT;


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

`Spell::EffectForceCast` always handed the forced cast the original caster as its unit target. When the triggered spell takes no unit target but does need a destination, `Spell::InitExplicitTargets` takes its "needs a dst, none set" branch and reads the *parameter* `targets` rather than the already-sanitised `m_targets`, so the original caster becomes the forced cast's destination. The forced cast then resolves against the original caster instead of against the unit that was forced to cast it.

`Spell::EffectSummonType` runs in `SPELL_EFFECT_HANDLE_HIT` mode and only ever sees `destTarget`, so an implicit `TARGET_UNIT_CASTER` on a summon effect cannot override that inherited destination.

The fix passes the unit target only when the triggered spell's explicit target mask accepts one - the same `TARGET_FLAG_UNIT_MASK | TARGET_FLAG_CORPSE_MASK` test `InitExplicitTargets` itself applies a few lines earlier before discarding it. All three force-cast effects (`SPELL_EFFECT_FORCE_CAST`, `SPELL_EFFECT_FORCE_CAST_WITH_VALUE`, `SPELL_EFFECT_FORCE_CAST_2`) route through this handler, so all three are covered.

### Reach

Twelve spells in the client data force-cast a spell that needs a destination but takes no unit target: 42073, 48759, 52187, 57838, 58566, 62207, 62301, 62921, 64088, 64598, 69839 and 70882.

Seven of them place their summon somewhere new: 48759, 52187, 57838, 58566, 62207, 62921 and 64088. Their triggers summon either at the destination itself (`TARGET_UNIT_CASTER`, which contributes no destination of its own, so the inherited one stands) or at a fixed offset from it (`TARGET_DEST_DEST_BACK` / `_LEFT` / `_RIGHT`). That is why the inherited destination showed up as a placement error instead of being overwritten.

The other five do not move:

- 42073 force-casts on itself, so the original and the forced caster are the same unit.
- 69839's force-cast effect is prevented by `spell_rotface_unstable_ooze_explosion_init` and never reaches this code.
- 70882's trigger 70883 carries `TARGET_DEST_CASTER` on `TargetB`, and `SelectImplicitCasterDestTargets` overwrites the destination with the forced caster's own position either way.
- 62301 and 64598 land correctly on master only because of the workaround below.

Of those seven, two are reachable on master today: 48759, cast by creature 27445's SmartAI when a player walks into its line of sight, so High Abbot Landgren now appears behind the player instead of behind the bell bunny; and 52187, Har'koa's gossip option, whose kitten now appears beside the player. 57838, 58566 and 70882 are cast by nothing in the world DB or in `src/`. 62207, 62921 and 64088 are what the accompanying Elder Brightleaf script PR starts casting: without this core fix every Unstable Sun Beam stacks on the elder instead of one landing at the elder and one under each player in range.

### Removed workaround

The `SpellInfoCorrections.cpp` entry for 62293 (Algalon's Cosmic Smash) forced `Effects[EFFECT_0].TargetB` to `TARGET_DEST_CASTER`. 62293 inherited the wrong destination like every other spell here, but that implicit target made `SelectImplicitCasterDestTargets` overwrite it with the forced caster afterwards (`m_targets.SetDst(dest)`), so the craters landed correctly in spite of the bug. The entry existed only to route around what this PR fixes, so it goes with it.

Removing it changes nothing in-game. `TARGET_DEST_CASTER` returns the caster's exact position, which is also what `InitExplicitTargets` now falls back to, so 33104 spawns in the same spot either way. TrinityCore carries the same correction, but there it is still load-bearing.

Worth knowing when reading the new test: because the correction covers Algalon on master, its subtest passes there too. It guards the fix in the merged state, where the correction is gone. The 62207 and 48759 subtests fail on master as it stands.

### AI-assisted Pull Requests

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Claude Opus 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:

- Closes

## SOURCE:

The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [x] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

A sniff of the Elder Brightleaf encounter shows the second Unstable Sun Beam's summon being cast by the *player*, not by the elder, and landing at that player's own position. 62207's client data says the same: effect 0 summons at the caster, effect 1 force-casts 62221 on every player within 100 yards, uncapped and `ONLY_ON_PLAYER`.

Not a cherry-pick. TrinityCore carries the same behaviour in both places, `unitTarget->CastSpell(m_caster, …)` in `EffectForceCast` and the identical destination fallback in `InitExplicitTargets`, so there is nothing upstream to credit here.

## Tests Performed:

This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Verified against the Elder Brightleaf encounter on a live stack: before the change both sun beams land on the elder, after it one lands on the elder and one under the player.

`TestEffects_ForceCastDestination` in `e2e/suites/spells/effects/` covers the core behaviour on a live stack with three oracles, driving 62207, 62301 and 48759 from a hostile NPC onto the bot: the summon must land on the unit that was forced to cast (62221, 62293) or at its documented offset from that unit (48757, 3 yards behind).

Green twice on the fixed core: 62207's beam 0.0 yards from the forced caster and 15.0 from the original, 62301's crater 0.0, 48757's summon 3.1 and 18.0. With the one-liner reverted and everything else identical, all three fail as assertions with every summon on the original caster instead.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Walk up to the bell bunny in Howling Fjord (creature 27445, part of "A Fall from Grace"): High Abbot Landgren must appear behind you, not behind the bunny.
2. Take Har'koa's gossip option in Zul'Drak (creature 28401): her kitten must appear beside you, not beside her.
3. Algalon's Cosmic Smash: the crater marker must still land on the players it targets and the damage must still hit that spot 4 seconds later. Placement should be unchanged, but this is the path the removed `SpellInfoCorrections.cpp` entry used to cover, so it is worth a look.
4. With the accompanying Elder Brightleaf script PR applied, pull the elder in the Conservatory of Life and watch where each Unstable Sun Beam lands: one at his feet, one under each player in range. Without this core fix they all stack on him.

## Known Issues and TODO List:

- [ ] None.

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
