### PR TITLE
fix(Core/Pets): Resume chase after deferred casts

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -144,7 +144,7 @@ go test -tags=e2e ./local/... -count=1 -v -timeout 30m -parallel 1
 | smoke | login / pad tele / relog / world alive | P0 | covered (`TestSmoke_*`) | — |
 | combat/charm | apply/cancel aura | P1 | covered; Yogg MC logout `blocked-harness` (no charm/MC drive) | #25506 |
 | combat/death | die → ghost → release → reclaim | P1 | covered | — |
-| combat/pets | summon / GUID / attack / dismiss | P1 | covered; dungeon Raise Dead `blocked-harness` (ready-check / instance summon) | #27081 |
+| combat/pets | summon / GUID / attack / dismiss | P1 | covered; two `blocked-harness` gaps below | #26661 #27081 |
 | combat/threat | engage / taunt switch / kill clears combat | P1 | covered | — |
 | combat/vehicles | spellclick steed enter/exit | P2 | covered | — |
 | spells/aura | apply/query; CC broken by damage; mount persist; paladin same-aura per-caster + Aura Mastery | P1 | covered (`TestAC_26130_*`, `TestAC_25765_*`) | #26130 #25765 |
@@ -165,6 +165,11 @@ go test -tags=e2e ./local/... -count=1 -v -timeout 30m -parallel 1
 | instances/classic/stratholme | Timmy remains hidden while a relevant Square Scarlet lives, then emerges after the area is clear | P2 | covered (`TestAC_26363_TimmyEmergesAfterSquareCleared`) | #26363 |
 | instances/ulduar | named tele; Freya wave interval; a Laughing Skull's Lunatic Gaze stops at the brain room's geometry instead of draining sanity through it | P2 | covered (`TestAC_27095_*`, `TestAC_27602_*`); Kologarn Charge `blocked-harness` (bridge Z after Charge) | #26266 #27095 #27602 |
 | world/gameevents | Call to Arms banners at the Dalaran portals belong to the side they stand on, and the already-correct Warsong set is unchanged. **Wants an exclusive realm**: starting a holiday re-anchors its schedule in the running worldserver until restart; holidays already running are left alone | P2 | covered (`TestAC_24380_*`); Shattrath's 23 positions `gap` | #24380 |
+
+Combat/pets harness gaps:
+
+- #26661 follow-resume after deferred hostile pet casts: no pet spell/reaction drive.
+- #27081 dungeon Raise Dead: no ready-check/instance summon drive.
 
 ---
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -144,7 +144,7 @@ go test -tags=e2e ./local/... -count=1 -v -timeout 30m -parallel 1
 | smoke | login / pad tele / relog / world alive | P0 | covered (`TestSmoke_*`) | — |
 | combat/charm | apply/cancel aura | P1 | covered; Yogg MC logout `blocked-harness` (no charm/MC drive) | #25506 |
 | combat/death | die → ghost → release → reclaim | P1 | covered | — |
-| combat/pets | summon / GUID / attack / dismiss | P1 | covered; two `blocked-harness` gaps below | #26661 #27081 |
+| combat/pets | summon / GUID / attack / dismiss | P1 | covered; dungeon Raise Dead `blocked-harness` (ready-check / instance summon) | #27081 |
 | combat/threat | engage / taunt switch / kill clears combat | P1 | covered | — |
 | combat/vehicles | spellclick steed enter/exit | P2 | covered | — |
 | spells/aura | apply/query; CC broken by damage; mount persist; paladin same-aura per-caster + Aura Mastery | P1 | covered (`TestAC_26130_*`, `TestAC_25765_*`) | #26130 #25765 |
@@ -165,11 +165,6 @@ go test -tags=e2e ./local/... -count=1 -v -timeout 30m -parallel 1
 | instances/classic/stratholme | Timmy remains hidden while a relevant Square Scarlet lives, then emerges after the area is clear | P2 | covered (`TestAC_26363_TimmyEmergesAfterSquareCleared`) | #26363 |
 | instances/ulduar | named tele; Freya wave interval; a Laughing Skull's Lunatic Gaze stops at the brain room's geometry instead of draining sanity through it | P2 | covered (`TestAC_27095_*`, `TestAC_27602_*`); Kologarn Charge `blocked-harness` (bridge Z after Charge) | #26266 #27095 #27602 |
 | world/gameevents | Call to Arms banners at the Dalaran portals belong to the side they stand on, and the already-correct Warsong set is unchanged. **Wants an exclusive realm**: starting a holiday re-anchors its schedule in the running worldserver until restart; holidays already running are left alone | P2 | covered (`TestAC_24380_*`); Shattrath's 23 positions `gap` | #24380 |
-
-Combat/pets harness gaps:
-
-- #26661 follow-resume after deferred hostile pet casts: no pet spell/reaction drive.
-- #27081 dungeon Raise Dead: no ready-check/instance summon drive.
 
 ---
 

--- a/src/server/game/AI/CoreAI/PetAI.cpp
+++ b/src/server/game/AI/CoreAI/PetAI.cpp
@@ -174,10 +174,19 @@ void PetAI::UpdateAI(uint32 diff)
             return;
         }
 
