### PR TITLE
fix(Scripts/Ulduar): stop Flame Leviathan saving the raid on pull

### DIFF
--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_flame_leviathan.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_flame_leviathan.cpp
@@ -207,7 +207,6 @@ struct boss_flame_leviathan : public BossAI
     uint8 _overloadCircuitCount;
 
     // Custom
-    void BindPlayers();
     void RadioSay(uint8 textid);
     void ActivateTowers();
     void TurnGates(bool _start, bool _death);
@@ -278,7 +277,6 @@ struct boss_flame_leviathan : public BossAI
         ActivateTowers();
         instance->SetBossState(BOSS_LEVIATHAN, SPECIAL);
 
-        BindPlayers();
         me->SetInCombatWithZone();
 
         if (!_startTimer)
@@ -482,11 +480,6 @@ struct boss_flame_leviathan : public BossAI
     }
 };
 
-void boss_flame_leviathan::BindPlayers()
-{
-    me->GetMap()->ToInstanceMap()->PermBindAllPlayers();
-}
-
 void boss_flame_leviathan::RadioSay(uint8 textid)
 {
     if (Creature* r = me->SummonCreature(NPC_BRANN_RADIO, me->GetPositionX() - 150, me->GetPositionY(), me->GetPositionZ(), me->GetOrientation(), TEMPSUMMON_TIMED_DESPAWN, 5000))
@@ -655,7 +648,6 @@ void boss_flame_leviathan::JustDied(Unit*)
     Talk(FLAME_LEVIATHAN_SAY_DEATH);
 
     TurnGates(false, true);
-    BindPlayers();
 }
 
 void boss_flame_leviathan::KilledUnit(Unit* who)


### PR DESCRIPTION
## Changes Proposed:

This PR proposes changes to:
-  [ ] Core (units, players, creatures, game systems).
-  [x] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

Flame Leviathan's `JustEngagedWith` called `PermBindAllPlayers()`, so pulling him permanently bound everyone in the map. That produced two separate reports:

- Everyone in the raid got "You are now saved to this instance" on the pull. Since [#27328](https://github.com/azerothcore/azerothcore-wotlk/pull/27328) gave him a real aggro range, simply walking up to him is enough to lock the ID.
- The perm bind flips the instance save's `CanReset` flag, and [`InstanceMap::AddPlayerToMap`](https://github.com/azerothcore/azerothcore-wotlk/blob/c3e3d216bf9a991895354248e9267ed455d870e9/src/server/game/Maps/Map.cpp#L2102-L2110) sends `SMSG_INSTANCE_LOCK_WARNING_QUERY` to anyone entering while the save can no longer reset. So a latecomer walking in after a wipe was prompted to save to a 0/14 raid, and someone teleporting in solo got bound silently.

Nothing needs to replace the call. Flame Leviathan already has `CREATURE_FLAG_EXTRA_INSTANCE_BIND` (`0x1`) in `creature_template.flags_extra` (`589825`), so [`Unit::Kill`](https://github.com/azerothcore/azerothcore-wotlk/blob/c3e3d216bf9a991895354248e9267ed455d870e9/src/server/game/Entities/Unit/Unit.cpp#L14245-L14255) binds the raid on death, which is how every other Ulduar boss does it: Ignis, Razorscale, XT-002, Kologarn, Auriaya, Hodir, Thorim, Freya, Mimiron, Vezax and Yogg-Saron all carry the same flag and none of them call `PermBindAllPlayers` from script. That also makes the second `BindPlayers()` call in `JustDied` redundant, so the helper goes away entirely and the diff is deletions only.

For contrast, [`boss_skeram`](https://github.com/azerothcore/azerothcore-wotlk/blob/c3e3d216bf9a991895354248e9267ed455d870e9/src/server/scripts/Kalimdor/TempleOfAhnQiraj/boss_skeram.cpp#L140) does call it by hand, because The Prophet Skeram has `flags_extra = 0` and has no other way to bind.

Resetting the instance after a Flame Leviathan wipe to re-pick towers is retail behaviour and is unaffected. Resetting *during* the fight stays blocked by `instance_ulduar`'s `IsEncounterInProgress` override, which special-cases Flame Leviathan's `SPECIAL` state by checking whether he is in combat.

### AI-assisted Pull Requests

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: Claude Code (Claude Opus 5)
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:

- Closes https://github.com/azerothcore/azerothcore-wotlk/issues/27550

## SOURCE:

The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [x] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

The video linked in https://github.com/chromiecraft/chromiecraft/issues/10164 shows "You are now saved to this instance" appearing on the Flame Leviathan kill, next to the Orbit-uary achievement and the DBM kill timer, not on the pull.

## Tests Performed:

This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue
- [ ] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Enter Ulduar with two characters in a group, pull Flame Leviathan and wipe. Neither character gets "You are now saved to this instance", and the raid ID stays empty.
2. Have the second character leave and walk back in. No prompt to save to a 0/14 raid, and entering solo does not bind silently either.
3. Reset the instance after the wipe, then kill Flame Leviathan. The save message appears on the kill and the ID shows 1/14.
4. Worth checking the hard mode path too, since towers are picked before the pull: destroy towers, wipe, reset, and confirm the tower state resets with the instance and a kill still saves normally.

## Known Issues and TODO List:

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs

When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