-        // Check before attacking to prevent pets from leaving stay position
-        if (me->GetCharmInfo()->HasCommandState(COMMAND_STAY))
+        CharmInfo* charmInfo = me->GetCharmInfo();
+        // Deferred hostile casts pause their chase at cast range. Resume once movement cannot interrupt the cast.
+        if (!me->HasReactState(REACT_PASSIVE) && charmInfo->HasCommandState(COMMAND_FOLLOW) &&
+            charmInfo->IsCommandAttack() && charmInfo->IsAtStay() && !me->IsMovementPreventedByCasting())
         {
-            if (me->GetCharmInfo()->IsCommandAttack() || (me->GetCharmInfo()->IsAtStay() && me->IsWithinMeleeRange(me->GetVictim())))
+            if (StartChase(me->GetVictim()))
+                charmInfo->SetIsAtStay(false);
+        }
+
+        // Check before attacking to prevent pets from leaving stay position
+        if (charmInfo->HasCommandState(COMMAND_STAY))
+        {
+            if (charmInfo->IsCommandAttack() || (charmInfo->IsAtStay() && me->IsWithinMeleeRange(me->GetVictim())))
                 _doMeleeAttack();
         }
         else
@@ -638,14 +647,7 @@ void PetAI::DoAttack(Unit* target, bool chase)
             ClearCharmInfoFlags();
             me->GetCharmInfo()->SetIsCommandAttack(oldCmdAttack); // For passive pets commanded to attack so they will use spells
 
-            if (_canMeleeAttack())
-            {
-                std::optional<ChaseAngle> chaseAngle;
-                if (combatRange == 0.f && !target->IsPlayer() && !target->IsPet())
-                    chaseAngle.emplace(float(M_PI), float(M_PI_4));
-
-                me->GetMotionMaster()->MoveChase(target, ChaseRange(0.f, combatRange), chaseAngle);
-            }
+            StartChase(target);
         }
         else // (Stay && ((Aggressive || Defensive) && In Melee Range)))
         {
@@ -656,6 +658,19 @@ void PetAI::DoAttack(Unit* target, bool chase)
             me->GetMotionMaster()->MoveIdle();
         }
     }
+}
+
+bool PetAI::StartChase(Unit* target)
+{
+    if (!_canMeleeAttack())
+        return false;
+
+    std::optional<ChaseAngle> chaseAngle;
+    if (combatRange == 0.f && !target->IsPlayer() && !target->IsPet())
+        chaseAngle.emplace(float(M_PI), float(M_PI_4));
+
+    me->GetMotionMaster()->MoveChase(target, ChaseRange(0.f, combatRange), chaseAngle);
+    return true;
 }
 
 void PetAI::MovementInform(uint32 moveType, uint32 data)

--- a/src/server/game/AI/CoreAI/PetAI.cpp
+++ b/src/server/game/AI/CoreAI/PetAI.cpp
@@ -662,7 +662,7 @@ void PetAI::DoAttack(Unit* target, bool chase)
 
 bool PetAI::StartChase(Unit* target)
 {
-    if (!_canMeleeAttack())
+    if (!target || target == me || me->HasUnitFlag(UNIT_FLAG_DISABLE_MOVE) || !_canMeleeAttack())
         return false;
 
     std::optional<ChaseAngle> chaseAngle;

--- a/src/server/game/AI/CoreAI/PetAI.h
+++ b/src/server/game/AI/CoreAI/PetAI.h
@@ -87,6 +87,7 @@ private:
     Unit* SelectNextTarget(bool allowAutoSelect) const;
     void HandleReturnMovement();
     void DoAttack(Unit* target, bool chase);
+    bool StartChase(Unit* target);
     bool CanAttack(Unit* target, SpellInfo const* spellInfo = nullptr);
     void ClearCharmInfoFlags();
 };


### PR DESCRIPTION
## Changes Proposed:

This PR covers the remaining Follow behavior from #26661. Defensive and aggressive pets that move into range for a hostile pet spell now resume chasing the same target once the cast no longer prevents movement. They no longer wait for another Attack command.

The chase setup is shared with normal pet attacks, preserving the existing ranged distance and chase angles.

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools (e.g. Claude, ChatGPT, or similar) were used entirely or partially to prepare this pull request. If checked, specify which tools and models below.
   - Tools/models used: GPT-5.6 Sol
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Follow-up to #26661 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
The changes have been validated through:
- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick). **Cherry-picks must be committed using the proper --author tag in order to be accepted, thus crediting the original authors, unless otherwise unable to be found**

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

Verified in game with defensive and aggressive pets on Follow. After moving into range and casting, the pet resumed chasing and closed the remaining distance without another Attack command.

Regression checks also passed for passive Follow, Stay, stationary channels, ranged pets, and moving targets.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Summon a Felhunter and set it to Follow and Defensive.
2. Move far enough from a hostile target that Spell Lock is out of range.
3. Order the Felhunter to cast Spell Lock.
4. Confirm that it moves into range, casts, and then continues into melee range without another Attack command.
5. Repeat with the pet set to Aggressive.
6. Repeat with Passive and confirm that the pet casts, then returns to its owner without attacking.
7. Set the pet to Stay and attempt the spell from out of range. Confirm that the pet does not move.
8. Channel Seduction with a Succubus. Confirm that it remains still during the channel and resumes chasing only after the channel ends.
9. Cast Firebolt with an Imp and confirm that it preserves its ranged combat distance.
10. Move the target after the cast and confirm that the pet continues pursuing it.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/GyFvXpk7)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
